### PR TITLE
Fix RoPE return annotation

### DIFF
--- a/book/src/week1-01-attention.md
+++ b/book/src/week1-01-attention.md
@@ -44,7 +44,7 @@ TODO: fix test case names, do not do same dims in this chapter: instead, introdu
 * [MLX Scaled Dot Product Attention API](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.fast.scaled_dot_product_attention.html) (assume dim_k=dim_v=dim_q and H_k=H_v=H_q)
 * [Attention is All You Need](https://arxiv.org/abs/1706.03762)
 
-Implement `scaled_dot_product_attention` following the below attention function. The function takes key, value, and query of the same dimensions, and a optional mask matrix `M`.
+Implement `scaled_dot_product_attention` following the below attention function. The function takes key, value, and query of the same dimensions, and an optional mask matrix `M`.
 
 $$
   \text{Attention} = \text{softmax}(\frac{QK^T}{\sqrt{d_k}} + M)V

--- a/src/tiny_llm/positional_encoding.py
+++ b/src/tiny_llm/positional_encoding.py
@@ -13,5 +13,5 @@ class RoPE:
 
     def __call__(
         self, x: mx.array, offset: slice | None = None
-    ) -> tuple[mx.array, mx.array]:
+    ) -> mx.array:
         pass

--- a/src/tiny_llm_week1_ref/positional_encoding.py
+++ b/src/tiny_llm_week1_ref/positional_encoding.py
@@ -24,7 +24,7 @@ class RoPE:
 
     def __call__(
         self, x: mx.array, offset: slice | None = None
-    ) -> tuple[mx.array, mx.array]:
+    ) -> mx.array:
         N, S, H, D = x.shape
         # if offset is not None:
         #     assert len(offset) == S, f"offset {len(offset)} must be of length {s}"

--- a/src/tiny_llm_week2_ref/positional_encoding.py
+++ b/src/tiny_llm_week2_ref/positional_encoding.py
@@ -24,7 +24,7 @@ class RoPE:
 
     def __call__(
         self, x: mx.array, offset: slice | None = None
-    ) -> tuple[mx.array, mx.array]:
+    ) -> mx.array:
         N, S, H, D = x.shape
         # if offset is not None:
         #     assert len(offset) == S, f"offset {len(offset)} must be of length {s}"


### PR DESCRIPTION
RoPE actually returns a single array instead of a tuple of two arrays