### PR TITLE
fix(ref): widen qwen2 week 2 offset type hints

### DIFF
--- a/src/tiny_llm_ref/qwen2_week2.py
+++ b/src/tiny_llm_ref/qwen2_week2.py
@@ -53,7 +53,7 @@ class Qwen2MultiHeadAttention:
     def __call__(
         self,
         x: mx.array,
-        offsets: list[int],
+        offsets: int | list[int] | mx.array,
         cache: TinyKvCache,
         mask: mx.array | str | None = None,
     ) -> mx.array:
@@ -172,7 +172,7 @@ class Qwen2TransformerBlock:
     def __call__(
         self,
         x: mx.array,
-        offset: int,
+        offset: int | list[int] | mx.array,
         cache: TinyKvCache,
         mask: mx.array | str | None = None,
     ) -> mx.array:
@@ -266,7 +266,7 @@ class Qwen2ModelWeek2:
     def __call__(
         self,
         inputs: mx.array,
-        offset: int,
+        offset: int | list[int] | mx.array,
         cache: list[TinyKvCache],
     ) -> mx.array:
         h = self.embedding(inputs)


### PR DESCRIPTION
## Summary
- update the Qwen2 week 2 reference signatures to match the batched offsets already supported at runtime
- allow scalar offsets, Python lists, and `mx.array` values consistently across model, block, and attention entry points

## Testing
- not run (per request)
