### PR TITLE
Remove redundant idle state from batch generator

### DIFF
--- a/src/tiny_llm/batch.py
+++ b/src/tiny_llm/batch.py
@@ -61,7 +61,6 @@ class Request:
 
 def _print_progress(
     requests: list[Request | None],
-    is_idle: list[bool],
     pending_prefill_request: Request | None,
     queue_size: int,
     progress_cnt: int,
@@ -70,13 +69,13 @@ def _print_progress(
     print(f"  --- {datetime.now() - start_time}")
     animation_frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
     animation_frame = animation_frames[progress_cnt % len(animation_frames)]
-    for i in range(len(requests)):
-        if is_idle[i]:
+    for i, request in enumerate(requests):
+        if request is None:
             print(f"  Decode #{i}: idle", flush=True)
         else:
-            text_preview = requests[i].text()[-80:].replace("\n", " ")
+            text_preview = request.text()[-80:].replace("\n", " ")
             print(
-                f"{animation_frame} Decode [req {requests[i].prompt_idx}, {requests[i].offset}]: {text_preview}",
+                f"{animation_frame} Decode [req {request.prompt_idx}, {request.offset}]: {text_preview}",
                 flush=True,
             )
     if pending_prefill_request is not None:
@@ -105,8 +104,7 @@ def batch_generate(
     batch_size=5,
     prefill_step=128,
 ):
-    decode_requests: list[Request] = [None] * batch_size
-    is_idle = [True] * batch_size
+    decode_requests: list[Request | None] = [None] * batch_size
     kv_cache = [
         BatchingKvCache(max_active_requests=batch_size, max_seq_len=max_seq_len)
         for _ in range(model.num_hidden_layers)
@@ -118,7 +116,7 @@ def batch_generate(
     start_time = datetime.now()
 
     while True:
-        if len(prompts) == 0 and all(is_idle):
+        if len(prompts) == 0 and all(req is None for req in decode_requests):
             break
         # prefill until no idle slots
         if len(prompts) > 0 and pending_prefill_request is None:
@@ -140,7 +138,6 @@ def batch_generate(
             if made_progress:
                 _print_progress(
                     decode_requests,
-                    is_idle,
                     pending_prefill_request,
                     len(prompts),
                     progress_cnt,
@@ -149,7 +146,7 @@ def batch_generate(
                 progress_cnt += 1
 
         # After the prefill request moves forward one step, we do the decode
-        if not all(is_idle):
+        if any(req is not None for req in decode_requests):
             next_tokens = []
             offsets = []
             # TODO: collect the next tokens and offsets from the decode requests
@@ -161,7 +158,6 @@ def batch_generate(
                 pass
             _print_progress(
                 decode_requests,
-                is_idle,
                 pending_prefill_request,
                 len(prompts),
                 progress_cnt,


### PR DESCRIPTION
## What changed

- Removed the separate `is_idle` tracking from `src/tiny_llm/batch.py`.
- Switched progress reporting and loop guards to treat `decode_requests[i] is None` as the source of truth for slot occupancy.
- Kept the starter implementation aligned with the same slot-state model already used in the reference implementation.
