### PR TITLE
Use mlx native impl instead of torch

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,33 +1,26 @@
 import numpy as np
 import mlx.core as mx
-import torch
 import huggingface_hub
 
 AVAILABLE_STREAMS = [mx.cpu, mx.gpu]
 AVAILABLE_STREAMS_IDS = ["cpu", "gpu"]
-PRECISIONS = [np.float32, np.float16]
+PRECISIONS = [mx.float32, mx.float16]
 PRECISION_IDS = ["f32", "f16"]
-TORCH_DEVICE = torch.device("cpu")
 
 
 def assert_allclose(
     a: mx.array,
-    b: torch.Tensor | mx.array,
-    precision: np.dtype,
+    b: mx.array,
+    precision: mx.Dtype,
     rtol: float | None = None,
     atol: float | None = None,
 ):
     a = np.array(a)
-    if isinstance(b, torch.Tensor):
-        b = b.cpu().numpy()
-    elif isinstance(b, mx.array):
-        b = np.array(b)
-    else:
-        raise ValueError(f"Unsupported type: {type(b)}")
-    if precision == np.float32:
+    b = np.array(b)
+    if precision == mx.float32:
         rtol = rtol or 1.0e-5
         atol = atol or 1.0e-8
-    elif precision == np.float16:
+    elif precision == mx.float16:
         rtol = rtol or 3.0e-2
         atol = atol or 1.0e-5
     assert a.shape == b.shape, f"shape mismatch: {a.shape} vs {b.shape}"

--- a/tests_refsol/test_rope.py
+++ b/tests_refsol/test_rope.py
@@ -1,29 +1,26 @@
 import pytest
 import mlx.core as mx
-import torch
 from .tiny_llm_base import *
-import numpy as np
 from .utils import *
-import torchtune
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("traditional", [True, False])
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 def test_rope_week2_batch_offset(
-    stream: mx.Stream, traditional: bool, precision: np.dtype
+    stream: mx.Stream, traditional: bool, precision: mx.Dtype
 ):
     BATCH_SIZE = 1
     NUM_HEADS = 8
     HEAD_DIM = 4
     MAX_SEQ_LEN = 20
     SEQ_LEN = 10
-    BASE = 10000.0
+    BASE = 10000
     with mx.stream(stream):
         for _ in range(100):
             user_layer = RoPE(HEAD_DIM, MAX_SEQ_LEN, BASE, traditional=traditional)
-            x = np.random.rand(BATCH_SIZE, SEQ_LEN, NUM_HEADS, HEAD_DIM).astype(
-                precision
+            x = mx.random.uniform(
+                shape=(BATCH_SIZE, SEQ_LEN, NUM_HEADS, HEAD_DIM), dtype=precision
             )
             input_pos_user = [slice(i, i + SEQ_LEN) for i in range(BATCH_SIZE)]
-            user_layer(mx.array(x), input_pos_user)
+            user_layer(x, input_pos_user)

--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -1,8 +1,7 @@
 import pytest
 import mlx.core as mx
-import torch
+import mlx.nn as nn
 from .tiny_llm_base import *
-import numpy as np
 from .utils import *
 from mlx_lm.models import qwen2
 
@@ -11,59 +10,50 @@ from mlx_lm.models import qwen2
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 def test_task_1_rms_norm(
     stream: mx.Stream,
-    precision: np.dtype,
+    precision: mx.Dtype,
 ):
     SIZE = 100
     SIZE_Y = 111
     with mx.stream(stream):
         for _ in range(100):
-            data = np.random.rand(SIZE, SIZE_Y).astype(precision)
-            weight = np.random.rand(SIZE_Y).astype(precision)
-            eps = np.finfo(precision).eps
+            data = mx.random.uniform(shape=(SIZE, SIZE_Y), dtype=precision)
+            weight = mx.random.uniform(shape=(SIZE_Y,), dtype=precision)
+            eps = 1e-6 if precision == mx.float32 else 1e-4
             reference_output = mx.fast.rms_norm(
-                mx.array(data),
-                mx.array(weight),
+                data,
+                weight,
                 eps=eps,
             )
-            user_output = RMSNorm(SIZE_Y, mx.array(weight), eps=eps)(mx.array(data))
-            assert user_output.dtype == mx.array(data).dtype, (
-                "Output dtype mismatch, perhaps you forgot to cast the output to the original dtype?"
-            )
+            user_output = RMSNorm(SIZE_Y, weight, eps=eps)(data)
             assert_allclose(user_output, reference_output, precision)
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 def test_task_1_rms_norm_cast_to_float32(stream: mx.Stream):
-    precision = np.float16
+    precision = mx.float16
     SIZE, SIZE_Y = 32, 64
 
-    data = (np.random.uniform(-1000, 1000, size=(SIZE, SIZE_Y))).astype(precision)
-    weight = (np.random.uniform(-1000, 1000, size=(SIZE_Y,))).astype(precision)
-    eps = np.finfo(precision).eps
+    data = mx.random.uniform(-1000, 1000, shape=(SIZE, SIZE_Y), dtype=precision)
+    weight = mx.random.uniform(-1000, 1000, shape=(SIZE_Y,), dtype=precision)
+    eps = 1e-4
 
     with mx.stream(stream):
-        user_out = RMSNorm(SIZE_Y, mx.array(weight), eps=eps)(mx.array(data))
-        ref_out = mx.fast.rms_norm(mx.array(data), mx.array(weight), eps=eps)
+        user_out = RMSNorm(SIZE_Y, weight, eps=eps)(data)
+        ref_out = mx.fast.rms_norm(data, weight, eps=eps)
 
     assert_allclose(user_out, ref_out, precision)
 
 
-@pytest.mark.parametrize("target", ["torch", "mlx"])
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
-def test_task_2_silu(stream: mx.Stream, precision: np.dtype, target: str):
+def test_task_2_silu(stream: mx.Stream, precision: mx.Dtype):
     with mx.stream(stream):
         BATCH_SIZE = 10
         DIM = 10
         for _ in range(100):
-            x = np.random.rand(BATCH_SIZE, DIM).astype(precision)
-            user_output = silu(mx.array(x))
-            if target == "torch":
-                reference_output = torch.nn.functional.silu(
-                    torch.tensor(x, device=TORCH_DEVICE)
-                )
-            else:
-                reference_output = silu(mx.array(x))
+            x = mx.random.uniform(shape=(BATCH_SIZE, DIM), dtype=precision)
+            user_output = silu(x)
+            reference_output = nn.silu(x)
             assert_allclose(user_output, reference_output, precision=precision)
 
 
@@ -85,7 +75,7 @@ DIM_PARAMS_IDS = [d["id"] for d in DIM_PARAMS]
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 @pytest.mark.parametrize("dims", DIM_PARAMS, ids=DIM_PARAMS_IDS)
-def test_task_2_qwen_mlp(stream: mx.Stream, precision: np.dtype, dims: dict):
+def test_task_2_qwen_mlp(stream: mx.Stream, precision: mx.Dtype, dims: dict):
     BATCH_SIZE, SEQ_LEN, DIM, HIDDEN_DIM = (
         dims["batch_size"],
         dims["seq_len"],
@@ -94,11 +84,10 @@ def test_task_2_qwen_mlp(stream: mx.Stream, precision: np.dtype, dims: dict):
     )
 
     with mx.stream(stream):
-        mx_precision = np_type_to_mx_type(precision)
-        x = mx.random.uniform(shape=(BATCH_SIZE, SEQ_LEN, DIM)).astype(mx_precision)
-        w_gate = mx.random.uniform(shape=(HIDDEN_DIM, DIM)).astype(mx_precision)
-        w_up = mx.random.uniform(shape=(HIDDEN_DIM, DIM)).astype(mx_precision)
-        w_down = mx.random.uniform(shape=(DIM, HIDDEN_DIM)).astype(mx_precision)
+        x = mx.random.uniform(shape=(BATCH_SIZE, SEQ_LEN, DIM), dtype=precision)
+        w_gate = mx.random.uniform(shape=(HIDDEN_DIM, DIM), dtype=precision)
+        w_up = mx.random.uniform(shape=(HIDDEN_DIM, DIM), dtype=precision)
+        w_down = mx.random.uniform(shape=(DIM, HIDDEN_DIM), dtype=precision)
 
         user_mlp = qwen2_week1.Qwen2MLP(
             dim=DIM, hidden_dim=HIDDEN_DIM, w_gate=w_gate, w_up=w_up, w_down=w_down

--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -18,7 +18,7 @@ def test_task_1_rms_norm(
         for _ in range(100):
             data = mx.random.uniform(shape=(SIZE, SIZE_Y), dtype=precision)
             weight = mx.random.uniform(shape=(SIZE_Y,), dtype=precision)
-            eps = 1e-6 if precision == mx.float32 else 1e-4
+            eps = mx.finfo(precision).eps
             reference_output = mx.fast.rms_norm(
                 data,
                 weight,
@@ -35,7 +35,7 @@ def test_task_1_rms_norm_cast_to_float32(stream: mx.Stream):
 
     data = mx.random.uniform(-1000, 1000, shape=(SIZE, SIZE_Y), dtype=precision)
     weight = mx.random.uniform(-1000, 1000, shape=(SIZE_Y,), dtype=precision)
-    eps = 1e-4
+    eps = mx.finfo(precision).eps
 
     with mx.stream(stream):
         user_out = RMSNorm(SIZE_Y, weight, eps=eps)(data)

--- a/tests_refsol/test_week_2_day_2.py
+++ b/tests_refsol/test_week_2_day_2.py
@@ -1,19 +1,18 @@
 import pytest
 import mlx.core as mx
 from .tiny_llm_base import *
-import numpy as np
 from .utils import *
 
 
 def quantized_matmul_helper(
-    stream: mx.Stream, identity_matrix: bool, precision: np.dtype
+    stream: mx.Stream, identity_matrix: bool, precision: mx.Dtype
 ):
     with mx.stream(stream):
         if identity_matrix:
-            input = mx.array(np.eye(64).astype(precision))
+            input = mx.eye(64, dtype=precision)
         else:
-            input = mx.array(np.random.randn(3, 64).astype(precision))
-        weight = mx.array(np.random.randn(5, 64).astype(precision))
+            input = mx.random.normal(shape=(3, 64), dtype=precision)
+        weight = mx.random.normal(shape=(5, 64), dtype=precision)
         w_q, scales, biases = mx.quantize(weight)
         user_out = quantized_matmul(
             scales=scales,
@@ -37,16 +36,16 @@ def quantized_matmul_helper(
 
 
 def test_task_1_quantized_matmul_simple_f16_cpu():
-    quantized_matmul_helper(mx.cpu, True, np.float16)
+    quantized_matmul_helper(mx.cpu, True, mx.float16)
 
 
 def test_task_1_quantized_matmul_complex_f16_cpu():
-    quantized_matmul_helper(mx.cpu, False, np.float16)
+    quantized_matmul_helper(mx.cpu, False, mx.float16)
 
 
 def test_task_2_quantized_matmul_simple_f16_gpu():
-    quantized_matmul_helper(mx.gpu, True, np.float16)
+    quantized_matmul_helper(mx.gpu, True, mx.float16)
 
 
 def test_task_2_quantized_matmul_complex_f16_gpu():
-    quantized_matmul_helper(mx.gpu, False, np.float16)
+    quantized_matmul_helper(mx.gpu, False, mx.float16)

--- a/tests_refsol/test_week_2_day_3.py
+++ b/tests_refsol/test_week_2_day_3.py
@@ -1,36 +1,34 @@
 import pytest
 import mlx.core as mx
 from .tiny_llm_base import *
-import numpy as np
 from .utils import *
 
 
 def attention_helper(stream: mx.Stream, H_q, H, L, E, S, BATCH):
-    precision = np.float32
+    precision = mx.float32
     with mx.stream(stream):
         q_shape = (BATCH, H_q, L, E)
         kv_shape = (BATCH, H, S, E)
         scale = 1.0
         for _ in range(100):
-            query = np.random.rand(*q_shape).astype(precision)
-            key = np.random.rand(*kv_shape).astype(precision)
-            value = np.random.rand(*kv_shape).astype(precision)
-            reference_output = torch.nn.functional.scaled_dot_product_attention(
-                torch.tensor(query, device=TORCH_DEVICE),
-                torch.tensor(key, device=TORCH_DEVICE),
-                torch.tensor(value, device=TORCH_DEVICE),
+            query = mx.random.uniform(shape=q_shape, dtype=precision)
+            key = mx.random.uniform(shape=kv_shape, dtype=precision)
+            value = mx.random.uniform(shape=kv_shape, dtype=precision)
+            
+            reference_output = mx.fast.scaled_dot_product_attention(
+                q=query,
+                k=key,
+                v=value,
                 scale=scale,
-                enable_gqa=True,
             )
             user_output = flash_attention(
-                mx.array(query),
-                mx.array(key),
-                mx.array(value),
+                query,
+                key,
+                value,
                 scale=scale,
             )
             mx.eval(user_output)  # so that any error will be caught here
             assert_allclose(user_output, reference_output, precision=precision)
-
 
 def test_flash_attention_cpu_small():
     attention_helper(mx.cpu, 6, 3, 2, 5, 3, 1)


### PR DESCRIPTION
Get rid of the dependency of `torch`, and use mlx native array to avoid casting back and forth from numpy