### PR TITLE
Revert "fix: Use non-traditional RoPE in Qwen2 test case. (#56)"

### DIFF
--- a/book/src/week1-03-gqa.md
+++ b/book/src/week1-03-gqa.md
@@ -108,6 +108,8 @@ x = scaled_dot_product_attention_grouped(q, k, v, scale, mask) -> B, L, H_q, D ;
 x = linear(x, wo) -> B, L, E
 ```
 
+Keep in mind that you should use non-traditional RoPE.
+
 You can test your implementation by running the following command:
 
 ```bash


### PR DESCRIPTION
This revert "fix: Use non-traditional RoPE in Qwen2 test case. (#56)".
The original test case corresponds to the correct implementation, which use non-traditional RoPE, should not be modified