### PR TITLE
fix: Add flash attention option and fix token offset

### DIFF
--- a/src/tiny_llm/qwen2_week2.py
+++ b/src/tiny_llm/qwen2_week2.py
@@ -88,7 +88,11 @@ class Qwen2TransformerBlock:
 
 
 class Qwen2ModelWeek2:
-    def __init__(self, mlx_model: Any):
+    def __init__(
+        self,
+        mlx_model: Any,
+        enable_flash_attn: bool = False,
+    ):
         pass
 
     def __call__(

--- a/src/tiny_llm_ref/generate.py
+++ b/src/tiny_llm_ref/generate.py
@@ -65,5 +65,5 @@ def simple_generate_with_kv_cache(
         print(detokenizer.last_segment, end="", flush=True)
         if token.item() == tokenizer.eos_token_id:
             break
-        offset += tokens.size
+        offset += token.size
         tokens = token


### PR DESCRIPTION
This PR fixes a bug in the simple_generate_with_kv_cache function where the offset was incorrectly incremented using tokens.size after the first decoding step.

Before the fix: The offset would grow as follows (note the jump from 6 → 12 in the first step):
```
Current offset: 6, tokens: array([108386, 104256, 3837, 105043, 100165, 11319], dtype=int32)
Current offset: 12, tokens: array([220], dtype=uint32)
Current offset: 13, tokens: array([108386], dtype=uint32)
Current offset: 14, tokens: array([6313], dtype=uint32)
Current offset: 15, tokens: array([104198], dtype=uint32)
Current offset: 16, tokens: array([101919], dtype=uint32)
```
This caused incorrect offset tracking, especially problematic when KV cache or rotary position encoding depends on accurate token indices.

After the fix: The offset is now correctly incremented by 1 per token generated:
```
Current offset: 6, tokens: array([108386, 104256, 3837, 105043, 100165, 11319], dtype=int32)
Current offset: 7, tokens: array([220], dtype=uint32)
Current offset: 8, tokens: array([14880], dtype=uint32)
Current offset: 9, tokens: array([106525], dtype=uint32)
Current offset: 10, tokens: array([3837], dtype=uint32)
Current offset: 11, tokens: array([35946], dtype=uint32)
Current offset: 12, tokens: array([99494], dtype=uint32)
Current offset: 13, tokens: array([34187], dtype=uint32)
```


