### PR TITLE
Fix MLX Metal API usage and Primitive interface for Axpby; restore successful build

### DIFF
--- a/src/extensions/src/axpby.cpp
+++ b/src/extensions/src/axpby.cpp
@@ -147,9 +147,8 @@ void Axpby::eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array
     kname << (contiguous_kernel ? "contiguous_" : "general_");
     kname << type_to_name(out);
 
-    // Make a kernel from this metal library
-    auto library = d.get_library("tiny_llm_ext");
-    auto kernel = d.get_kernel(kname.str(), library);
+    // Make a kernel from this metal library (use lib name overload)
+    auto kernel = d.get_kernel(kname.str(), "tiny_llm_ext");
 
     // Prepare to encode kernel
     auto &compute_encoder = d.get_command_encoder(s.index);
@@ -206,6 +205,11 @@ void Axpby::eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array
 ///////////////////////////////////////////////////////////////////////////////
 // Primitive Transforms
 ///////////////////////////////////////////////////////////////////////////////
+
+/** Print primitive name and parameters */
+void Axpby::print(std::ostream &os) {
+    os << name() << "(alpha=" << alpha_ << ", beta=" << beta_ << ")";
+}
 
 /** The Jacobian-vector product. */
 std::vector<mx::array> Axpby::jvp(const std::vector<mx::array> &primals, const std::vector<mx::array> &tangents,

--- a/src/extensions/src/axpby.h
+++ b/src/extensions/src/axpby.h
@@ -63,7 +63,10 @@ public:
                                                              const std::vector<int> &axes) override;
 
     /** Print the primitive. */
-    const char* name() const override { return "Axpby"; }
+    void print(std::ostream &os) override;
+
+    /** Name of the primitive (not virtual in some MLX versions). */
+    const char* name() const { return "Axpby"; }
 
     /** Equivalence check **/
     bool is_equivalent(const mx::Primitive &other) const override;

--- a/src/extensions/src/utils.cpp
+++ b/src/extensions/src/utils.cpp
@@ -9,7 +9,7 @@ namespace tiny_llm_ext {
 void load_library(mx::Device d, const char *path) {
 #ifdef _METAL_
     auto &md = mx::metal::device(d);
-    md.get_library("tiny_llm_ext", path);
+    md.register_library("tiny_llm_ext", path);
 #endif
 }
 


### PR DESCRIPTION
## How I found this error
- Running 
```
pdm run build-ext
```
failed with a C++ compilation error in src/extensions/src/utils.cpp:
  - get_library expected a builder callback (std::function<std::string(void)>), but a const char* path was provided.
## Where is the cause of this error
- MLX Metal API changes:
  - get_library(name, path) is no longer valid; get_library now takes a builder callback.
  - The intended flow is to register_library(name, path) once and then request kernels by library name.
- Primitive interface mismatch:
  - The installed MLX version expects print(std::ostream&) to be implemented; name() may not be virtual, so override on it can be incorrect.
## Where it changed and how it worked
- src/extensions/src/utils.cpp
  - Changed to md.register_library("tiny_llm_ext", path);
  - Fixes the API mismatch by registering the metallib with MLX.
- src/extensions/src/axpby.cpp
  - Switched kernel acquisition to d.get_kernel(kname.str(), "tiny_llm_ext");
  - Uses the overload that resolves kernels by registered library name.
- src/extensions/src/axpby.h and src/extensions/src/axpby.cpp
  - Added void print(std::ostream& os) override; and implemented it to show alpha/beta.
  - Removed override from name() to avoid interface mismatch in this MLX version.
## Result
- pdm run build-ext now completes successfully.
- The Metal library is correctly registered and kernels are resolved by name.
- The Axpby primitive fully satisfies the MLX Primitive interface for the installed version.