### PR TITLE
Fix ref batch token normalization

### DIFF
--- a/src/tiny_llm_ref/batch.py
+++ b/src/tiny_llm_ref/batch.py
@@ -9,7 +9,7 @@ from datetime import datetime
 def _step(model, y, offsets, kv_cache):
     logits = model(y, offsets, kv_cache)
     logits = logits[:, -1, :]
-    logprobs = logits - mx.logsumexp(logits, keepdims=True)
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
     sampler = lambda x: mx.argmax(x, axis=-1)
     y = sampler(logprobs)
     return y
@@ -194,6 +194,7 @@ def batch_generate(
             for i in range(batch_size):
                 req = decode_requests[i]
                 if req is not None:
+                    req.decode_done(next_tokens[i].item())
                     remove_reason = None
                     if req.is_done:
                         remove_reason = "EOS"
@@ -203,11 +204,10 @@ def batch_generate(
                         print(
                             f"Removing request {i} due to {remove_reason}", flush=True
                         )
-                        batch_cache.remove_request(i)
+                        for layer_cache in kv_cache:
+                            layer_cache.remove_request(i)
                         result.append((req.prompt_idx, req.text()))
                         decode_requests[i] = None
-                        continue
-                    req.decode_done(next_tokens[i].item())
             _print_progress(
                 decode_requests,
                 pending_prefill_request,


### PR DESCRIPTION
## What changed

This patch fixes two batching issues in `src/tiny_llm_ref/batch.py`:

- normalize logits per request by passing `axis=-1` to `mx.logsumexp(...)`
- remove finished requests from every layer cache after decoding, instead of only touching the leaked last `batch_cache` binding

## Why

The main bug was that batched decoding normalized across the wrong dimension, so requests in the same batch interfered with each other and produced broken outputs.

While debugging that path, I also fixed request cleanup so a finished request is removed from all layer caches before its slot is reused.

