### PR TITLE
fixing the pdm test command wk1

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -36,7 +36,7 @@ pdm install -v # this will automatically create a virtual environment and instal
 ```bash
 pdm run python check.py
 # The reference solution should pass all the tests
-pdm run test_ref_impl_week1
+pdm run test-week1-ref
 ```
 
 ## Run Unit Tests


### PR DESCRIPTION
In toml file an alias is set to run the file 
`test-week1-ref.cmd = "pytest tests_ref_impl_week1"`

so no need to run command 
`pdm run test_ref_impl_week1`

below command will work
pdm run test-week1-ref

