### PR TITLE
Fix: remove offset parameter to Qwen2MultiHeadAttention.__call__ meth…

### DIFF
--- a/src/tiny_llm/qwen2_week1.py
+++ b/src/tiny_llm/qwen2_week1.py
@@ -29,7 +29,6 @@ class Qwen2MultiHeadAttention:
     def __call__(
         self,
         x: mx.array,
-        offset: int,
         mask: mx.array | str | None = None,
     ) -> mx.array:
         pass
@@ -78,7 +77,6 @@ class Qwen2TransformerBlock:
     def __call__(
         self,
         x: mx.array,
-        offset: int,
         mask: mx.array | str | None = None,
     ) -> mx.array:
         pass
@@ -91,6 +89,5 @@ class Qwen2ModelWeek1:
     def __call__(
         self,
         inputs: mx.array,
-        offset: int,
     ) -> mx.array:
         pass


### PR DESCRIPTION
# Fix: Remove offset parameter to Qwen2MultiHeadAttention.__call__ method

## Description
When I try to test the [Task 1: Implement simple_generate](https://skyzh.github.io/tiny-llm/week1-06-generate-response.html#task-1-implement-simple_generate), I got this error:
```
(base) Zhens-MacBook-Air-2:tiny-llm zhentong$ pdm run main --solution tiny_llm --loader week1 --model qwen2-0.5b \
>   --prompt "Give me a short introduction to large language model"
Using your tiny_llm solution
Fetching 7 files: 100%|██████████████████████████████████| 7/7 [00:00<00:00, 97218.97it/s]
Using week1 loader for Qwen/Qwen2-0.5B-Instruct-MLX
Traceback (most recent call last):
  File "/Users/zhentong/Documents/tiny-llm/main.py", line 87, in <module>
    simple_generate(tiny_llm_model, tokenizer, prompt, sampler=sampler)
  File "/Users/zhentong/Documents/tiny-llm/src/tiny_llm/generate.py", line 29, in simple_generate
    token = _step(model, tokens)
            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/zhentong/Documents/tiny-llm/src/tiny_llm/generate.py", line 15, in _step
    logits = model(y[None])
             ^^^^^^^^^^^^^^
TypeError: Qwen2ModelWeek1.__call__() missing 1 required positional argument: 'offset'
```
The error is caused by the unspecified input `offset`, and I looked back how the model use the offset, and found that the `Qwen2MultiHeadAttention` in `tiny_llm/qwen2_week1.py` is with an input parameter `offset`, while I can not find it in `tiny_llm_ref/qwen2_week1.py`. After reading the most recent commit history, I noticed that the offset is removed in the `tiny_llm_ref`, but remains unchanged in the `tiny_llm`

## Changes Made
This PR fixes a method signature mismatch in the `Qwen2MultiHeadAttention` class. The `__call__` method in the `tiny-llm/` needs to remove the `offset` parameter.

## Testing
- Method signature now matches
- After fixed this, the [Task 1: Implement simple_generate](https://skyzh.github.io/tiny-llm/week1-06-generate-response.html#task-1-implement-simple_generate) can pass the test.