### PR TITLE
Bump mlx to >=0.27 and fix build-ext from week 1, day 7

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5daed9b471ae8d795d175b6732b822213acc091f3b969e745cb5a63a69ef87ac"
+content_hash = "sha256:57bf554af33b4cc63ec547d0b25307f18a1642bec8ff0c628d71866a926180cd"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,18 @@ version = "0.1.0"
 requires-python = ">=3.10, <3.13"
 readme = "README.md"
 dependencies = [
-    "mlx>=0.25.0",
+    "mlx>=0.27.0",
     "torch>=2.6.0",
     "torchtune>=0.6.1",
     "torchao>=0.10.0",
-    "mlx-lm>=0.23.0",
+    "mlx-lm>=0.26.0",
     "numpy>=2.2.4",
     "pytest>=8.3.5",
     "ruff>=0.11.6",
     # this should not usually appear in a project dependency list but we add it to simplify the setup process
     "setuptools>=62",
     "nanobind==2.4.0",
-    "pytest-benchmark>=5.1.0"
+    "pytest-benchmark>=5.1.0",
 ]
 
 [tool.pdm.scripts]
@@ -48,7 +48,5 @@ copy-test.cmd = "python scripts/dev-tools.py copy-test"
 book.cmd = "mdbook serve book/"
 
 [tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]
+addopts = ["--import-mode=importlib"]
 pythonpath = "src"

--- a/src/extensions/src/axpby.h
+++ b/src/extensions/src/axpby.h
@@ -63,10 +63,10 @@ public:
                                                              const std::vector<int> &axes) override;
 
     /** Print the primitive. */
-    void print(std::ostream &os) override;
+    void print(std::ostream &os);
 
     /** Name of the primitive (not virtual in some MLX versions). */
-    const char* name() const { return "Axpby"; }
+    const char *name() const override { return "Axpby"; }
 
     /** Equivalence check **/
     bool is_equivalent(const mx::Primitive &other) const override;

--- a/src/extensions/src/utils.cpp
+++ b/src/extensions/src/utils.cpp
@@ -9,7 +9,7 @@ namespace tiny_llm_ext {
 void load_library(mx::Device d, const char *path) {
 #ifdef _METAL_
     auto &md = mx::metal::device(d);
-    md.register_library("tiny_llm_ext", path);
+    md.get_library("tiny_llm_ext", path);
 #endif
 }
 


### PR DESCRIPTION
Resolves #50, applies the patch from there and updates pyproject / lockfile to specify newer version of mlx.

After this patch, this works for me:
```
pdm install -v
pdm run build-ext
pdm run build-ext-test
```