### PR TITLE
docs: Update vLLM RoPE implementation link to reflect recent modularization

### DIFF
--- a/book/src/week1-02-positional-encodings.md
+++ b/book/src/week1-02-positional-encodings.md
@@ -79,7 +79,7 @@ frequencies to each half separately.
 
 **📚 Readings**
 
-- [vLLM implementation of RoPE](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/rotary_embedding.py)
+- [vLLM implementation of RoPE](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/rotary_embedding)
 
 
 You can test your implementation by running the following command:


### PR DESCRIPTION
## Purpose
The RoPE (Rotary Position Embedding) implementation link in the reading materials was outdated and no longer accessible. This PR updates the reference to point to the most recent vLLM implementation following their recent modularization of the RoPE codebase.

## Changes Made
- Updated the vLLM RoPE implementation link in `week1-02-positional-encodings.md`
- The link now points to the current modularized RoPE implementation

## Context
The vLLM project recently completed a major refactoring of their RoPE implementation (merged 17 hours ago in [PR #22192](https://github.com/vllm-project/vllm/pull/22192)). This refactoring:

- Converted the monolithic `rotary_embeddings.py` into a well-structured module
- Separated different RoPE implementations into individual files for better maintainability
- Added proper licensing headers to new RoPE implementation files
- Improved extensibility for additional RoPE kernels

The previous link in our documentation was pointing to an outdated implementation that is no longer accessible, making it difficult for students to reference the current vLLM RoPE implementation.

## Related
- [vLLM PR #22192: Refactor ROPE into module](https://github.com/vllm-project/vllm/pull/22192)