### PR TITLE
Fix f-string syntax error preventing module import in python 3.11

### DIFF
--- a/src/tiny_llm_ref/batch.py
+++ b/src/tiny_llm_ref/batch.py
@@ -93,8 +93,9 @@ def _print_progress(
         if is_idle[i]:
             print(f"  Decode #{i}: idle", flush=True)
         else:
+            text_preview = requests[i].text()[-80:].replace('\n', ' ')
             print(
-                f"{animation_frame} Decode [req {requests[i].prompt_idx}, {requests[i].offset}]: {requests[i].text()[-80:].replace('\n', ' ')}",
+                f"{animation_frame} Decode [req {requests[i].prompt_idx}, {requests[i].offset}]: {text_preview}",
                 flush=True,
             )
     if pending_prefill_request is not None:


### PR DESCRIPTION
## Problem
Running `pdm run main.py --solution ref --loader week1 --model qwen2-0.5b` with python 3.11.13 fails with a SyntaxError due to an invalid f-string expression in `batch.py`:

```bash
pdm run main.py --solution ref --loader week1

Using tiny_llm_ref solution
Failed to load C++/Metal extension
Traceback (most recent call last):
  File "/Users/x/Documents/Project/tiny-llm/main.py", line 38, in <module>
    from tiny_llm_ref import (
  File "/Users/x/Documents/Project/tiny-llm/src/tiny_llm_ref/__init__.py", line 14, in <module>
    from .batch import *
  File "/Users/x/Documents/Project/tiny-llm/src/tiny_llm_ref/batch.py", line 97
    f"{animation_frame} Decode [req {requests[i].prompt_idx}, {requests[i].offset}]: {requests[i].text()[-80:].replace('\n', ' ')}",
                                                                                                                                   ^
SyntaxError: f-string expression part cannot include a backslash
```

## Solution
Extract string replacement operation outside f-string expression to avoid backslash in f-string expression part, which is not allowed in Python syntax.

- Move .replace('\n', ' ') operation to separate variable
- Improves code readability and fixes SyntaxError

It's worth noting that this limitation **was removed in Python 3.12**.