### PR TITLE
perf: Optimize quantized matmul for small decode batches

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -14,6 +14,18 @@ class BenchRequest:
     max_new_tokens: int
 
 
+@dataclass
+class BatchRequestState:
+    """Per-request state while it moves from prefill into a decode batch."""
+
+    request: BenchRequest
+    kv_cache: list
+    offset: int = 0
+    generated_tokens: int = 0
+    next_token: int | None = None
+    is_prefill_done: bool = False
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Benchmark tiny-llm token throughput with synthetic token IDs."
@@ -32,6 +44,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-output-len", type=int, default=256)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument(
+        "--batch-decode",
+        action="store_true",
+        help="Run the Week 2 continuous-batching decode benchmark.",
+    )
+    parser.add_argument("--batch-size", type=int, default=5)
+    parser.add_argument(
+        "--prefill-step",
+        type=int,
+        default=128,
+        help="Maximum number of prompt tokens to prefill per scheduler step.",
+    )
+    parser.add_argument(
+        "--max-seq-len",
+        type=int,
+        default=512,
+        help="Maximum prompt+generated length for a batched request.",
+    )
     return parser.parse_args()
 
 
@@ -48,19 +78,29 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--min-output-len cannot be greater than --max-output-len")
     if args.warmup < 0:
         raise ValueError("--warmup must be >= 0")
+    if args.batch_decode and args.loader != "week2":
+        raise ValueError("--batch-decode is only supported with --loader week2")
+    if args.batch_decode and args.batch_size <= 0:
+        raise ValueError("--batch-size must be > 0")
+    if args.batch_decode and args.prefill_step <= 0:
+        raise ValueError("--prefill-step must be > 0")
+    if args.batch_decode and args.max_seq_len <= 0:
+        raise ValueError("--max-seq-len must be > 0")
+    if args.batch_decode and args.num_seqs < args.batch_size:
+        raise ValueError("--batch-decode requires --num-seqs >= --batch-size")
 
 
 def load_solution_modules(solution: str):
     if solution == "tiny_llm":
         from tiny_llm import models
-        from tiny_llm.kv_cache import TinyKvFullCache
+        from tiny_llm.kv_cache import BatchingKvCache, TinyKvFullCache
 
-        return "tiny_llm", models, TinyKvFullCache
+        return "tiny_llm", models, TinyKvFullCache, BatchingKvCache
     if solution in {"tiny_llm_ref", "ref"}:
         from tiny_llm_ref import models
-        from tiny_llm_ref.kv_cache import TinyKvFullCache
+        from tiny_llm_ref.kv_cache import BatchingKvCache, TinyKvFullCache
 
-        return "tiny_llm_ref", models, TinyKvFullCache
+        return "tiny_llm_ref", models, TinyKvFullCache, BatchingKvCache
     raise ValueError(f"Solution {solution} not supported for bench")
 
 
@@ -110,6 +150,14 @@ def sample_next_week1(model, y: mx.array) -> mx.array:
 
 def sample_next_week2(model, y: mx.array, offset: int, kv_cache: list) -> mx.array:
     output_logits = model(y[None, :], offset, kv_cache)
+    logits = output_logits[:, -1, :]
+    return mx.argmax(logits, axis=-1)
+
+
+def sample_next_week2_batched(
+    model, y: mx.array, offsets: list[int], kv_cache: list
+) -> mx.array:
+    output_logits = model(y, offsets, kv_cache)
     logits = output_logits[:, -1, :]
     return mx.argmax(logits, axis=-1)
 
@@ -165,6 +213,136 @@ def run_one_request_week2(
     return generated_tokens, prefill_time, decode_time
 
 
+def run_batch_requests_week2(
+    model,
+    requests: list[BenchRequest],
+    kv_cache_cls,
+    batching_kv_cache_cls,
+    *,
+    batch_size: int,
+    prefill_step: int,
+    max_seq_len: int,
+) -> tuple[int, int, float, float]:
+    """Benchmark Week 2 continuous batching without tokenizer/detokenizer overhead."""
+
+    decode_requests: list[BatchRequestState | None] = [None] * batch_size
+    batch_kv_cache = [
+        batching_kv_cache_cls(max_active_requests=batch_size, max_seq_len=max_seq_len)
+        for _ in range(model.num_hidden_layers)
+    ]
+    pending_prefill: BatchRequestState | None = None
+    next_request_idx = 0
+
+    generated_tokens = 0
+    decode_tokens = 0
+    prefill_time = 0.0
+    decode_time = 0.0
+
+    while True:
+        if (
+            next_request_idx >= len(requests)
+            and pending_prefill is None
+            and all(req is None for req in decode_requests)
+        ):
+            break
+
+        if pending_prefill is None and next_request_idx < len(requests):
+            pending_prefill = BatchRequestState(
+                request=requests[next_request_idx],
+                kv_cache=[kv_cache_cls() for _ in range(model.num_hidden_layers)],
+            )
+            next_request_idx += 1
+
+        if pending_prefill is not None and not pending_prefill.is_prefill_done:
+            remaining = (
+                len(pending_prefill.request.prompt_token_ids) - pending_prefill.offset
+            )
+            chunk_len = min(prefill_step, remaining)
+            chunk = pending_prefill.request.prompt_token_ids[
+                pending_prefill.offset : pending_prefill.offset + chunk_len
+            ]
+            t0 = perf_counter()
+            token = sample_next_week2(
+                model,
+                mx.array(chunk, dtype=mx.int32),
+                pending_prefill.offset,
+                pending_prefill.kv_cache,
+            )
+            mx.eval(token)
+            prefill_time += perf_counter() - t0
+            pending_prefill.offset += chunk_len
+
+            for layer_cache in pending_prefill.kv_cache:
+                mx.eval(layer_cache.key_values[0], layer_cache.key_values[1])
+
+            if pending_prefill.offset == len(pending_prefill.request.prompt_token_ids):
+                pending_prefill.is_prefill_done = True
+                pending_prefill.generated_tokens = 1
+                pending_prefill.next_token = token.item()
+                generated_tokens += 1
+
+        if pending_prefill is not None and pending_prefill.is_prefill_done:
+            if (
+                pending_prefill.generated_tokens
+                >= pending_prefill.request.max_new_tokens
+                or pending_prefill.offset >= max_seq_len
+            ):
+                for layer_cache in pending_prefill.kv_cache:
+                    layer_cache.release()
+                pending_prefill = None
+                continue
+
+            for slot, current in enumerate(decode_requests):
+                if current is None:
+                    for prefill_cache, batch_cache in zip(
+                        pending_prefill.kv_cache, batch_kv_cache
+                    ):
+                        batch_cache.add_request(prefill_cache, slot)
+                    decode_requests[slot] = pending_prefill
+                    pending_prefill = None
+                    break
+
+        if any(req is not None for req in decode_requests):
+            next_tokens = []
+            offsets = []
+            active_slots = []
+            for slot, req in enumerate(decode_requests):
+                if req is None:
+                    next_tokens.append(0)
+                    offsets.append(0)
+                    continue
+                next_tokens.append(req.next_token)
+                offsets.append(req.offset)
+                active_slots.append(slot)
+
+            t1 = perf_counter()
+            decoded = sample_next_week2_batched(
+                model,
+                mx.array(next_tokens, dtype=mx.int32).reshape(-1, 1),
+                offsets,
+                batch_kv_cache,
+            )
+            mx.eval(decoded)
+            decode_time += perf_counter() - t1
+
+            for slot in active_slots:
+                req = decode_requests[slot]
+                req.next_token = decoded[slot].item()
+                req.offset += 1
+                req.generated_tokens += 1
+                generated_tokens += 1
+                decode_tokens += 1
+                if (
+                    req.generated_tokens >= req.request.max_new_tokens
+                    or req.offset >= max_seq_len
+                ):
+                    for layer_cache in batch_kv_cache:
+                        layer_cache.remove_request(slot)
+                    decode_requests[slot] = None
+
+    return generated_tokens, decode_tokens, prefill_time, decode_time
+
+
 def safe_div(num: float, den: float) -> float:
     return num / den if den > 0 else 0.0
 
@@ -174,7 +352,9 @@ def main() -> None:
     validate_args(args)
 
     rng = Random(args.seed)
-    solution_name, models, kv_cache_cls = load_solution_modules(args.solution)
+    solution_name, models, kv_cache_cls, batching_kv_cache_cls = load_solution_modules(
+        args.solution
+    )
     model_name = models.shortcut_name_to_full_name(args.model)
     print(
         f"Solution={solution_name} Loader={args.loader} Device={args.device} "
@@ -199,12 +379,29 @@ def main() -> None:
                 enable_flash_attn=args.enable_flash_attn,
             )
 
-            def run_one_request(request: BenchRequest) -> tuple[int, float, float]:
-                return run_one_request_week2(
-                    model,
-                    request,
-                    kv_cache_cls,
-                )
+            if args.batch_decode:
+
+                def run_benchmark(
+                    bench_requests: list[BenchRequest],
+                ) -> tuple[int, int, float, float]:
+                    return run_batch_requests_week2(
+                        model,
+                        bench_requests,
+                        kv_cache_cls,
+                        batching_kv_cache_cls,
+                        batch_size=args.batch_size,
+                        prefill_step=args.prefill_step,
+                        max_seq_len=args.max_seq_len,
+                    )
+
+            else:
+
+                def run_one_request(request: BenchRequest) -> tuple[int, float, float]:
+                    return run_one_request_week2(
+                        model,
+                        request,
+                        kv_cache_cls,
+                    )
 
         requests = build_requests(
             rng=rng,
@@ -228,32 +425,50 @@ def main() -> None:
                 leave=False,
             )
             for i in warmup_iter:
-                run_one_request(requests[i % len(requests)])
+                if args.batch_decode and args.loader == "week2":
+                    run_benchmark([requests[i % len(requests)]])
+                else:
+                    run_one_request(requests[i % len(requests)])
 
-        total_prompt_tokens = 0
+        total_prompt_tokens = sum(len(request.prompt_token_ids) for request in requests)
+        progress = tqdm(total=len(requests), desc="Bench", dynamic_ncols=True)
+
         total_generated_tokens = 0
         total_decode_tokens = 0
         total_prefill_time = 0.0
         total_decode_time = 0.0
 
-        progress = tqdm(total=len(requests), desc="Bench", dynamic_ncols=True)
-
         t0 = perf_counter()
-        for request in requests:
-            generated_tokens, prefill_time, decode_time = run_one_request(request)
-            total_prompt_tokens += len(request.prompt_token_ids)
-            total_generated_tokens += generated_tokens
-            total_decode_tokens += max(0, generated_tokens - 1)
-            total_prefill_time += prefill_time
-            total_decode_time += decode_time
+        if args.batch_decode:
+            (
+                total_generated_tokens,
+                total_decode_tokens,
+                total_prefill_time,
+                total_decode_time,
+            ) = run_benchmark(requests)
+            progress.update(len(requests))
             elapsed = perf_counter() - t0
-            progress.update(1)
             progress.set_postfix(
                 {
                     "out_tok/s": f"{safe_div(total_generated_tokens, elapsed):.1f}",
                     "decode_tok/s": f"{safe_div(total_decode_tokens, total_decode_time):.1f}",
                 }
             )
+        else:
+            for request in requests:
+                generated_tokens, prefill_time, decode_time = run_one_request(request)
+                total_generated_tokens += generated_tokens
+                total_decode_tokens += max(0, generated_tokens - 1)
+                total_prefill_time += prefill_time
+                total_decode_time += decode_time
+                elapsed = perf_counter() - t0
+                progress.update(1)
+                progress.set_postfix(
+                    {
+                        "out_tok/s": f"{safe_div(total_generated_tokens, elapsed):.1f}",
+                        "decode_tok/s": f"{safe_div(total_decode_tokens, total_decode_time):.1f}",
+                    }
+                )
         total_time = perf_counter() - t0
         progress.close()
 

--- a/src/extensions_ref/src/quantized_matmul.cpp
+++ b/src/extensions_ref/src/quantized_matmul.cpp
@@ -205,7 +205,20 @@ void QuantizedMatmul::eval_gpu(const std::vector<mx::array> &inputs, std::vector
     compute_encoder.set_bytes(K, 7);
 
     size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
-    const int x_size = 32;
+    // For decode/small-batch matmuls, avoid reserving 32 lanes for M when
+    // only a few rows are active. Keep the original 32-row tile otherwise.
+    int x_size = 32;
+    if (M <= 1) {
+        x_size = 1;
+    } else if (M <= 2) {
+        x_size = 2;
+    } else if (M <= 4) {
+        x_size = 4;
+    } else if (M <= 8) {
+        x_size = 8;
+    } else if (M <= 16) {
+        x_size = 16;
+    }
     const int y_size = tgp_size / x_size;
     if (tgp_size < x_size * y_size) {
         throw std::runtime_error("quantized_matmul: tgp_size must be larger than x*y");


### PR DESCRIPTION
## Summary

This PR optimizes the reference 4-bit quantized matmul Metal launch shape for small-M decode workloads.

The existing kernel always uses a 32-row tile in the M dimension:

```cpp
threads_per_group = (32, maxTotalThreadsPerThreadgroup / 32, 1)
```

During decode, M is often small (`M = 1` for single-request decode, or small batch sizes for continuous batching). In those cases, most M-dimension lanes are idle. This PR keeps the total threadgroup size unchanged, but shifts lanes from the M dimension to the K/output-column dimension when M is small:

```cpp
x_size = 1  if M <= 1
x_size = 2  if M <= 2
x_size = 4  if M <= 4
x_size = 8  if M <= 8
x_size = 16 if M <= 16
x_size = 32 otherwise

y_size = maxTotalThreadsPerThreadgroup / x_size
```

For larger M, this keeps the original 32-row tile.

## Benchmark support

I also added a synthetic-token batch decode benchmark path to `bench.py`:

- `--batch-decode` runs the Week 2 continuous-batching decode path.
- It uses `BatchingKvCache` and batched offsets, matching the Week 2 batching task shape.
- It excludes tokenizer/detokenizer overhead, matching the existing synthetic-token benchmark style.
- It validates `--num-seqs >= --batch-size` so larger batch-size measurements are not accidentally under-filled.

The original non-batch benchmark path remains the default.

## Benchmark setup

Model and command shape:

```bash
PYTHONPATH=src pdm run bench \
  --solution tiny_llm_ref \
  --loader week2 \
  --model qwen3-0.6b \
  --enable-flash-attn \
  --batch-decode \
  --batch-size <B> \
  --num-seqs 32 \
  --min-input-len 32 \
  --max-input-len 64 \
  --min-output-len 16 \
  --max-output-len 32 \
  --prefill-step 128 \
  --warmup 0 \
  --seed 0
```

Fixed workload:

- prompt tokens: 1631
- generated tokens: 783
- local hardware: MacBook Pro, Apple M4 Pro, 12-core CPU, 48GB memory, MLX GPU backend
- Qwen/Qwen3-0.6B-MLX-4bit
- single run with fixed seed

## Results

| batch_size | baseline decode tok/s | this PR decode tok/s | decode change | baseline output tok/s | this PR output tok/s |
|---:|---:|---:|---:|---:|---:|
| 1 | 34.88 | 45.45 | +30.3% | 31.91 | 40.12 |
| 2 | 57.39 | 70.49 | +22.8% | 48.51 | 56.80 |
| 4 | 86.42 | 105.15 | +21.7% | 66.60 | 76.94 |
| 8 | 112.58 | 133.74 | +18.8% | 79.73 | 91.45 |
| 16 | 121.17 | 125.58 | +3.6% | 84.62 | 86.06 |

The improvement is concentrated in small-M decode cases. Local B=16 results were only a small improvement on my machine, while reviewer testing on M5 Pro showed a larger B=16 decode gain, so this PR includes the `M <= 16` tile as well.

## Validation

Correctness tests:

```bash
PYTHONPATH=src pdm run test-refsol --week 2 --day 2 -- -k quantized_matmul -q
PYTHONPATH=src pdm run test-refsol --week 2 --day 4 -- -k flash_attention -q
PYTHONPATH=src pdm run test-refsol --week 2 --day 6 -- -k "batching_kv_cache or qwen3_0_6b" -q
```

Smoke checks:

```bash
# Original non-batch benchmark path
PYTHONPATH=src pdm run bench --solution tiny_llm_ref --loader week2 --model qwen3-0.6b --enable-flash-attn --num-seqs 2 --min-input-len 8 --max-input-len 8 --min-output-len 4 --max-output-len 4 --warmup 0

# New batch-decode benchmark path
PYTHONPATH=src pdm run bench --solution tiny_llm_ref --loader week2 --model qwen3-0.6b --enable-flash-attn --batch-decode --batch-size 2 --num-seqs 2 --min-input-len 8 --max-input-len 8 --min-output-len 4 --max-output-len 4 --prefill-step 8 --warmup 0

# Guard against under-filled batch measurements
PYTHONPATH=src pdm run bench --solution tiny_llm_ref --loader week2 --model qwen3-0.6b --batch-decode --batch-size 16 --num-seqs 8 --min-input-len 8 --max-input-len 8 --min-output-len 4 --max-output-len 4 --warmup 0
```
