### PR TITLE
add tests to ensure the precision of `RMSNorm`

### DIFF
--- a/src/tiny_llm_ref/layer_norm.py
+++ b/src/tiny_llm_ref/layer_norm.py
@@ -8,7 +8,6 @@ class RMSNorm:
         self.weight = weight.astype(mx.float32)
 
     def __call__(self, x: mx.array) -> mx.array:
-        # TODO: tests to ensure the precision of this function
         orig_dtype = x.dtype
         x = x.astype(mx.float32)
         return (


### PR DESCRIPTION
1. add a type assertion in `test_task_1_rms_norm` to check if users forgot to cast the output to the original dtype

2. add a new test function called `test_task_1_rms_norm_cast_to_float32` to ensure the precision of `RMSNorm`

This test feeds large (±1000) float16 inputs through RMSNorm so that squaring them overflows the tiny float16 range (producing infinities and zeros) unless the implementation first widens to float32. By comparing against mx.fast.rms_norm (which does the cast internally), we guarantee that a pure float16 path will fail—so any missing float16→float32 conversion is immediately caught.