### PR TITLE
doc: Document KV cache materialization during chunked prefill

### DIFF
--- a/book/src/week2-06-prefill-and-batch.md
+++ b/book/src/week2-06-prefill-and-batch.md
@@ -120,6 +120,8 @@ src/tiny_llm/batch.py
 
 Modify `try_prefill` so that it performs prefilling in chunks, rather than all at once.
 
+> **Tip:** Call `mx.eval` on the KV cache after each prefill chunk. Otherwise, MLX keeps extending a lazy expression across chunks, and memory usage keeps growing.
+
 You can test your implementation by running:
 
 ```bash

--- a/book/src/week2-06-prefill-and-batch.md
+++ b/book/src/week2-06-prefill-and-batch.md
@@ -120,7 +120,7 @@ src/tiny_llm/batch.py
 
 Modify `try_prefill` so that it performs prefilling in chunks, rather than all at once.
 
-> **Tip:** Call `mx.eval` on the KV cache after each prefill chunk. Otherwise, MLX keeps extending a lazy expression across chunks, and memory usage keeps growing.
+Note that you should materialize KV cache between chunks. Because MLX uses lazy evaluation, and chunked prefill keeps extending the KV cache across multiple model calls. If you never call `mx.eval`, the cache becomes a longer and longer lazy expression, so memory usage keeps growing. Calling `mx.eval` on the key and value tensors after each chunk materializes the current KV cache and truncates the graph.
 
 You can test your implementation by running:
 

--- a/src/tiny_llm_ref/batch.py
+++ b/src/tiny_llm_ref/batch.py
@@ -56,7 +56,8 @@ class Request:
         )
         self.offset += tokens_to_prefill
 
-        # Materialize KV cache after each chunk so the lazy graph does not keep growing.
+        # Materialize KV cache after each prefill chunk to truncate the lazy
+        # computation graph and prevent memory from growing unboundedly.
         for i in self.kv_cache:
             mx.eval(i.key_values[0])
             mx.eval(i.key_values[1])
@@ -203,9 +204,7 @@ def batch_generate(
                     elif req.offset >= max_seq_len:
                         remove_reason = "max seq len"
                     if remove_reason is not None:
-                        print(
-                            f"Removing request {i} due to {remove_reason}", flush=True
-                        )
+                        print(f"Removing request {i} due to {remove_reason}", flush=True)
                         for layer_cache in kv_cache:
                             layer_cache.remove_request(i)
                         result.append((req.prompt_idx, req.text()))

--- a/src/tiny_llm_ref/batch.py
+++ b/src/tiny_llm_ref/batch.py
@@ -55,6 +55,8 @@ class Request:
             self.kv_cache,
         )
         self.offset += tokens_to_prefill
+
+        # Materialize KV cache after each chunk so the lazy graph does not keep growing.
         for i in self.kv_cache:
             mx.eval(i.key_values[0])
             mx.eval(i.key_values[1])


### PR DESCRIPTION
## What changed

This follow-up adds a short explanation for why chunked prefill materializes the KV cache with `mx.eval`:

- add an inline comment in `src/tiny_llm_ref/batch.py`
- add a matching tip in `book/src/week2-06-prefill-and-batch.md`

## Why

The existing code does the right thing, but the reason is easy to miss when reading the implementation or the chapter. This note makes it explicit that `mx.eval` is there to keep the lazy graph from growing across prefill chunks.
