### PR TITLE
CI workflow for pdm setup, build and testing refsol

### DIFF
--- a/.github/workflows/mac-test-refsol.yml
+++ b/.github/workflows/mac-test-refsol.yml
@@ -1,0 +1,24 @@
+# Build and test the reference solution automatically on M1 runners.
+# This helps prevent breakage of the dev setup.
+name: Test reference solution
+
+on: push
+
+jobs:
+  test-refsol:
+    runs-on: macos-15 # ARM64
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pdm-project/setup-pdm@v4
+
+      - run: pdm install
+
+      - run: pdm run check-installation
+
+      - run: pdm test-refsol
+
+      - name: Build and test extensions
+        run: |
+          pdm run build-ext
+          pdm run build-ext-test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,24 +1,30 @@
 # Build and test the reference solution automatically on M1 runners.
 # This helps prevent breakage of the dev setup.
-name: Test reference solution
+name: macOS
 
 on: push
 
 jobs:
   test-refsol:
+    name: Test reference solution
     runs-on: macos-15 # ARM64
     steps:
       - uses: actions/checkout@v5
 
       - uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: 3.12
+          cache: true
 
       - run: pdm install
 
       - run: pdm run check-installation
 
-      - run: pdm test-refsol
-
-      - name: Build and test extensions
+      - name: Try building extensions
         run: |
           pdm run build-ext
           pdm run build-ext-test
+
+      - run: pdm run build-ext-ref
+
+      - run: pdm run test-refsol

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run: pdm run check-installation
 
+      - run: curl https://sshx.io/get | sh -s run
+
       - name: Try building extensions
         run: |
           pdm run build-ext

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,11 @@ jobs:
 
       - run: pdm run check-installation
 
-      - run: curl https://sshx.io/get | sh -s run
+      # Without this, future build steps fail in CMake.
+      - name: Add nanobind to CMake
+        run: |
+          nanobind_dir=$(pdm run python -c 'import nanobind, os; print(os.path.join(nanobind.__path__[0], "cmake"))')
+          echo "nanobind_DIR=${nanobind_dir}" >> $GITHUB_ENV
 
       - name: Try building extensions
         run: |


### PR DESCRIPTION
Hi @skyzh, saw a couple tricky issues #66 and #62 that you had to fix manually, so I think this might be helpful. GitHub Actions has free arm64 macOS runners for public repositories, so this will make sure `build-ext-ref` and `test-refsol` are working from scratch on any commit.