### PR TITLE
Add doc of grouped query attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You may join skyzh's Discord server and study with the tiny-llm community.
 | -------------- | ----------------------------------------------------------- | ---- | ---- | --- |
 | 1.1            | Attention                                                   | ✅    | ✅   | ✅  |
 | 1.2            | RoPE                                                        | ✅    | ✅   | ✅  |
-| 1.3            | Grouped Query Attention                                     | ✅    | 🚧   | 🚧  |
+| 1.3            | Grouped Query Attention                                     | ✅    | ✅   | ✅  |
 | 1.4            | RMSNorm and MLP                                             | ✅    | 🚧   | 🚧  |
 | 1.5            | Transformer Block                                           | ✅    | 🚧   | 🚧  |
 | 1.6            | Load the Model                                              | ✅    | 🚧   | 🚧  |

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,7 +8,7 @@
 - [Week 1: From Matmul to Text](./week1-overview.md)
     - [Attention and Multi-Head Attention](./week1-01-attention.md)
     - [Positional Encodings and RoPE](./week1-02-positional-encodings.md)
-    - [Grouped/Multi Query Attention]()
+    - [Grouped/Multi Query Attention](./week1-03-gqa.md)
     - [Multilayer Perceptron Layer and Transformer]()
     - [Wiring the Qwen2 Model]()
     - [Loading the Model]()

--- a/book/src/week1-01-attention.md
+++ b/book/src/week1-01-attention.md
@@ -54,9 +54,9 @@ $$
 L is seq_len, in PyTorch API it's S (source len)
 D is head_dim
 
-K: N.. x L x D
-V: N.. x L x D
-Q: N.. x L x D
+key: N.. x L x D
+value: N.. x L x D
+query: N.. x L x D
 output: N.. x L x D
 ```
 
@@ -66,9 +66,9 @@ Because we are always using the attention layer within the multi-head attention 
 the model will be:
 
 ```
-K: 1 x H x L x D
-V: 1 x H x L x D
-Q: 1 x H x L x D
+key: 1 x H x L x D
+value: 1 x H x L x D
+query: 1 x H x L x D
 output: 1 x H x L x D
 mask: 1 x H x L x L
 ```
@@ -113,7 +113,7 @@ Now, you have a tensor of the shape `N.. x L x H x D` for each of the key, value
 * This makes each attention head an independent batch, so that attention can be calculated separately for each head across the sequence `L`.
 * If you kept `H` behind `L`, attention calculation would mix head and sequence dimensions, which is not what we want — each head should focus only on the relationships between tokens in its own subspace.
 
-Then, the attention function produces output for each of the head of the token. Then, you can transpose it back into `N.. x L x H x D` and reshape it
+The attention function produces output for each of the head of the token. Then, you can transpose it back into `N.. x L x H x D` and reshape it
 so that all heads get merged back together with a shape of `N.. x L x (H x D)`. Map it through the output weight matrix to get
 the final output.
 

--- a/book/src/week1-03-gqa.md
+++ b/book/src/week1-03-gqa.md
@@ -1,1 +1,58 @@
-# Grouped/Multi Query Attention
+# Week 1 Day 3: Grouped Query Attention (GQA)
+
+<div class="warning">
+
+This book is not complete and this chapter is not finalized yet. We are still working on the reference solution, writing
+tests, and unify the math notations in the book.
+
+</div>
+
+In day 3, we will implement Grouped Query Attention (GQA). The Qwen2 models use GQA which is an optimization technique for multi-head attention that reduces the computational and memory costs associated with the Key (K) and Value (V) projections. Instead of each Query (Q) head having its own K and V heads (like in Multi-Head Attention, MHA), multiple Q heads share the same K and V heads. Multi-Query Attention (MQA) is a special case of GQA where all Q heads share a single K/V head pair.
+
+
+**Readings**
+
+*   [GQA Paper (Training Generalized Multi-Query Transformer Models from Pre-Trained Checkpoints)](https://arxiv.org/abs/2305.13245)
+*   [Qwen layers implementation in mlx-lm](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen2.py)
+*   [PyTorch API (the case where enable_gqa=True)](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html)
+*   [torchtune.modules.MultiHeadAttention](https://pytorch.org/torchtune/0.3/generated/torchtune.modules.MultiHeadAttention.html)
+
+## Task: Implement `scaled_dot_product_attention_grouped`
+
+In this task, we will implement the grouped scaled dot product attention function, which forms the core of GQA.
+
+Implement `scaled_dot_product_attention_grouped` in `src/tiny_llm/attention.py`. This function is similar to the standard scaled dot product attention, but handles the case where the number of query heads is a multiple of the number of key/value heads.
+
+The main progress is the same as the standard scaled dot product attention. The difference is that the K and V heads are shared across multiple Q heads. This means that instead of having `H_q` separate K and V heads, we have `H` K and V heads, and each K and V head is shared by `n_repeats = H_q // H` Q heads.  
+
+The core idea is to reshape `query`, `key`, and `value` so that the K and V tensors can be effectively broadcasted to match the query heads within their groups during the `matmul` operations.
+    *   Think about how to isolate the `H` and `n_repeats` dimensions in the `query` tensor.
+    *   Consider adding a dimension of size 1 for `n_repeats` in the `key` and `value` tensors to enable broadcasting.
+Then perform the scaled dot product attention calculation (`matmul`, scale, optional mask, `softmax`, `matmul`). Broadcasting should handle the head repetition implicitly.
+
+Note that, leverage broadcasting instead of repeating the K and V tensors is more efficient. This is because broadcasting allows the same data to be used in multiple places without creating multiple copies of the data, which can save memory and improve performance.
+
+At last, don't forget to reshape the final result back to the expected output shape.
+
+```
+N.. is zero or more dimensions for batches
+H_q is the number of query heads
+H is the number of key/value heads (H_q must be divisible by H)
+L is the query sequence length
+S is the key/value sequence length
+D is the head dimension
+
+query: N.. x H_q x L x D
+key: N.. x H x S x D
+value: N.. x H x S x D
+mask: N.. x H_q x L x S
+output: N.. x H_q x L x D
+```
+
+You can test your implementation by running the following command:
+
+```bash
+pdm run test -k week_1_day_3_task_1 -v
+```
+
+{{#include copyright.md}}

--- a/src/tiny_llm_week1_ref/attention.py
+++ b/src/tiny_llm_week1_ref/attention.py
@@ -26,16 +26,16 @@ def scaled_dot_product_attention_grouped(
     factor = mx.rsqrt(query.shape[-1]) if scale is None else mx.array(scale)
     factor = factor.astype(query.dtype)
     expected_shape = query.shape
-    query = query.reshape(-1, query.shape[-3], query.shape[-2], query.shape[-1])
-    key = key.reshape(-1, key.shape[-3], key.shape[-2], key.shape[-1])
-    value = value.reshape(-1, value.shape[-3], value.shape[-2], value.shape[-1])
-    B, H_q, L, E = query.shape
-    _, H, S, _ = key.shape
+
+    H_q, L, D = query.shape[-3:]
+    H, S, _ = key.shape[-3:]
     assert H_q % H == 0
     n_repeats = H_q // H
-    query = query.reshape((B, H, n_repeats, L, E))
-    key = key.reshape((B, H, 1, S, E))
-    value = value.reshape((B, H, 1, S, E))
+
+    query = query.reshape(-1, H, n_repeats, L, D)
+    key = key.reshape(-1, H, 1, S, D)
+    value = value.reshape(-1, H, 1, S, D)
+    
     scores = mx.matmul(query, key.swapaxes(-2, -1)) * factor
     if mask is not None:
         mask = mask.reshape(-1, H, n_repeats, mask.shape[-2], mask.shape[-1])

--- a/src/tiny_llm_week2_ref/attention.py
+++ b/src/tiny_llm_week2_ref/attention.py
@@ -27,16 +27,16 @@ def scaled_dot_product_attention_grouped(
     factor = mx.rsqrt(query.shape[-1]) if scale is None else mx.array(scale)
     factor = factor.astype(query.dtype)
     expected_shape = query.shape
-    query = query.reshape(-1, query.shape[-3], query.shape[-2], query.shape[-1])
-    key = key.reshape(-1, key.shape[-3], key.shape[-2], key.shape[-1])
-    value = value.reshape(-1, value.shape[-3], value.shape[-2], value.shape[-1])
-    B, H_q, L, E = query.shape
-    _, H, S, _ = key.shape
+  
+    H_q, L, D = query.shape[-3:]
+    H, S, _ = key.shape[-3:]
     assert H_q % H == 0
     n_repeats = H_q // H
-    query = query.reshape((B, H, n_repeats, L, E))
-    key = key.reshape((B, H, 1, S, E))
-    value = value.reshape((B, H, 1, S, E))
+
+    query = query.reshape(-1, H, n_repeats, L, D)
+    key = key.reshape(-1, H, 1, S, D)
+    value = value.reshape(-1, H, 1, S, D)
+    
     scores = mx.matmul(query, key.swapaxes(-2, -1)) * factor
     if mask is not None:
         if mask == "causal":

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -134,28 +134,28 @@ def test_multi_head_attention_week_1_day_1_task_2(
     "batch_dimension", [0, 1, 2], ids=["batch_0", "batch_1", "batch_2"]
 )
 @pytest.mark.parametrize("scale", [None, 0.8])
-def test_attention_grouped(
+def test_attention_grouped_week_1_day_3_task_1(
     stream: mx.Stream, precision: np.dtype, batch_dimension: int, scale: float | None
 ):
     with mx.stream(stream):
         H_q = 18
         H = 6
         L = 7
-        E = 5
+        D = 5
         S = 3
         BATCH = 10
         BATCH_2 = 2
         if batch_dimension == 0:
-            q_shape = (H_q, L, E)
-            kv_shape = (H, S, E)
+            q_shape = (H_q, L, D)
+            kv_shape = (H, S, D)
             mask_shape = (H_q, L, S)
         elif batch_dimension == 1:
-            q_shape = (BATCH, H_q, L, E)
-            kv_shape = (BATCH, H, S, E)
+            q_shape = (BATCH, H_q, L, D)
+            kv_shape = (BATCH, H, S, D)
             mask_shape = (BATCH, H_q, L, S)
         elif batch_dimension == 2:
-            q_shape = (BATCH_2, BATCH, H_q, L, E)
-            kv_shape = (BATCH_2, BATCH, H, S, E)
+            q_shape = (BATCH_2, BATCH, H_q, L, D)
+            kv_shape = (BATCH_2, BATCH, H, S, D)
             mask_shape = (BATCH_2, BATCH, H_q, L, S)
         for _ in range(100):
             query = np.random.rand(*q_shape).astype(precision)


### PR DESCRIPTION
This PR does:
- Add the doc for week1 day3
- Make `scaled_dot_product_attention_grouped` ref impl neater
- Replace notation `E` with `D` in `test_attention_grouped`. From week1 day1, `E` indicates embedding dimension and `D` indicates head dimension. I think here should be head dimension(correct me if I'm wrong)