### PR TITLE
Clarify Qwen3 model size test names

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,7 +55,7 @@ def np_type_to_mx_type(np_type: np.dtype) -> mx.Dtype:
         raise ValueError(f"Unsupported numpy type: {np_type}")
 
 
-def qwen_3_06b_model_exists() -> bool:
+def qwen3_0_6b_model_exists() -> bool:
     try:
         huggingface_hub.snapshot_download(
             "Qwen/Qwen3-0.6B-MLX-4bit", local_files_only=True
@@ -66,7 +66,7 @@ def qwen_3_06b_model_exists() -> bool:
         return False
 
 
-def qwen_3_17b_model_exists() -> bool:
+def qwen3_1_7b_model_exists() -> bool:
     try:
         huggingface_hub.snapshot_download(
             "Qwen/Qwen3-1.7B-MLX-4bit", local_files_only=True
@@ -77,7 +77,7 @@ def qwen_3_17b_model_exists() -> bool:
         return False
 
 
-def qwen_3_4b_model_exists() -> bool:
+def qwen3_4b_model_exists() -> bool:
     try:
         huggingface_hub.snapshot_download(
             "Qwen/Qwen3-4B-MLX-4bit", local_files_only=True

--- a/tests_refsol/test_week_1_day_5.py
+++ b/tests_refsol/test_week_1_day_5.py
@@ -87,23 +87,23 @@ def test_task_1_transformer_block(
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_utils_qwen_3_06b():
+def test_utils_qwen3_0_6b():
     pass
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_utils_qwen_3_4b():
+def test_utils_qwen3_4b():
     pass
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_utils_qwen_3_17b():
+def test_utils_qwen3_1_7b():
     pass
 
 
@@ -122,7 +122,7 @@ def helper_test_task_3(model_name: str, iters: int = 10):
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
 def test_task_2_embedding_call():
     mlx_model, _ = load("Qwen/Qwen3-0.6B-MLX-4bit")
@@ -139,7 +139,7 @@ def test_task_2_embedding_call():
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
 def test_task_2_embedding_as_linear():
     mlx_model, _ = load("Qwen/Qwen3-0.6B-MLX-4bit")
@@ -156,21 +156,21 @@ def test_task_2_embedding_as_linear():
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_task_3_qwen_3_06b():
+def test_task_3_qwen3_0_6b():
     helper_test_task_3("Qwen/Qwen3-0.6B-MLX-4bit", 5)
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_task_3_qwen_3_4b():
+def test_task_3_qwen3_4b():
     helper_test_task_3("Qwen/Qwen3-4B-MLX-4bit", 1)
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_task_3_qwen_3_17b():
+def test_task_3_qwen3_1_7b():
     helper_test_task_3("Qwen/Qwen3-1.7B-MLX-4bit", 3)

--- a/tests_refsol/test_week_2_day_1.py
+++ b/tests_refsol/test_week_2_day_1.py
@@ -10,23 +10,23 @@ from mlx_lm import load
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_utils_qwen_3_06b():
+def test_utils_qwen3_0_6b():
     pass
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_utils_qwen_3_4b():
+def test_utils_qwen3_4b():
     pass
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_utils_qwen_3_17b():
+def test_utils_qwen3_1_7b():
     pass
 
 
@@ -46,23 +46,23 @@ def helper_test_task_3(model_name: str, iters: int = 10):
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_task_3_qwen_3_06b():
+def test_task_3_qwen3_0_6b():
     helper_test_task_3("Qwen/Qwen3-0.6B-MLX-4bit", 5)
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_task_3_qwen_3_4b():
+def test_task_3_qwen3_4b():
     helper_test_task_3("Qwen/Qwen3-4B-MLX-4bit", 1)
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_task_3_qwen_3_17b():
+def test_task_3_qwen3_1_7b():
     helper_test_task_3("Qwen/Qwen3-1.7B-MLX-4bit", 3)
 
 
@@ -92,16 +92,16 @@ def helper_test_task_4(
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_task_4_qwen_3_06b():
+def test_task_4_qwen3_0_6b():
     helper_test_task_4("Qwen/Qwen3-0.6B-MLX-4bit", seq_len=3)
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_task_4_qwen_3_4b():
+def test_task_4_qwen3_4b():
     helper_test_task_4(
         "Qwen/Qwen3-4B-MLX-4bit",
         seq_len=3,
@@ -109,7 +109,7 @@ def test_task_4_qwen_3_4b():
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_task_4_qwen_3_17b():
+def test_task_4_qwen3_1_7b():
     helper_test_task_4("Qwen/Qwen3-1.7B-MLX-4bit", seq_len=3)

--- a/tests_refsol/test_week_2_day_6.py
+++ b/tests_refsol/test_week_2_day_6.py
@@ -319,16 +319,16 @@ def helper_test_task_3(
 
 
 @pytest.mark.skipif(
-    not qwen_3_06b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
+    not qwen3_0_6b_model_exists(), reason="Qwen3-0.6B-4bit model not found"
 )
-def test_task_3_qwen_3_06b():
+def test_task_3_qwen3_0_6b():
     helper_test_task_3("Qwen/Qwen3-0.6B-MLX-4bit", seq_len=3)
 
 
 @pytest.mark.skipif(
-    not qwen_3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
+    not qwen3_4b_model_exists(), reason="Qwen3-4B-4bit model not found"
 )
-def test_task_3_qwen_3_4b():
+def test_task_3_qwen3_4b():
     helper_test_task_3(
         "Qwen/Qwen3-4B-MLX-4bit",
         seq_len=3,
@@ -336,9 +336,9 @@ def test_task_3_qwen_3_4b():
 
 
 @pytest.mark.skipif(
-    not qwen_3_17b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
+    not qwen3_1_7b_model_exists(), reason="Qwen3-1.7B-4bit model not found"
 )
-def test_task_3_qwen_3_17b():
+def test_task_3_qwen3_1_7b():
     helper_test_task_3(
         "Qwen/Qwen3-1.7B-MLX-4bit",
         seq_len=3,


### PR DESCRIPTION
## Summary

- Rename Qwen3 0.6B and 1.7B model-existence helpers to use explicit decimal separators in Python identifiers.
- Use the compact `qwen3` prefix in affected reference-solution skip guards and test names, so `1.7B` is not easy to read as `17B`.
