### PR TITLE
Add week 3 paged attention kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Week 1 and 2 is complete. Week 3 is in progress.
 | 2.6            | Continuous Batching                                         | ✅    | ✅   | ✅  |
 | 2.7            | Chunked Prefill                                             | ✅    | ✅   | ✅  |
 | 3.1            | Paged Attention - Part 1                                    | ✅    | ✅   | 🚧  |
-| 3.2            | Paged Attention - Part 2                                    | 🚧    | 🚧   | 🚧  |
+| 3.2            | Paged Attention - Part 2                                    | ✅    | ✅   | 🚧  |
 | 3.3            | MoE (Mixture of Experts)                                    | 🚧    | 🚧   | 🚧  |
 | 3.4            | Speculative Decoding                                        | 🚧    | ✅   | 🚧  |
 | 3.5            | RAG Pipeline                                                | 🚧    | 🚧   | 🚧  |

--- a/book/src/week3-01-paged-attention-part1.md
+++ b/book/src/week3-01-paged-attention-part1.md
@@ -196,14 +196,15 @@ This is not the final paged attention runtime yet, but it is a very useful inter
 
 ## How This Maps to `tiny-llm`
 
-## `src/tiny_llm/kv_cache.py`
+## `src/tiny_llm/paged_kv_cache.py`
 
 Add:
 
-- `PagePool`
-- `PagedRequestCache`
+- `TinyKvPagedPool`
+- `TinyKvPagedCache`
 
-Keep `TinyKvFullCache` around as a baseline and test oracle.
+Keep `TinyKvFullCache` in `src/tiny_llm/kv_cache.py` as a baseline and test
+oracle.
 
 The key Day 1 behavior is:
 
@@ -240,7 +241,7 @@ Before implementing, make sure the following are clear:
 ## Task 1: Design `PagePool`
 
 ```
-src/tiny_llm/kv_cache.py
+src/tiny_llm/paged_kv_cache.py
 ```
 
 Design a model-owned page pool that:
@@ -254,7 +255,7 @@ Design a model-owned page pool that:
 ## Task 2: Design `PagedRequestCache`
 
 ```
-src/tiny_llm/kv_cache.py
+src/tiny_llm/paged_kv_cache.py
 ```
 
 Replace the "one layer cache = one dense KV tensor" model with:
@@ -268,7 +269,7 @@ Replace the "one layer cache = one dense KV tensor" model with:
 ## Task 3: Add a Dense-Gather Compatibility Path
 
 ```
-src/tiny_llm/kv_cache.py
+src/tiny_llm/paged_kv_cache.py
 src/tiny_llm/qwen2_week3.py
 ```
 

--- a/book/src/week3-02-paged-attention-part2.md
+++ b/book/src/week3-02-paged-attention-part2.md
@@ -22,16 +22,18 @@ Once KV is paged, dense `B x H x S x D` tensors are no longer the natural runtim
 ```plain
 block_table:  [B, max_pages_per_request]
 context_lens: [B]
-slot_mapping: [B] or [num_new_tokens]
 ```
 
 For the current layer being executed:
 
 - `block_table[b, i]` gives the page id for request `b`'s current-layer logical page `i`
 - `context_lens[b]` gives the valid token count for request `b`
-- `slot_mapping` tells us where newly generated K/V should be written
 
 This is the bridge between the scheduler and the attention kernel.
+
+A production runtime often also carries write-side metadata such as `slot_mapping`.
+For this chapter, we keep the write side inside the cache and focus on the read-side
+metadata needed by attention.
 
 ## Why `block_table` Matters
 
@@ -70,6 +72,7 @@ paged_attention(
     value_pages,
     block_table,
     context_lens,
+    page_size,
     scale=None,
     mask="causal",
 )
@@ -78,14 +81,19 @@ paged_attention(
 With shapes like:
 
 ```plain
-query:        B, H_q, L, D
-key_pages:    P, H_kv, page_size, D
-value_pages:  P, H_kv, page_size, D
-block_table:  B, max_pages
-context_lens: B
+query:          B, H_q, L, D
+key_pages[i]:   1, H_kv, page_size, D
+value_pages[i]: 1, H_kv, page_size, D
+block_table:    B, max_pages
+context_lens:   B
 ```
 
 Compared with the Week 2 dense path, the important difference is that the source length is no longer represented as one contiguous tensor dimension. It is reconstructed logically from the page table.
+
+In this chapter, `paged_attention` should read pages directly from a GPU
+kernel. The runtime contract is now: model code and batching code pass pages
+plus metadata, and the attention kernel walks that metadata without first
+rebuilding dense K/V.
 
 ## Prefill Metadata
 
@@ -96,7 +104,8 @@ During prefill, a chunk may span multiple pages. The runtime needs to know:
 - how many valid tokens are in the tail page,
 - how to map incoming K/V rows into page storage.
 
-This is why a paged design usually carries a write-side structure such as `slot_mapping`.
+In this teaching implementation, the cache still owns the write-side bookkeeping.
+The attention path only needs the block table after the write is done.
 
 ## Decode Metadata
 
@@ -104,8 +113,8 @@ During decode, each active request typically writes one token.
 
 The runtime should be able to:
 
-1. compute the destination slot for that token,
-2. write K/V into the correct page slot,
+1. append the token's K/V to the current tail page,
+2. allocate a new page only if the tail page is full,
 3. update the current layer cache's `context_len`,
 4. run attention over the full logical context using `block_table`
 
@@ -113,7 +122,7 @@ This is the point where decode stops paying the repeated dense-repack cost from 
 
 ## How This Maps to `tiny-llm`
 
-## `src/tiny_llm/attention.py`
+### `src/tiny_llm/attention.py`
 
 Add a new function:
 
@@ -122,34 +131,55 @@ def paged_attention(...):
     ...
 ```
 
-The easiest rollout is:
+For this course implementation, make it a FlashAttention-style page-walking
+Metal kernel:
 
-1. first implement it as a gather-then-call wrapper around existing attention,
-2. later replace that wrapper with a real paged kernel or paged FlashAttention path.
+1. use `block_table[b]` to find the physical pages for request `b`,
+2. use `context_lens[b]` to ignore unused tail capacity,
+3. visit K/V in small tiles instead of materializing dense K/V,
+4. merge each tile into the output with online softmax.
 
-That preserves correctness while the runtime contracts stabilize.
+The important change from Week 2 is the K/V address calculation. Week 2 can
+advance through dense K/V by pointer arithmetic. Week 3 must translate each
+logical key position through `block_table` first:
 
-## `src/tiny_llm/qwen2_week3.py`
-
-The attention module should be able to branch on cache capability:
-
-```python
-if cache.supports_paged_attention:
-    x = paged_attention(...)
-else:
-    x = scaled_dot_product_attention_grouped(...)
+```plain
+logical key position -> logical page -> physical page id -> slot in page
 ```
 
-This keeps the model code readable while letting the cache and kernel evolve independently.
+After that lookup, the online-softmax update is the same idea as Week 2
+FlashAttention. We still avoid a dense K/V gather before attention.
 
-## `src/tiny_llm/batch.py`
+The page pool should therefore expose contiguous physical storage:
+
+```plain
+key_pages:   P, H_kv, page_size, D
+value_pages: P, H_kv, page_size, D
+```
+
+A Python list of page tensors is convenient for teaching the allocator, but a
+GPU kernel needs a single buffer so `page_id` can be turned into an address.
+
+### `src/tiny_llm/qwen2_week3.py`
+
+The attention module should call the paged runtime directly:
+
+```python
+metadata = cache.update_and_fetch_paged(...)
+x = paged_attention(...)
+```
+
+Week 3 cache handles are expected to provide paged metadata. If a dense cache is
+passed to the Week 3 model, that is a programming error rather than a signal to
+silently fall back to Week 2 attention.
+
+### `src/tiny_llm/batch.py`
 
 The scheduler now needs to prepare runtime metadata instead of only dense K/V:
 
 - per-layer page tables for each active request
 - padded batch `block_table`
 - `context_lens`
-- write positions for prefill and decode
 
 This is where continuous batching and paged attention finally connect. In Week 2, batching worked by repacking tensors. In Week 3, batching should work by reusing page tables and updating only the new slots.
 
@@ -158,9 +188,9 @@ This is where continuous batching and paged attention finally connect. In Week 2
 The safest implementation order is:
 
 1. paged storage
-2. dense gather compatibility path
-3. `block_table` / `context_lens` plumbing
-4. real paged attention dispatch
+2. `block_table` / `context_lens` plumbing
+3. FlashAttention-style page-walking GPU attention
+4. model and batch dispatch
 
 This order matters because it gives us a clean correctness baseline at each step.
 
@@ -177,6 +207,7 @@ These are the invariants worth checking in tests:
 ## Task 1: Add Batch Metadata
 
 ```
+src/tiny_llm/paged_kv_cache.py
 src/tiny_llm/kv_cache.py
 src/tiny_llm/batch.py
 ```
@@ -185,7 +216,6 @@ Extend the batch cache and scheduler so they can prepare:
 
 - `block_table`
 - `context_lens`
-- write-slot metadata
 
 for all active requests.
 
@@ -193,9 +223,24 @@ for all active requests.
 
 ```
 src/tiny_llm/attention.py
+src/extensions/src/paged_attention.cpp
+src/extensions/src/paged_attention.metal
 ```
 
 Add a paged attention interface whose inputs come from the paged runtime rather than a dense reconstructed `S` dimension.
+
+The reference solution walks every request's block table and keeps online
+softmax state:
+
+```python
+running_max = max(previous_max, page_max)
+running_sum = previous_sum * exp(previous_max - running_max) + page_sum
+output = previous_output * exp(previous_max - running_max) + page_output
+```
+
+After all visible pages are consumed, divide `output` by `running_sum`.
+This is the key idea that lets the kernel avoid materializing dense K/V while
+still producing the same result as dense attention.
 
 ## Task 3: Dispatch from the Model
 

--- a/main.py
+++ b/main.py
@@ -91,18 +91,15 @@ with mx.stream(mx.gpu if args.device == "gpu" else mx.cpu):
                 draft_tiny_llm_model = None
         elif args.loader == "week3":
             print(
-                f"Using week3 loader with flash_attn={args.enable_flash_attn} thinking={args.enable_thinking} for {args.model}"
+                f"Using week3 loader with thinking={args.enable_thinking} for {args.model}"
             )
-            tiny_llm_model = models.dispatch_model(
-                args.model, mlx_model, week=3, enable_flash_attn=args.enable_flash_attn
-            )
+            tiny_llm_model = models.dispatch_model(args.model, mlx_model, week=3)
             if draft_mlx_model is not None:
                 print(f"Using draft model {args.draft_model}")
                 draft_tiny_llm_model = models.dispatch_model(
                     args.draft_model,
                     draft_mlx_model,
                     week=3,
-                    enable_flash_attn=args.enable_flash_attn,
                 )
             else:
                 draft_tiny_llm_model = None

--- a/src/extensions_ref/CMakeLists.txt
+++ b/src/extensions_ref/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(
   PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}/src/quantized_matmul.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/flash_attention.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/paged_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/utils.cpp
 )
 
@@ -60,6 +61,7 @@ if(MLX_BUILD_METAL)
     SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/quantized_matmul.metal
     ${CMAKE_CURRENT_LIST_DIR}/src/flash_attention.metal
+    ${CMAKE_CURRENT_LIST_DIR}/src/paged_attention.metal
     INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}
     ${MLX_INCLUDE_DIRS}

--- a/src/extensions_ref/bindings.cpp
+++ b/src/extensions_ref/bindings.cpp
@@ -46,4 +46,22 @@ NB_MODULE(_ext, m) {
         Returns:
             array: ``softmax(query @ key.T * scale) @ value``
       )");
+
+    m.def("paged_attention", &tiny_llm_ext_ref::paged_attention, "query"_a, "key_pages"_a, "value_pages"_a,
+          "block_table"_a, "context_lens"_a, "scale"_a = 1.0, "is_causal"_a = false, "num_kv_heads"_a, "num_heads"_a,
+          "stream"_a = nb::none(), R"(
+        Paged attention layer
+
+        Args:
+            query (array): Query array with shape [B * H_q, L, D].
+            key_pages (array): Key page storage with shape [P, H_kv, page_size, D].
+            value_pages (array): Value page storage with shape [P, H_kv, page_size, D].
+            block_table (array): Physical page ids with shape [B, max_pages].
+            context_lens (array): Valid context length for each request.
+            scale (float): Scaling factor.
+            is_causal (bool): Enable causal masking.
+
+        Returns:
+            array: ``softmax(query @ paged_key.T * scale) @ paged_value``
+      )");
 }

--- a/src/extensions_ref/src/paged_attention.cpp
+++ b/src/extensions_ref/src/paged_attention.cpp
@@ -1,0 +1,309 @@
+#include <cmath>
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include "mlx/backend/cpu/encoder.h"
+#include "mlx/utils.h"
+#include "tiny_llm_ext.h"
+
+#ifdef _METAL_
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/utils.h"
+#endif
+
+namespace tiny_llm_ext_ref {
+
+mx::array paged_attention(const mx::array &q, const mx::array &key_pages, const mx::array &value_pages,
+                          const mx::array &block_table, const mx::array &context_lens, const float scale,
+                          const bool is_causal, const int num_kv_heads, const int num_heads, mx::StreamOrDevice s) {
+    if (q.dtype() != mx::float32 || key_pages.dtype() != mx::float32 || value_pages.dtype() != mx::float32) {
+        throw std::runtime_error("paged_attention: q, key_pages, and value_pages must be float32");
+    }
+    if (block_table.dtype() != mx::int32 || context_lens.dtype() != mx::int32) {
+        throw std::runtime_error("paged_attention: block_table and context_lens must be int32");
+    }
+    if (q.shape().size() != 3) {
+        throw std::runtime_error("paged_attention: q must be 3D [B * H_q, L, D]");
+    }
+    if (key_pages.shape().size() != 4 || value_pages.shape().size() != 4) {
+        throw std::runtime_error("paged_attention: page tensors must be 4D [P, H_kv, page_size, D]");
+    }
+    if (block_table.shape().size() != 2 || context_lens.shape().size() != 1) {
+        throw std::runtime_error("paged_attention: block_table must be 2D and context_lens must be 1D");
+    }
+    if (num_heads % num_kv_heads != 0) {
+        throw std::runtime_error("paged_attention: num_heads must be divisible by num_kv_heads");
+    }
+    if (q.shape()[0] % num_heads != 0) {
+        throw std::runtime_error("paged_attention: q.shape[0] must be divisible by num_heads");
+    }
+    if (key_pages.shape() != value_pages.shape()) {
+        throw std::runtime_error("paged_attention: key_pages and value_pages must have the same shape");
+    }
+    if (key_pages.shape()[1] != num_kv_heads) {
+        throw std::runtime_error("paged_attention: page tensor head count must equal num_kv_heads");
+    }
+    if (q.shape()[2] != key_pages.shape()[3]) {
+        throw std::runtime_error("paged_attention: q and page tensors must have the same head dimension");
+    }
+    if (block_table.shape()[0] != context_lens.shape()[0]) {
+        throw std::runtime_error("paged_attention: block_table and context_lens batch sizes must match");
+    }
+    if (q.shape()[0] / num_heads != block_table.shape()[0]) {
+        throw std::runtime_error("paged_attention: q batch size must match block_table batch size");
+    }
+
+    return mx::array(q.shape(), mx::float32,
+                     std::make_shared<PagedAttention>(to_stream(s), scale, is_causal, num_kv_heads, num_heads),
+                     {q, key_pages, value_pages, block_table, context_lens});
+}
+
+void PagedAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) {
+    auto &q = inputs[0];
+    auto &key_pages = inputs[1];
+    auto &value_pages = inputs[2];
+    auto &block_table = inputs[3];
+    auto &context_lens = inputs[4];
+    auto &out = outputs[0];
+
+    if (out.dtype() != mx::float32) {
+        throw std::runtime_error("paged_attention: output dtype must be float32");
+    }
+    if (!q.flags().row_contiguous || !key_pages.flags().row_contiguous || !value_pages.flags().row_contiguous ||
+        !block_table.flags().row_contiguous || !context_lens.flags().row_contiguous) {
+        throw std::runtime_error("paged_attention: all inputs must be contiguous");
+    }
+
+    out.set_data(mx::allocator::malloc(out.nbytes()));
+
+    auto &encoder = mx::cpu::get_command_encoder(stream());
+    encoder.set_input_array(q);
+    encoder.set_input_array(key_pages);
+    encoder.set_input_array(value_pages);
+    encoder.set_input_array(block_table);
+    encoder.set_input_array(context_lens);
+    encoder.set_output_array(out);
+
+    encoder.dispatch([out_ptr = out.data<float>(), q = mx::array::unsafe_weak_copy(q),
+                      key_pages = mx::array::unsafe_weak_copy(key_pages),
+                      value_pages = mx::array::unsafe_weak_copy(value_pages),
+                      block_table = mx::array::unsafe_weak_copy(block_table),
+                      context_lens = mx::array::unsafe_weak_copy(context_lens), scale = scale_,
+                      is_causal = is_causal_, num_kv_heads = num_kv_heads_, num_heads = num_heads_]() {
+        const int64_t N = q.shape()[0];
+        const int64_t L = q.shape()[1];
+        const int64_t D = q.shape()[2];
+        const int64_t page_size = key_pages.shape()[2];
+        const int64_t max_pages = block_table.shape()[1];
+        const int64_t q_kv_ratio = num_heads / num_kv_heads;
+
+        const float *q_ptr = q.data<float>();
+        const float *key_ptr = key_pages.data<float>();
+        const float *value_ptr = value_pages.data<float>();
+        const int32_t *block_ptr = block_table.data<int32_t>();
+        const int32_t *lens_ptr = context_lens.data<int32_t>();
+
+        const int64_t Br = 32;
+        const int64_t Bc = 32;
+        const int64_t Tr = (L + Br - 1) / Br;
+        const int64_t S_capacity = max_pages * page_size;
+        const int64_t context_capacity = std::max<int64_t>(S_capacity, 0);
+
+        for (int64_t n = 0; n < N; n++) {
+            const int64_t batch = n / num_heads;
+            const int64_t q_head = n % num_heads;
+            const int64_t kv_head = q_head / q_kv_ratio;
+            const int64_t context_len = lens_ptr[batch];
+            if (context_len <= 0) {
+                std::fill(out_ptr + n * L * D, out_ptr + (n + 1) * L * D, 0.0f);
+                continue;
+            }
+
+            const int64_t context_limit = std::min<int64_t>(context_len, context_capacity);
+            const int64_t Tc = (context_limit + Bc - 1) / Bc;
+            const int64_t causal_offset = context_len - L;
+
+            for (int64_t i = 0; i < Tr; i++) {
+                const int64_t br_upper_bound = std::min<int64_t>(L - i * Br, Br);
+                std::vector<float> q_i(Br * D, 0.0f);
+                for (int64_t a = 0; a < br_upper_bound; a++) {
+                    for (int64_t c = 0; c < D; c++) {
+                        q_i[a * D + c] = q_ptr[n * L * D + (i * Br + a) * D + c];
+                    }
+                }
+
+                std::vector<float> o_i(Br * D, 0.0f);
+                std::vector<float> l_i(Br, 0.0f);
+                std::vector<float> m_i(Br, -std::numeric_limits<float>::infinity());
+
+                for (int64_t j = 0; j < Tc; j++) {
+                    const int64_t col_min = j * Bc;
+                    const int64_t row_max = i * Br + br_upper_bound - 1;
+                    if (is_causal && col_min > row_max + causal_offset) {
+                        continue;
+                    }
+
+                    const int64_t bc_upper_bound = std::min<int64_t>(context_limit - col_min, Bc);
+                    std::vector<float> s_i(Br * Bc, -std::numeric_limits<float>::infinity());
+                    std::vector<char> valid(Br * Bc, 0);
+
+                    for (int64_t b = 0; b < bc_upper_bound; b++) {
+                        const int64_t key_pos = col_min + b;
+                        const int64_t page_idx = key_pos / page_size;
+                        if (page_idx >= max_pages) {
+                            continue;
+                        }
+                        const int64_t page_id = block_ptr[batch * max_pages + page_idx];
+                        if (page_id < 0) {
+                            continue;
+                        }
+                        const int64_t slot = key_pos - page_idx * page_size;
+                        for (int64_t a = 0; a < br_upper_bound; a++) {
+                            if (is_causal && key_pos > i * Br + a + causal_offset) {
+                                continue;
+                            }
+                            float score = 0.0f;
+                            for (int64_t c = 0; c < D; c++) {
+                                const int64_t k_idx = ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
+                                score += q_i[a * D + c] * key_ptr[k_idx];
+                            }
+                            s_i[a * Bc + b] = score * scale;
+                            valid[a * Bc + b] = 1;
+                        }
+                    }
+
+                    for (int64_t a = 0; a < br_upper_bound; a++) {
+                        float rowmax = -std::numeric_limits<float>::infinity();
+                        for (int64_t b = 0; b < bc_upper_bound; b++) {
+                            if (valid[a * Bc + b]) {
+                                rowmax = std::max(rowmax, s_i[a * Bc + b]);
+                            }
+                        }
+                        if (rowmax == -std::numeric_limits<float>::infinity()) {
+                            continue;
+                        }
+
+                        const float new_max = std::max(m_i[a], rowmax);
+                        const float old_scale = std::exp(m_i[a] - new_max);
+                        float rowsum = 0.0f;
+                        for (int64_t b = 0; b < bc_upper_bound; b++) {
+                            if (valid[a * Bc + b]) {
+                                rowsum += std::exp(s_i[a * Bc + b] - new_max);
+                            }
+                        }
+
+                        for (int64_t c = 0; c < D; c++) {
+                            float res = 0.0f;
+                            for (int64_t b = 0; b < bc_upper_bound; b++) {
+                                if (!valid[a * Bc + b]) {
+                                    continue;
+                                }
+                                const int64_t key_pos = col_min + b;
+                                const int64_t page_idx = key_pos / page_size;
+                                const int64_t page_id = block_ptr[batch * max_pages + page_idx];
+                                const int64_t slot = key_pos - page_idx * page_size;
+                                const int64_t v_idx = ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
+                                res += std::exp(s_i[a * Bc + b] - new_max) * value_ptr[v_idx];
+                            }
+                            o_i[a * D + c] = old_scale * o_i[a * D + c] + res;
+                        }
+
+                        l_i[a] = old_scale * l_i[a] + rowsum;
+                        m_i[a] = new_max;
+                    }
+                }
+
+                for (int64_t a = 0; a < br_upper_bound; a++) {
+                    for (int64_t c = 0; c < D; c++) {
+                        const int64_t out_idx = n * L * D + (i * Br + a) * D + c;
+                        out_ptr[out_idx] = l_i[a] > 0.0f ? o_i[a * D + c] / l_i[a] : 0.0f;
+                    }
+                }
+            }
+        }
+    });
+}
+
+#ifdef _METAL_
+void PagedAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) {
+    const auto &q = inputs[0];
+    const auto &key_pages = inputs[1];
+    const auto &value_pages = inputs[2];
+    const auto &block_table = inputs[3];
+    const auto &context_lens = inputs[4];
+    auto &out = outputs[0];
+
+    if (out.dtype() != mx::float32) {
+        throw std::runtime_error("paged_attention: output dtype must be float32");
+    }
+    if (!q.flags().row_contiguous || !key_pages.flags().row_contiguous || !value_pages.flags().row_contiguous ||
+        !block_table.flags().row_contiguous || !context_lens.flags().row_contiguous) {
+        throw std::runtime_error("paged_attention: all inputs must be contiguous");
+    }
+
+    out.set_data(mx::allocator::malloc(out.nbytes()));
+
+    auto &s = stream();
+    auto &d = mx::metal::device(s.device);
+    auto library = d.get_library("tiny_llm_ext_ref");
+    auto kernel = d.get_kernel("paged_attention_f32", library);
+
+    auto &compute_encoder = d.get_command_encoder(s.index);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(q, 0);
+    compute_encoder.set_input_array(key_pages, 1);
+    compute_encoder.set_input_array(value_pages, 2);
+    compute_encoder.set_input_array(block_table, 3);
+    compute_encoder.set_input_array(context_lens, 4);
+    compute_encoder.set_output_array(out, 5);
+
+    const int N = q.shape()[0];
+    const int L = q.shape()[1];
+    const int D = q.shape()[2];
+    const int page_size = key_pages.shape()[2];
+    const int max_pages = block_table.shape()[1];
+    compute_encoder.set_bytes(N, 6);
+    compute_encoder.set_bytes(L, 7);
+    compute_encoder.set_bytes(D, 8);
+    compute_encoder.set_bytes(page_size, 9);
+    compute_encoder.set_bytes(max_pages, 10);
+    compute_encoder.set_bytes(static_cast<int>(is_causal_), 11);
+    compute_encoder.set_bytes(num_kv_heads_, 12);
+    compute_encoder.set_bytes(num_heads_, 13);
+    compute_encoder.set_bytes(scale_, 14);
+
+    size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
+    size_t simd_width = kernel->threadExecutionWidth();
+
+    const int Br = 32;
+    const int Bc = 32;
+    if (simd_width * Br > tgp_size) {
+        throw std::runtime_error("paged_attention: simd_width * Br must fit in the threadgroup");
+    }
+    if (Bc > simd_width) {
+        throw std::runtime_error("paged_attention: Bc must be less than or equal to simd_width");
+    }
+    if (D > 128) {
+        throw std::runtime_error("paged_attention: head dimension must be less than or equal to 128");
+    }
+
+    const int Tr = (L + Br - 1) / Br;
+    const int Tc = (max_pages * page_size + Bc - 1) / Bc;
+
+    compute_encoder.set_bytes(Br, 15);
+    compute_encoder.set_bytes(Bc, 16);
+    compute_encoder.set_bytes(Tr, 17);
+    compute_encoder.set_bytes(Tc, 18);
+
+    compute_encoder.dispatch_threadgroups(MTL::Size(N, Tr, 1), MTL::Size(Br, simd_width, 1));
+}
+#else
+void PagedAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) {
+    throw std::runtime_error("PagedAttention has no GPU implementation.");
+}
+#endif
+
+}  // namespace tiny_llm_ext_ref

--- a/src/extensions_ref/src/paged_attention.metal
+++ b/src/extensions_ref/src/paged_attention.metal
@@ -1,0 +1,126 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+[[kernel]] void paged_attention_f32(
+    device const float* q [[buffer(0)]],
+    device const float* key_pages [[buffer(1)]],
+    device const float* value_pages [[buffer(2)]],
+    device const int* block_table [[buffer(3)]],
+    device const int* context_lens [[buffer(4)]],
+    device float* out [[buffer(5)]],
+    constant const int& N [[buffer(6)]],
+    constant const int& L [[buffer(7)]],
+    constant const int& D [[buffer(8)]],
+    constant const int& page_size [[buffer(9)]],
+    constant const int& max_pages [[buffer(10)]],
+    constant const int& is_causal [[buffer(11)]],
+    constant const int& num_kv_heads [[buffer(12)]],
+    constant const int& num_heads [[buffer(13)]],
+    constant const float& scale [[buffer(14)]],
+    constant const int& Br [[buffer(15)]],
+    constant const int& Bc [[buffer(16)]],
+    [[maybe_unused]] constant const int& Tr [[buffer(17)]],
+    constant const int& Tc [[buffer(18)]],
+    uint2 group_id [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  const int n = group_id.x;
+  const int i = group_id.y;
+  const int a = simd_gid;
+  const int b = simd_lid;
+  const int row = i * Br + a;
+  const bool is_i_in_range = n < N && row < L && a < Br;
+
+  const int batch = n / num_heads;
+  const int q_head = n % num_heads;
+  const int q_kv_ratio = num_heads / num_kv_heads;
+  const int kv_head = q_head / q_kv_ratio;
+  const int context_len = context_lens[batch];
+  const int causal_offset = context_len - L;
+
+  threadgroup float q_local[32][128];
+  threadgroup float o_i[32 * 128];
+
+  if (simd_lid == 0) {
+    for (int c = 0; c < D; c++) {
+      q_local[a][c] = is_i_in_range ? q[n * L * D + row * D + c] : 0.0f;
+      o_i[a * D + c] = 0.0f;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float m_i = -INFINITY;
+  float l_i = 0.0f;
+
+  for (int j = 0; j < Tc; j++) {
+    const int col = j * Bc + b;
+    if (j * Bc >= context_len) {
+      continue;
+    }
+    if (is_causal) {
+      const int row_max = min((i + 1) * Br - 1, L - 1);
+      if (j * Bc > row_max + causal_offset) {
+        continue;
+      }
+    }
+
+    const int page_idx = col / page_size;
+    const int slot = col - page_idx * page_size;
+    int page_id = -1;
+    bool is_j_in_range = col < context_len && b < Bc && page_idx < max_pages;
+    if (is_j_in_range) {
+      page_id = block_table[batch * max_pages + page_idx];
+      is_j_in_range = page_id >= 0;
+    }
+
+    bool visible = is_i_in_range && is_j_in_range;
+    if (visible && is_causal) {
+      visible = col <= row + causal_offset;
+    }
+
+    float s_a_b = -INFINITY;
+    if (visible) {
+      float score = 0.0f;
+      for (int c = 0; c < D; c++) {
+        const int k_idx =
+            ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
+        score += q_local[a][c] * key_pages[k_idx];
+      }
+      s_a_b = score * scale;
+    }
+
+    const float rowmax = simd_max(s_a_b);
+    const float new_max = max(m_i, rowmax);
+    const float old_scale = exp(m_i - new_max);
+    m_i = new_max;
+
+    const float p_a_b = visible ? exp(s_a_b - m_i) : 0.0f;
+    const float rowsum = simd_sum(p_a_b);
+    l_i = old_scale * l_i + rowsum;
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (int c = 0; c < D; c++) {
+      float partial = 0.0f;
+      if (visible) {
+        const int v_idx =
+            ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
+        partial = p_a_b * value_pages[v_idx];
+      }
+      const float res = simd_sum(partial);
+      if (simd_lid == 0 && is_i_in_range) {
+        o_i[a * D + c] = old_scale * o_i[a * D + c] + res;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (simd_lid == 0) {
+    for (int c = 0; c < D; c++) {
+      if (is_i_in_range) {
+        out[n * L * D + row * D + c] =
+            l_i > 0.0f ? o_i[a * D + c] / l_i : 0.0f;
+      }
+    }
+  }
+}

--- a/src/extensions_ref/src/tiny_llm_ext.h
+++ b/src/extensions_ref/src/tiny_llm_ext.h
@@ -69,4 +69,31 @@ private:
     int num_heads_;
 };
 
+mx::array paged_attention(const mx::array &q, const mx::array &key_pages, const mx::array &value_pages,
+                          const mx::array &block_table, const mx::array &context_lens, const float scale,
+                          const bool is_causal, const int num_kv_heads, const int num_heads, mx::StreamOrDevice s = {});
+
+class PagedAttention : public mx::Primitive {
+public:
+    explicit PagedAttention(mx::Stream stream, const float scale, const bool is_causal, const int num_kv_heads,
+                            const int num_heads)
+        : mx::Primitive(stream), scale_(scale), is_causal_(is_causal), num_kv_heads_(num_kv_heads), num_heads_(num_heads) {};
+
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &inputs,
+                                                             const std::vector<int> &axes) override {
+        throw std::runtime_error("PagedAttention has no vmap implementation.");
+    }
+
+    const char *name() const override { return "PagedAttention"; }
+
+private:
+    float scale_;
+    bool is_causal_;
+    int num_kv_heads_;
+    int num_heads_;
+};
+
 }  // namespace tiny_llm_ext_ref

--- a/src/tiny_llm/__init__.py
+++ b/src/tiny_llm/__init__.py
@@ -6,10 +6,13 @@ from .positional_encoding import *
 from .quantize import *
 from .generate import *
 from .kv_cache import *
+from .paged_kv_cache import *
 from .qwen2_week1 import Qwen2ModelWeek1
 from .qwen2_week2 import Qwen2ModelWeek2
+from .qwen2_week3 import Qwen2ModelWeek3
 from .qwen3 import Qwen3Model
 from .sampler import *
 from .kv_cache import *
+from .paged_kv_cache import *
 from .batch import *
 from .models import *

--- a/src/tiny_llm/paged_kv_cache.py
+++ b/src/tiny_llm/paged_kv_cache.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+
+from .kv_cache import TinyKvCache
+
+
+@dataclass
+class PagedKvMetadata:
+    key_pages: mx.array
+    value_pages: mx.array
+    block_table: mx.array
+    context_lens: mx.array
+    page_size: int
+    mask: mx.array | str | None = None
+
+
+class TinyKvPagedPool:
+    def __init__(self, page_size: int = 128):
+        pass
+
+    @property
+    def num_pages(self) -> int:
+        pass
+
+    @property
+    def num_free_pages(self) -> int:
+        pass
+
+    def allocate_page(self) -> int:
+        pass
+
+    def read_page(self, page_id: int) -> tuple[mx.array, mx.array]:
+        pass
+
+    def write_page_slice(
+        self,
+        page_id: int,
+        start: int,
+        key: mx.array,
+        value: mx.array,
+    ) -> None:
+        pass
+
+    def free_page(self, page_id: int) -> None:
+        pass
+
+
+class TinyKvPagedCache(TinyKvCache):
+    def __init__(self, pool: TinyKvPagedPool):
+        pass
+
+    @property
+    def num_pages(self) -> int:
+        pass
+
+    def gather_dense(self) -> tuple[mx.array, mx.array]:
+        pass
+
+    def update_and_fetch(
+        self,
+        key: mx.array,
+        value: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> tuple[mx.array, mx.array, int, Optional[mx.array]]:
+        pass
+
+    def block_table(self, max_pages: int | None = None) -> mx.array:
+        pass
+
+    def context_lens(self) -> mx.array:
+        pass
+
+    def paged_metadata(
+        self,
+        max_pages: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> PagedKvMetadata:
+        pass
+
+    def update_and_fetch_paged(
+        self,
+        key: mx.array,
+        value: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> PagedKvMetadata:
+        pass
+
+    def rewind(self, n: int):
+        pass
+
+    def release(self):
+        pass

--- a/src/tiny_llm/qwen2_week3.py
+++ b/src/tiny_llm/qwen2_week3.py
@@ -1,0 +1,29 @@
+import mlx.core as mx
+from .kv_cache import TinyKvCache
+from .qwen2_week2 import (
+    Qwen2MLP,
+    Qwen2MultiHeadAttention,
+    Qwen2TransformerBlock,
+)
+from typing import Any
+
+
+class Qwen2ModelWeek3:
+    def __init__(
+        self,
+        mlx_model: Any,
+        page_size: int = 128,
+    ):
+        self.num_hidden_layers = mlx_model.args.num_hidden_layers
+        pass
+
+    def create_kv_cache(self) -> list[TinyKvCache]:
+        pass
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        offset: int | list[int] | mx.array,
+        cache: list[TinyKvCache],
+    ) -> mx.array:
+        pass

--- a/src/tiny_llm_ref/__init__.py
+++ b/src/tiny_llm_ref/__init__.py
@@ -6,11 +6,13 @@ from .positional_encoding import *
 from .quantize import *
 from .generate import *
 from .kv_cache import *
+from .paged_kv_cache import *
 from .qwen2_week1 import Qwen2ModelWeek1
 from .qwen2_week2 import Qwen2ModelWeek2
 from .qwen2_week3 import Qwen2ModelWeek3
 from .qwen3 import Qwen3Model
 from .sampler import *
 from .kv_cache import *
+from .paged_kv_cache import *
 from .batch import *
 from .models import *

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -66,6 +66,53 @@ def scaled_dot_product_attention_grouped(
     return result.reshape(expected_shape)
 
 
+def paged_attention(
+    query: mx.array,
+    key_pages: mx.array,
+    value_pages: mx.array,
+    block_table: mx.array,
+    context_lens: mx.array,
+    page_size: int,
+    scale: float | None = None,
+    mask: mx.array | str | None = None,
+) -> mx.array:
+    """
+    Paged attention backed by the C++/Metal extension.
+
+    The Python wrapper keeps the model-facing shape as [B, H_q, L, D], while
+    the extension sees flattened query heads and contiguous page storage.
+    """
+    if isinstance(mask, mx.array):
+        raise NotImplementedError("Paged attention only supports mask=None or causal")
+    if mask is not None and mask != "causal":
+        raise NotImplementedError
+
+    factor = mx.rsqrt(query.shape[-1]) if scale is None else mx.array(scale)
+    B, H_q, L, D = query.shape
+    _, H, _, _ = key_pages.shape
+    assert H_q % H == 0
+
+    query = mx.contiguous(query.astype(mx.float32).reshape(B * H_q, L, D))
+    key_pages = mx.contiguous(key_pages.astype(mx.float32))
+    value_pages = mx.contiguous(value_pages.astype(mx.float32))
+    block_table = mx.contiguous(block_table.astype(mx.int32))
+    context_lens = mx.contiguous(context_lens.astype(mx.int32))
+    is_causal = mask == "causal"
+
+    result = tiny_llm_ext_ref.paged_attention(
+        query,
+        key_pages,
+        value_pages,
+        block_table,
+        context_lens,
+        float(factor),
+        is_causal=is_causal,
+        num_kv_heads=H,
+        num_heads=H_q,
+    )
+    return mx.contiguous(result.reshape(B, H_q, L, D))
+
+
 def flash_attention(
     query: mx.array,
     key: mx.array,

--- a/src/tiny_llm_ref/kv_cache.py
+++ b/src/tiny_llm_ref/kv_cache.py
@@ -37,6 +37,21 @@ class TinyKvCache(ABC):
         """
         return None
 
+    def update_and_fetch_paged(
+        self,
+        key: mx.array,
+        value: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> "PagedKvMetadata":
+        """
+        Update this cache and return paged attention metadata.
+
+        Week 3 caches override this. Dense caches intentionally do not provide
+        paged metadata, so calling this on them is a programming error.
+        """
+        raise NotImplementedError("This KV cache does not support paged attention")
+
     def rewind(self, n: int):
         """
         Remove the newest n logical tokens from this cache.
@@ -46,233 +61,6 @@ class TinyKvCache(ABC):
         drop dense suffixes or return whole pages to a page pool.
         """
         raise NotImplementedError("This KV cache does not support rewind")
-
-
-class TinyKvPagedPool:
-    """Model-local physical storage for paged KV.
-
-    The model owns one pool and passes it to every layer cache. The pool gives
-    out physical page ids from one free list. Because every live page id is
-    unique, the page id alone is enough to find the physical K/V page.
-    """
-
-    def __init__(self, page_size: int = 128):
-        assert page_size > 0
-        self.page_size = page_size
-        self.key_pages: list[mx.array | None] = []
-        self.value_pages: list[mx.array | None] = []
-        self.free_page_ids: list[int] = []
-        self.used_page_ids: set[int] = set()
-
-    @property
-    def num_pages(self) -> int:
-        return len(self.key_pages)
-
-    @property
-    def num_free_pages(self) -> int:
-        return len(self.free_page_ids)
-
-    def _check_page_chunk(self, x: mx.array) -> None:
-        B, H, S, D = x.shape
-        assert 0 < S <= self.page_size
-
-    def allocate_page(self) -> int:
-        # The page id is allocated from a model-wide free list. In this teaching
-        # version, a layer cache owns the page until release/rewind returns it.
-        if self.free_page_ids:
-            page_id = self.free_page_ids.pop()
-        else:
-            page_id = self.num_pages
-            self.key_pages.append(None)
-            self.value_pages.append(None)
-        self.used_page_ids.add(page_id)
-        return page_id
-
-    def read_page(self, page_id: int) -> tuple[mx.array, mx.array]:
-        key = self.key_pages[page_id]
-        value = self.value_pages[page_id]
-        if key is None or value is None:
-            raise ValueError(f"Page {page_id} has no storage")
-        return key, value
-
-    def _ensure_page_storage(
-        self,
-        page_id: int,
-        key: mx.array,
-        value: mx.array,
-    ) -> tuple[mx.array, mx.array]:
-        key_page = self.key_pages[page_id]
-        value_page = self.value_pages[page_id]
-        if key_page is not None and value_page is not None:
-            return key_page, value_page
-
-        B, H, _, D = key.shape
-        key_page = mx.zeros((B, H, self.page_size, D), dtype=key.dtype)
-        value_page = mx.zeros((B, H, self.page_size, D), dtype=value.dtype)
-        self.key_pages[page_id] = key_page
-        self.value_pages[page_id] = value_page
-        return key_page, value_page
-
-    def write_page_slice(
-        self,
-        page_id: int,
-        start: int,
-        key: mx.array,
-        value: mx.array,
-    ) -> None:
-        assert key.shape == value.shape
-        self._check_page_chunk(key)
-        if page_id not in self.used_page_ids:
-            raise ValueError(f"Page {page_id} is free")
-        key_page, value_page = self._ensure_page_storage(page_id, key, value)
-        B, H, capacity, D = key_page.shape
-        assert value_page.shape == (B, H, capacity, D)
-        assert capacity == self.page_size
-        assert key.shape[:2] == (B, H)
-        assert key.shape[3] == D
-        end = start + key.shape[2]
-        assert 0 <= start <= capacity
-        assert end <= self.page_size
-
-        key_page[:, :, start:end, :] = key
-        value_page[:, :, start:end, :] = value
-        self.key_pages[page_id] = key_page
-        self.value_pages[page_id] = value_page
-
-    def free_page(self, page_id: int) -> None:
-        if page_id not in self.used_page_ids:
-            raise ValueError(f"Page {page_id} is already free")
-        # Keep the page id stable, but drop its old K/V tensors so the id can be
-        # handed to a future cache.
-        self.used_page_ids.remove(page_id)
-        self.key_pages[page_id] = None
-        self.value_pages[page_id] = None
-        self.free_page_ids.append(page_id)
-
-
-class TinyKvPagedCache(TinyKvCache):
-    """Layer-local K/V cache backed by a model-owned page pool.
-
-    Each transformer layer gets its own TinyKvPagedCache and therefore its own
-    `page_ids`, `page_lens`, and `offset`. The shared part is only the pool,
-    which lets pages be recycled across requests and layers.
-    """
-
-    def __init__(self, pool: TinyKvPagedPool):
-        self.pool = pool
-        self.page_size = self.pool.page_size
-        self.page_ids: list[int] = []
-        self.page_lens: list[int] = []
-        self.offset = 0
-
-    @property
-    def num_pages(self) -> int:
-        return len(self.page_ids)
-
-    @property
-    def key_values(self) -> tuple[mx.array, mx.array] | None:
-        if self.offset == 0:
-            return None
-        return self.gather_dense()
-
-    def _append_chunk(self, key: mx.array, value: mx.array) -> None:
-        assert key.shape == value.shape
-        B, H, S, D = key.shape
-        assert B == 1, "Paged request cache only supports one request at a time"
-        start = 0
-
-        # First fill the existing tail page if it has free slots.
-        if self.page_ids and self.page_lens[-1] < self.page_size:
-            page_id = self.page_ids[-1]
-            page_start = self.page_lens[-1]
-            take = min(self.page_size - page_start, S)
-            self.pool.write_page_slice(
-                page_id,
-                page_start,
-                key[:, :, :take, :],
-                value[:, :, :take, :],
-            )
-            self.page_lens[-1] += take
-            start += take
-
-        # Then allocate fresh pages for the remaining chunk. We only write the
-        # valid prefix; unused tail slots are ignored by page_lens.
-        while start < S:
-            end = min(start + self.page_size, S)
-            page_id = self.pool.allocate_page()
-            self.pool.write_page_slice(
-                page_id,
-                0,
-                key[:, :, start:end, :],
-                value[:, :, start:end, :],
-            )
-            self.page_ids.append(page_id)
-            self.page_lens.append(end - start)
-            start = end
-
-        self.offset += S
-
-    def gather_dense(self) -> tuple[mx.array, mx.array]:
-        assert self.offset > 0
-        # Stage A compatibility path: attention still expects dense K/V, so we
-        # trim each fixed-capacity page to its valid prefix and concatenate
-        # request pages in logical order.
-        key_chunks = []
-        value_chunks = []
-        for page_id, page_len in zip(self.page_ids, self.page_lens):
-            key_page, value_page = self.pool.read_page(page_id)
-            assert key_page.shape[2] == self.page_size
-            assert value_page.shape[2] == self.page_size
-            key_chunks.append(key_page[:, :, :page_len, :])
-            value_chunks.append(value_page[:, :, :page_len, :])
-        if len(key_chunks) == 1:
-            return key_chunks[0], value_chunks[0]
-        return mx.concat(key_chunks, axis=2), mx.concat(value_chunks, axis=2)
-
-    def update_and_fetch(
-        self,
-        key: mx.array,
-        value: mx.array,
-        mask_length: int | None = None,
-        mask: mx.array | str | None = None,
-    ) -> tuple[mx.array, mx.array, int, Optional[mx.array]]:
-        assert key.shape == value.shape
-        self._append_chunk(key, value)
-        # Day 1 keeps the old attention interface. Day 2 can replace this dense
-        # gather with block_table/context_lens metadata.
-        dense_key, dense_value = self.gather_dense()
-        return dense_key, dense_value, self.offset, mask
-
-    def rewind(self, n: int):
-        assert 0 <= n <= self.offset
-        new_offset = self.offset - n
-        if new_offset == self.offset:
-            return
-        if new_offset == 0:
-            self.release()
-            return
-
-        target_num_pages = (new_offset + self.page_size - 1) // self.page_size
-        while len(self.page_ids) > target_num_pages:
-            # Whole pages beyond the new logical length return to the shared
-            # allocator. Stale suffix slots in the final page are ignored because
-            # page_lens defines the valid prefix and future writes overwrite them.
-            page_id = self.page_ids.pop()
-            self.page_lens.pop()
-            self.pool.free_page(page_id)
-
-        last_page_len = new_offset - self.page_size * (target_num_pages - 1)
-        self.page_lens[-1] = last_page_len
-        self.offset = new_offset
-
-    def release(self):
-        # Request completion returns every page owned by this layer cache to the
-        # model-level allocator. Other layer caches release their own pages.
-        for page_id in self.page_ids:
-            self.pool.free_page(page_id)
-        self.page_ids.clear()
-        self.page_lens.clear()
-        self.offset = 0
 
 
 class BatchingKvCache(TinyKvCache):
@@ -297,9 +85,8 @@ class BatchingKvCache(TinyKvCache):
         else:
             assert self.HD == (H, D), f"expect {self.HD} but got {H, D}"
         assert B == self.max_active_requests
-        # Step 1: append each active row into its request cache. For paged
-        # caches, this writes into the request's page table and then gathers a
-        # dense view for the current Week 3 Day 1 attention path.
+        # Step 1: append each active row into its request cache. This method
+        # preserves the legacy dense batch interface for Week 2/Day 1 callers.
         data = []
         for b in range(B):
             if self.kv_caches[b] is None:
@@ -342,10 +129,70 @@ class BatchingKvCache(TinyKvCache):
                 raise NotImplementedError
         return keys, values, None, masks.reshape(B, 1, mask_length, seq_len)
 
+    def update_and_fetch_paged(
+        self,
+        keys: mx.array,
+        values: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> "PagedKvMetadata":
+        from .paged_kv_cache import PagedKvMetadata, TinyKvPagedCache
+
+        B, H, S, D = keys.shape
+        assert keys.shape == values.shape
+        assert S <= self.max_seq_len
+        if self.HD is None:
+            self.HD = (H, D)
+        else:
+            assert self.HD == (H, D), f"expect {self.HD} but got {H, D}"
+        assert B == self.max_active_requests
+
+        pool = None
+        context_lens = []
+        max_pages = 0
+        for b in range(B):
+            cache = self.kv_caches[b]
+            if cache is None:
+                context_lens.append(0)
+                continue
+            if not isinstance(cache, TinyKvPagedCache):
+                raise ValueError("BatchingKvCache contains a non-paged request cache")
+            cache.update_and_fetch_paged(
+                keys[b : b + 1],
+                values[b : b + 1],
+                mask_length=mask_length,
+                mask=mask,
+            )
+            if pool is None:
+                pool = cache.pool
+            elif pool is not cache.pool:
+                raise ValueError("Paged batch caches must share one page pool")
+            context_lens.append(cache.offset)
+            max_pages = max(max_pages, cache.num_pages)
+
+        if pool is None:
+            raise ValueError("Cannot build paged metadata without active requests")
+
+        rows = []
+        for cache in self.kv_caches:
+            if cache is None:
+                rows.append([-1] * max_pages)
+            else:
+                rows.append(cache.page_ids + [-1] * (max_pages - cache.num_pages))
+
+        return PagedKvMetadata(
+            key_pages=pool.key_pages,
+            value_pages=pool.value_pages,
+            block_table=mx.array(rows, dtype=mx.int32),
+            context_lens=mx.array(context_lens, dtype=mx.int32),
+            page_size=pool.page_size,
+            mask=mask,
+        )
+
     def add_request(self, prefilled: TinyKvCache, id: int):
         if id >= self.max_active_requests:
             raise ValueError(f"Request id {id} is out of range")
-        if getattr(prefilled, "key_values", None) is not None:
+        if isinstance(prefilled, TinyKvFullCache) and prefilled.key_values is not None:
             keys, _ = prefilled.key_values
             B, H, _, D = keys.shape
             assert B == 1

--- a/src/tiny_llm_ref/paged_kv_cache.py
+++ b/src/tiny_llm_ref/paged_kv_cache.py
@@ -1,0 +1,287 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+
+from .kv_cache import TinyKvCache
+
+
+@dataclass
+class PagedKvMetadata:
+    key_pages: mx.array
+    value_pages: mx.array
+    block_table: mx.array
+    context_lens: mx.array
+    page_size: int
+    mask: mx.array | str | None = None
+
+
+class TinyKvPagedPool:
+    """Model-local physical storage for paged KV.
+
+    The model owns one pool and passes it to every layer cache. The pool gives
+    out physical page ids from one free list. Because every live page id is
+    unique, the page id alone is enough to find the physical K/V page.
+    """
+
+    def __init__(self, page_size: int = 128):
+        assert page_size > 0
+        self.page_size = page_size
+        self.key_pages: mx.array | None = None
+        self.value_pages: mx.array | None = None
+        self.free_page_ids: list[int] = []
+        self.used_page_ids: set[int] = set()
+        self.num_allocated_pages = 0
+
+    @property
+    def num_pages(self) -> int:
+        return self.num_allocated_pages
+
+    @property
+    def num_free_pages(self) -> int:
+        return len(self.free_page_ids)
+
+    def _check_page_chunk(self, x: mx.array) -> None:
+        B, H, S, D = x.shape
+        assert 0 < S <= self.page_size
+
+    def allocate_page(self) -> int:
+        # The page id is allocated from a model-wide free list. In this teaching
+        # version, a layer cache owns the page until release/rewind returns it.
+        if self.free_page_ids:
+            page_id = self.free_page_ids.pop()
+        else:
+            page_id = self.num_pages
+            self.num_allocated_pages += 1
+        self.used_page_ids.add(page_id)
+        return page_id
+
+    def read_page(self, page_id: int) -> tuple[mx.array, mx.array]:
+        if self.key_pages is None or self.value_pages is None:
+            raise ValueError(f"Page {page_id} has no storage")
+        if page_id >= self.num_pages:
+            raise ValueError(f"Page {page_id} is out of range")
+        return (
+            self.key_pages[page_id : page_id + 1],
+            self.value_pages[page_id : page_id + 1],
+        )
+
+    def _ensure_page_storage(self, key: mx.array, value: mx.array) -> None:
+        B, H, _, D = key.shape
+        assert B == 1
+
+        if self.key_pages is not None and self.value_pages is not None:
+            assert self.key_pages.shape[1:] == (H, self.page_size, D)
+            assert self.value_pages.shape == self.key_pages.shape
+            assert self.key_pages.dtype == key.dtype
+            assert self.value_pages.dtype == value.dtype
+            if self.key_pages.shape[0] >= self.num_pages:
+                return
+
+        new_key_pages = mx.zeros(
+            (self.num_pages, H, self.page_size, D), dtype=key.dtype
+        )
+        new_value_pages = mx.zeros(
+            (self.num_pages, H, self.page_size, D), dtype=value.dtype
+        )
+        if self.key_pages is not None and self.value_pages is not None:
+            old_pages = self.key_pages.shape[0]
+            new_key_pages[:old_pages, :, :, :] = self.key_pages
+            new_value_pages[:old_pages, :, :, :] = self.value_pages
+        self.key_pages = new_key_pages
+        self.value_pages = new_value_pages
+
+    def write_page_slice(
+        self,
+        page_id: int,
+        start: int,
+        key: mx.array,
+        value: mx.array,
+    ) -> None:
+        assert key.shape == value.shape
+        self._check_page_chunk(key)
+        if page_id not in self.used_page_ids:
+            raise ValueError(f"Page {page_id} is free")
+        self._ensure_page_storage(key, value)
+        assert self.key_pages is not None
+        assert self.value_pages is not None
+        H, capacity, D = self.key_pages.shape[1:]
+        assert self.value_pages.shape == self.key_pages.shape
+        assert capacity == self.page_size
+        assert key.shape[:2] == (1, H)
+        assert key.shape[3] == D
+        end = start + key.shape[2]
+        assert 0 <= start <= capacity
+        assert end <= self.page_size
+
+        self.key_pages[page_id, :, start:end, :] = key[0]
+        self.value_pages[page_id, :, start:end, :] = value[0]
+
+    def free_page(self, page_id: int) -> None:
+        if page_id not in self.used_page_ids:
+            raise ValueError(f"Page {page_id} is already free")
+        # Keep the page id stable. The stale K/V bytes can stay in the backing
+        # tensor because block_table/page_lens decide which slots are live.
+        self.used_page_ids.remove(page_id)
+        self.free_page_ids.append(page_id)
+
+
+class TinyKvPagedCache(TinyKvCache):
+    """Layer-local K/V cache backed by a model-owned page pool.
+
+    Each transformer layer gets its own TinyKvPagedCache and therefore its own
+    `page_ids`, `page_lens`, and `offset`. The shared part is only the pool,
+    which lets pages be recycled across requests and layers.
+    """
+
+    def __init__(self, pool: TinyKvPagedPool):
+        self.pool = pool
+        self.page_size = self.pool.page_size
+        self.page_ids: list[int] = []
+        self.page_lens: list[int] = []
+        self.offset = 0
+
+    @property
+    def num_pages(self) -> int:
+        return len(self.page_ids)
+
+    @property
+    def key_values(self) -> tuple[mx.array, mx.array] | None:
+        if self.offset == 0:
+            return None
+        return self.gather_dense()
+
+    def _append_chunk(self, key: mx.array, value: mx.array) -> None:
+        assert key.shape == value.shape
+        B, H, S, D = key.shape
+        assert B == 1, "Paged request cache only supports one request at a time"
+        start = 0
+
+        # First fill the existing tail page if it has free slots.
+        if self.page_ids and self.page_lens[-1] < self.page_size:
+            page_id = self.page_ids[-1]
+            page_start = self.page_lens[-1]
+            take = min(self.page_size - page_start, S)
+            self.pool.write_page_slice(
+                page_id,
+                page_start,
+                key[:, :, :take, :],
+                value[:, :, :take, :],
+            )
+            self.page_lens[-1] += take
+            start += take
+
+        # Then allocate fresh pages for the remaining chunk. We only write the
+        # valid prefix; unused tail slots are ignored by page_lens.
+        while start < S:
+            end = min(start + self.page_size, S)
+            page_id = self.pool.allocate_page()
+            self.pool.write_page_slice(
+                page_id,
+                0,
+                key[:, :, start:end, :],
+                value[:, :, start:end, :],
+            )
+            self.page_ids.append(page_id)
+            self.page_lens.append(end - start)
+            start = end
+
+        self.offset += S
+
+    def gather_dense(self) -> tuple[mx.array, mx.array]:
+        assert self.offset > 0
+        # Dense compatibility path for tests and older callers. The paged
+        # attention path uses block_table/context_lens instead of this gather.
+        key_chunks = []
+        value_chunks = []
+        for page_id, page_len in zip(self.page_ids, self.page_lens):
+            key_page, value_page = self.pool.read_page(page_id)
+            assert key_page.shape[2] == self.page_size
+            assert value_page.shape[2] == self.page_size
+            key_chunks.append(key_page[:, :, :page_len, :])
+            value_chunks.append(value_page[:, :, :page_len, :])
+        if len(key_chunks) == 1:
+            return key_chunks[0], value_chunks[0]
+        return mx.concat(key_chunks, axis=2), mx.concat(value_chunks, axis=2)
+
+    def update_and_fetch(
+        self,
+        key: mx.array,
+        value: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> tuple[mx.array, mx.array, int, Optional[mx.array]]:
+        assert key.shape == value.shape
+        self._append_chunk(key, value)
+        # Keep the old dense interface for Day 1 callers. Day 2 uses
+        # update_and_fetch_paged so attention can read pages directly.
+        dense_key, dense_value = self.gather_dense()
+        return dense_key, dense_value, self.offset, mask
+
+    def block_table(self, max_pages: int | None = None) -> mx.array:
+        if max_pages is None:
+            max_pages = self.num_pages
+        assert max_pages >= self.num_pages
+        page_ids = self.page_ids + [-1] * (max_pages - self.num_pages)
+        return mx.array([page_ids], dtype=mx.int32)
+
+    def context_lens(self) -> mx.array:
+        return mx.array([self.offset], dtype=mx.int32)
+
+    def paged_metadata(
+        self,
+        max_pages: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> PagedKvMetadata:
+        assert self.pool.key_pages is not None
+        assert self.pool.value_pages is not None
+        return PagedKvMetadata(
+            key_pages=self.pool.key_pages,
+            value_pages=self.pool.value_pages,
+            block_table=self.block_table(max_pages=max_pages),
+            context_lens=self.context_lens(),
+            page_size=self.page_size,
+            mask=mask,
+        )
+
+    def update_and_fetch_paged(
+        self,
+        key: mx.array,
+        value: mx.array,
+        mask_length: int | None = None,
+        mask: mx.array | str | None = None,
+    ) -> PagedKvMetadata:
+        assert key.shape == value.shape
+        self._append_chunk(key, value)
+        return self.paged_metadata(mask=mask)
+
+    def rewind(self, n: int):
+        assert 0 <= n <= self.offset
+        new_offset = self.offset - n
+        if new_offset == self.offset:
+            return
+        if new_offset == 0:
+            self.release()
+            return
+
+        target_num_pages = (new_offset + self.page_size - 1) // self.page_size
+        while len(self.page_ids) > target_num_pages:
+            # Whole pages beyond the new logical length return to the shared
+            # allocator. Stale suffix slots in the final page are ignored because
+            # page_lens defines the valid prefix and future writes overwrite them.
+            page_id = self.page_ids.pop()
+            self.page_lens.pop()
+            self.pool.free_page(page_id)
+
+        last_page_len = new_offset - self.page_size * (target_num_pages - 1)
+        self.page_lens[-1] = last_page_len
+        self.offset = new_offset
+
+    def release(self):
+        # Request completion returns every page owned by this layer cache to the
+        # model-level allocator. Other layer caches release their own pages.
+        for page_id in self.page_ids:
+            self.pool.free_page(page_id)
+        self.page_ids.clear()
+        self.page_lens.clear()
+        self.offset = 0

--- a/src/tiny_llm_ref/qwen2_week3.py
+++ b/src/tiny_llm_ref/qwen2_week3.py
@@ -1,16 +1,14 @@
 import mlx.core as mx
 
 from .basics import silu
-from .attention import (
-    scaled_dot_product_attention_grouped,
-    flash_attention,
-)
+from .attention import paged_attention
 from .layer_norm import RMSNorm
 from .positional_encoding import RoPE
 from typing import Any
 from .embedding import Embedding
 from .quantize import dequantize_linear, QuantizedWeights, quantized_linear
-from .kv_cache import TinyKvCache, TinyKvPagedCache, TinyKvPagedPool
+from .kv_cache import TinyKvCache
+from .paged_kv_cache import TinyKvPagedCache, TinyKvPagedPool
 
 
 class Qwen2MultiHeadAttention:
@@ -28,7 +26,6 @@ class Qwen2MultiHeadAttention:
         bv: mx.array,
         max_seq_len: int = 32768,
         theta: int = 1000000,
-        use_flash_attention: bool = False,
     ):
         self.hidden_size = hidden_size
         self.num_heads = num_heads
@@ -49,7 +46,6 @@ class Qwen2MultiHeadAttention:
         self.bk = bk
         self.bv = bv
         self.rope = RoPE(self.head_dim, max_seq_len, theta, traditional=False)
-        self.use_flash_attention = use_flash_attention
 
     def __call__(
         self,
@@ -77,25 +73,23 @@ class Qwen2MultiHeadAttention:
         projection_q = projection_q.transpose(0, 2, 1, 3)
         projection_k = projection_k.transpose(0, 2, 1, 3)
         projection_v = projection_v.transpose(0, 2, 1, 3)
-        projection_k, projection_v, _, mask = cache.update_and_fetch(
-            projection_k, projection_v, mask_length=L, mask=mask
+
+        metadata = cache.update_and_fetch_paged(
+            projection_k.astype(mx.float32),
+            projection_v.astype(mx.float32),
+            mask_length=L,
+            mask=mask,
         )
-        if self.use_flash_attention:
-            x = flash_attention(
-                projection_q.astype(mx.float32),
-                projection_k.astype(mx.float32),
-                projection_v.astype(mx.float32),
-                scale=self.scale,
-                mask=mask,
-            ).astype(x.dtype)
-        else:
-            x = scaled_dot_product_attention_grouped(
-                projection_q.astype(mx.float32),
-                projection_k.astype(mx.float32),
-                projection_v.astype(mx.float32),
-                scale=self.scale,
-                mask=mask,
-            ).astype(x.dtype)
+        x = paged_attention(
+            projection_q.astype(mx.float32),
+            metadata.key_pages,
+            metadata.value_pages,
+            metadata.block_table,
+            metadata.context_lens,
+            metadata.page_size,
+            scale=self.scale,
+            mask=metadata.mask,
+        ).astype(x.dtype)
         x = x.transpose(0, 2, 1, 3).reshape(B, L, self.hidden_size)
         return quantized_linear(x, self.wo)
 
@@ -144,7 +138,6 @@ class Qwen2TransformerBlock:
         w_post_attention_layernorm: mx.array,
         max_seq_len: int = 32768,
         theta: int = 1000000,
-        use_flash_attention: bool = False,
     ):
         self.num_attention_heads = num_attention_heads
         self.hidden_size = hidden_size
@@ -166,7 +159,6 @@ class Qwen2TransformerBlock:
             bv=bv,
             max_seq_len=max_seq_len,
             theta=theta,
-            use_flash_attention=use_flash_attention,
         )
 
     def __call__(
@@ -187,7 +179,6 @@ class Qwen2ModelWeek3:
     def __init__(
         self,
         mlx_model: Any,
-        enable_flash_attn: bool = False,
         page_size: int = 128,
     ):
         self.num_hidden_layers = mlx_model.args.num_hidden_layers
@@ -254,7 +245,6 @@ class Qwen2ModelWeek3:
                 ].post_attention_layernorm.weight.astype(precision),
                 max_seq_len=mlx_model.args.max_position_embeddings,
                 theta=mlx_model.args.rope_theta,
-                use_flash_attention=enable_flash_attn,
             )
             self.layers_inner.append(layer)
         self.norm = RMSNorm(

--- a/tests_refsol/test_week_3_day_2.py
+++ b/tests_refsol/test_week_3_day_2.py
@@ -1,0 +1,200 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from .tiny_llm_base import (
+    BatchingKvCache,
+    Qwen2ModelWeek2,
+    Qwen2ModelWeek3,
+    TinyKvPagedCache,
+    TinyKvPagedPool,
+    flash_attention,
+    paged_attention,
+    scaled_dot_product_attention_grouped,
+)
+from .utils import assert_allclose
+
+
+def _random_chunk(
+    length: int, num_heads: int = 2, head_dim: int = 4
+) -> tuple[mx.array, mx.array]:
+    key = mx.random.normal(shape=(1, num_heads, length, head_dim)).astype(mx.float32)
+    value = mx.random.normal(shape=(1, num_heads, length, head_dim)).astype(mx.float32)
+    return key, value
+
+
+def _quantized_layer(
+    out_dim: int, in_dim: int, *, bias: bool = False, group_size: int = 64
+) -> SimpleNamespace:
+    weight = mx.random.normal(shape=(out_dim, in_dim), dtype=mx.float16)
+    quantized_weight, scales, biases = mx.quantize(weight, group_size=group_size, bits=4)
+    layer = SimpleNamespace(
+        weight=quantized_weight,
+        scales=scales,
+        biases=biases,
+        group_size=group_size,
+        bits=4,
+    )
+    if bias:
+        layer.bias = mx.random.normal(shape=(out_dim,), dtype=mx.float16)
+    return layer
+
+
+def _fake_qwen2_mlx_model() -> SimpleNamespace:
+    mx.random.seed(0)
+    args = SimpleNamespace(
+        num_hidden_layers=2,
+        hidden_size=64,
+        vocab_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        intermediate_size=128,
+        rms_norm_eps=1e-5,
+        max_position_embeddings=128,
+        rope_theta=10000,
+        tie_word_embeddings=True,
+    )
+    embed_tokens = _quantized_layer(args.vocab_size, args.hidden_size)
+    kv_hidden_size = (
+        args.hidden_size // args.num_attention_heads * args.num_key_value_heads
+    )
+    layers = []
+    for _ in range(args.num_hidden_layers):
+        layers.append(
+            SimpleNamespace(
+                self_attn=SimpleNamespace(
+                    q_proj=_quantized_layer(
+                        args.hidden_size, args.hidden_size, bias=True
+                    ),
+                    k_proj=_quantized_layer(
+                        kv_hidden_size, args.hidden_size, bias=True
+                    ),
+                    v_proj=_quantized_layer(
+                        kv_hidden_size, args.hidden_size, bias=True
+                    ),
+                    o_proj=_quantized_layer(args.hidden_size, args.hidden_size),
+                ),
+                mlp=SimpleNamespace(
+                    gate_proj=_quantized_layer(args.intermediate_size, args.hidden_size),
+                    up_proj=_quantized_layer(args.intermediate_size, args.hidden_size),
+                    down_proj=_quantized_layer(args.hidden_size, args.intermediate_size),
+                ),
+                input_layernorm=SimpleNamespace(
+                    weight=mx.ones((args.hidden_size,), dtype=mx.float16)
+                ),
+                post_attention_layernorm=SimpleNamespace(
+                    weight=mx.ones((args.hidden_size,), dtype=mx.float16)
+                ),
+            )
+        )
+    return SimpleNamespace(
+        args=args,
+        model=SimpleNamespace(
+            embed_tokens=embed_tokens,
+            layers=layers,
+            norm=SimpleNamespace(weight=mx.ones((args.hidden_size,), dtype=mx.float16)),
+        ),
+    )
+
+
+def test_task_1_paged_attention_matches_dense_flash_attention():
+    page_size = 4
+    pool = TinyKvPagedPool(page_size=page_size)
+    cache = TinyKvPagedCache(pool=pool)
+    first_key, first_value = _random_chunk(3)
+    second_key, second_value = _random_chunk(3)
+
+    cache.update_and_fetch(first_key, first_value)
+    metadata = cache.update_and_fetch_paged(second_key, second_value, mask="causal")
+
+    query = mx.random.normal(shape=(1, 4, second_key.shape[2], 4)).astype(mx.float32)
+    dense_key, dense_value = cache.gather_dense()
+    dense_output = flash_attention(
+        query,
+        dense_key,
+        dense_value,
+        mask="causal",
+    )
+    paged_output = paged_attention(
+        query,
+        metadata.key_pages,
+        metadata.value_pages,
+        metadata.block_table,
+        metadata.context_lens,
+        metadata.page_size,
+        mask=metadata.mask,
+    )
+
+    assert metadata.block_table.tolist() == [[0, 1]]
+    assert metadata.context_lens.tolist() == [6]
+    assert metadata.key_pages.shape == (2, 2, page_size, 4)
+    assert metadata.value_pages.shape == (2, 2, page_size, 4)
+    assert_allclose(paged_output, dense_output, precision=mx.float32)
+
+
+def test_task_2_batched_paged_attention_matches_dense_attention():
+    page_size = 4
+    pool = TinyKvPagedPool(page_size=page_size)
+    first = TinyKvPagedCache(pool=pool)
+    second = TinyKvPagedCache(pool=pool)
+    first.update_and_fetch(*_random_chunk(3))
+    second.update_and_fetch(*_random_chunk(6))
+
+    batch = BatchingKvCache(max_active_requests=3, max_seq_len=16)
+    batch.add_request(first, 0)
+    batch.add_request(second, 2)
+
+    keys = mx.zeros((3, 2, 1, 4), dtype=mx.float32)
+    values = mx.zeros((3, 2, 1, 4), dtype=mx.float32)
+    keys[0:1], values[0:1] = _random_chunk(1)
+    keys[2:3], values[2:3] = _random_chunk(1)
+
+    metadata = batch.update_and_fetch_paged(
+        keys,
+        values,
+        mask_length=1,
+        mask="causal",
+    )
+    query = mx.random.normal(shape=(3, 4, 1, 4)).astype(mx.float32)
+    paged_output = paged_attention(
+        query,
+        metadata.key_pages,
+        metadata.value_pages,
+        metadata.block_table,
+        metadata.context_lens,
+        metadata.page_size,
+        mask=metadata.mask,
+    )
+
+    first_key, first_value = first.gather_dense()
+    first_output = scaled_dot_product_attention_grouped(
+        query[0:1], first_key, first_value, mask="causal"
+    )
+    second_key, second_value = second.gather_dense()
+    second_output = scaled_dot_product_attention_grouped(
+        query[2:3], second_key, second_value, mask="causal"
+    )
+
+    assert metadata.context_lens.tolist() == [4, 0, 7]
+    assert metadata.block_table.shape == (3, 2)
+    assert metadata.block_table.tolist()[1] == [-1, -1]
+    assert metadata.key_pages.shape == (3, 2, page_size, 4)
+    assert_allclose(paged_output[0:1], first_output, precision=mx.float32)
+    assert_allclose(paged_output[2:3], second_output, precision=mx.float32)
+
+
+def test_task_3_incremental_decode_matches_week2_with_paged_attention():
+    mlx_model = _fake_qwen2_mlx_model()
+    week2_model = Qwen2ModelWeek2(mlx_model)
+    week3_model = Qwen2ModelWeek3(mlx_model, page_size=4)
+    inputs = mx.array([[1, 5, 7, 3, 9, 11]], dtype=mx.int32)
+    week2_cache = week2_model.create_kv_cache()
+    week3_cache = week3_model.create_kv_cache()
+
+    for offset in range(inputs.shape[1]):
+        token = inputs[:, offset : offset + 1]
+        week2_out = week2_model(token, offset, week2_cache)
+        week3_out = week3_model(token, offset, week3_cache)
+        week2_out = week2_out - mx.logsumexp(week2_out, keepdims=True)
+        week3_out = week3_out - mx.logsumexp(week3_out, keepdims=True)
+        assert_allclose(week3_out, week2_out, precision=mx.float16, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Summary

- Add Week 3 paged KV cache storage and metadata plumbing for `block_table` / `context_lens`.
- Add the reference MLX C++/Metal paged attention kernel using page-table reads and FlashAttention-style online softmax.
- Wire Qwen2 Week 3, starter scaffolding, docs, and reference tests for paged attention part 2.
