### PR TITLE
fix: Use non-traditional RoPE in Qwen2 test case.

### DIFF
--- a/book/src/week1-03-gqa.md
+++ b/book/src/week1-03-gqa.md
@@ -108,6 +108,8 @@ x = scaled_dot_product_attention_grouped(q, k, v, scale, mask) -> B, L, H_q, D ;
 x = linear(x, wo) -> B, L, E
 ```
 
+Keep in mind that you should use non-traditional RoPE.
+
 You can test your implementation by running the following command:
 
 ```bash

--- a/tests_refsol/test_week_1_day_3.py
+++ b/tests_refsol/test_week_1_day_3.py
@@ -158,7 +158,7 @@ def test_task_3_qwen2_grouped_query_attention(
             rms_norm_eps=1e-6,
             vocab_size=1000,
             rope_theta=theta,
-            rope_traditional=False,
+            rope_traditional=True,
             max_position_embeddings=max_seq_len,
         )
 


### PR DESCRIPTION
Since you claim that "The Qwen2 model uses a non-traditional form of RoPE" in the tutorial book, maybe it's better to use a non-traditional RoPE test case and notify the followers. 