### PR TITLE
Add tests for week 2, day 6 - continuous batching

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install HuggingFace weights
+        run: |
+          brew install huggingface-cli
+          hf download Qwen/Qwen2-0.5B-Instruct-MLX
+
       - uses: pdm-project/setup-pdm@v4
         with:
           python-version: 3.12

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Week 1 is complete. Week 2 is in progress.
 | 2.3            | Quantized Matmul and Linear - GPU                           | ✅    | ✅   | 🚧  |
 | 2.4            | Flash Attention 2 - CPU                                     | ✅    | ✅   | 🚧  |
 | 2.5            | Flash Attention 2 - GPU                                     | ✅    | ✅   | 🚧  |
-| 2.6            | Continuous Batching                                         | ✅    | 🚧   | ✅  |
-| 2.7            | Chunked Prefill                                             | ✅    | 🚧   | ✅  |
+| 2.6            | Continuous Batching                                         | ✅    | ✅   | ✅  |
+| 2.7            | Chunked Prefill                                             | ✅    | ✅   | ✅  |
 | 3.1            | Paged Attention - Part 1                                    | 🚧    | 🚧   | 🚧  |
 | 3.2            | Paged Attention - Part 2                                    | 🚧    | 🚧   | 🚧  |
 | 3.3            | MoE (Mixture of Experts)                                    | 🚧    | 🚧   | 🚧  |
 | 3.4            | Speculative Decoding                                        | 🚧    | 🚧   | 🚧  |
 | 3.5            | RAG Pipeline                                                | 🚧    | 🚧   | 🚧  |
 | 3.6            | AI Agent     / Tool Calling                                 | 🚧    | 🚧   | 🚧  |
-| 3.7            | Long Context                                                 | 🚧    | 🚧   | 🚧  |
+| 3.7            | Long Context                                                | 🚧    | 🚧   | 🚧  |
 
 Other topics not covered: quantized/compressed kv cache, prefix/prompt cache; sampling, fine tuning; smaller kernels (softmax, silu, etc)

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -60,6 +60,7 @@ them with:
 
 ```bash
 huggingface-cli login
+huggingface-cli download Qwen/Qwen2-0.5B-Instruct-MLX
 huggingface-cli download Qwen/Qwen2-7B-Instruct-MLX
 ```
 

--- a/book/src/week2-06-prefill-and-batch.md
+++ b/book/src/week2-06-prefill-and-batch.md
@@ -92,6 +92,12 @@ src/tiny_llm/qwen2_week2.py
 
 Ensure your model can handle multiple requests simultaneously. You should also use the masks returned by the batch KV cache.
 
+You should pass all of the tests by running:
+
+```bash
+pdm run test --week 2 --day 6 -- -k task_3
+```
+
 ## Task 4: Batch Generate
 
 ```

--- a/src/tiny_llm/kv_cache.py
+++ b/src/tiny_llm/kv_cache.py
@@ -1,9 +1,11 @@
+from abc import ABC, abstractmethod
 from typing import Optional
 
 import mlx.core as mx
 
 
-class TinyKvCache:
+class TinyKvCache(ABC):
+    @abstractmethod
     def update_and_fetch(
         self,
         key: mx.array,
@@ -26,7 +28,6 @@ class TinyKvCache:
             In week 2 day 6/7, we need to return the updated key-value cache, the updated value, the sequence length, and the mask.
             so that the batching kv cache can use this information to generate the mask.
         """
-        pass
 
 
 class BatchingKvCache(TinyKvCache):


### PR DESCRIPTION
Added tests to make sure that `BatchingKvCache` works properly with the model implementation in `Qwen2ModelWeek2` and supports continuous batching.

I didn't add tests for `BatchingKvCache` in particular, similar to `TinyFullKvCache`, since the reader might implement the kv cache with different dimension order like (B, L, H, D) as the book recommends, rather than (B, H, L, D) as in the reference solution. What matters is that it works together with the model code.

Some other changes:

- Made `self.HD` optional in BatchingKvCache so that you can add requests with zero tokens / sequence length if needed. It is only used for checks, so it can be filled in on first read of H, D dimensions.
- Fixed a typo in one branch of `TinyFullKvCache::update_and_fetch` that returned 0 instead of S.
- I made `TinyKvCache` an abstract class. Just did it since when I was reading, `def update_and_fetch(): pass` looked like a placeholder to fill in rather than an abstract method to me.