### PR TITLE
Keep Week 2 embeddings quantized

### DIFF
--- a/book/src/week2-02-quantized-matmul.md
+++ b/book/src/week2-02-quantized-matmul.md
@@ -218,10 +218,11 @@ For each output element C[i, k]:
   C[i, k] = float16/bfloat16(sum)
 ```
 
-## Task 1: Implement QuantizedWeights
+## Task 1: Implement QuantizedWeights and QuantizedEmbedding
 
 ```
 src/tiny_llm/quantize.py
+src/tiny_llm/embedding.py
 ```
 
 First, familiarize yourself with the `QuantizedWeights` class, which stores quantized weight information:
@@ -237,6 +238,17 @@ First, familiarize yourself with the `QuantizedWeights` class, which stores quan
 The `from_mlx_layer` static method extracts these fields from MLX's quantized linear layers when loading the model.
 
 Next, implement the `quantized_linear` function, which is a wrapper around `quantized_matmul` that mimics the standard `linear` function interface. And we'll implement `quantized_matmul` in the next task.
+
+The token embedding table should also stay quantized in Week 2. Add a
+`QuantizedEmbedding` wrapper with two call patterns:
+
+- `embedding(input_ids)` is a row lookup. Gather the matching packed rows,
+  scales, and biases, then call `mx.dequantize` on only those selected rows.
+- `embedding.as_linear(h)` is the tied output projection. Implement this with
+  `quantized_linear(h, embedding_weight)` so it uses your quantized matmul path
+  instead of materializing the full `vocab_size x hidden_size` table. This path
+  starts working once the quantized matmul kernel is implemented in the next
+  tasks.
 
 ## Task 2: Implement `quantized_matmul` (CPU version)
 
@@ -322,6 +334,12 @@ src/tiny_llm/qwen3_week2.py
 Integrate your quantized matmul into the Week 2 Qwen3 model so that inference runs on quantized weights end-to-end.
 
 Change the weight type from `mx.array` to `QuantizedWeights` for all linear layers in attention (`wq/wk/wv/wo`) and MLP (`w_gate/w_up/w_down`). Replace every `linear(x, w)` call with `quantized_linear(x, w)`. In the model loading code, use `QuantizedWeights.from_mlx_layer(...)` to extract quantized weight information from each MLX linear layer, instead of calling `mx.dequantize` to get a full 16-bit matrix. Make sure the Week 1 loader still dequantizes (since Week 1 layers expect plain `mx.array`), while the Week 2 loader does **not** dequantize.
+
+For embeddings, wire the `QuantizedEmbedding` from Task 1 into the loader:
+load `embed_tokens` with `QuantizedWeights.from_mlx_layer(...)` and pass it to
+`QuantizedEmbedding`. If the model has a separate `lm_head`, keep that head as
+`QuantizedWeights` too and apply it with `quantized_linear`; `lm_head` is a
+projection, not an embedding lookup.
 
 Qwen3 MLX quantized layers may use **float16** or **bfloat16** for the tensors involved in dequantization. Your kernel should accept `scales`, `biases`, and activations in either dtype, require them to match, and return the same dtype. If you see `nan` or garbage output, a dtype mismatch is the most likely cause.
 

--- a/src/tiny_llm/embedding.py
+++ b/src/tiny_llm/embedding.py
@@ -1,8 +1,20 @@
 import mlx.core as mx
+from .quantize import QuantizedWeights
 
 
 class Embedding:
     def __init__(self, vocab_size: int, embedding_dim: int, weight: mx.array):
+        pass
+
+    def __call__(self, x: mx.array) -> mx.array:
+        pass
+
+    def as_linear(self, x: mx.array) -> mx.array:
+        pass
+
+
+class QuantizedEmbedding:
+    def __init__(self, vocab_size: int, embedding_dim: int, weight: QuantizedWeights):
         pass
 
     def __call__(self, x: mx.array) -> mx.array:

--- a/src/tiny_llm_ref/embedding.py
+++ b/src/tiny_llm_ref/embedding.py
@@ -1,5 +1,6 @@
 import mlx.core as mx
 from .basics import linear
+from .quantize import QuantizedWeights, quantized_linear
 
 
 class Embedding:
@@ -13,3 +14,22 @@ class Embedding:
 
     def as_linear(self, x: mx.array) -> mx.array:
         return linear(x, self.weight)
+
+
+class QuantizedEmbedding:
+    def __init__(self, vocab_size: int, embedding_dim: int, weight: QuantizedWeights):
+        self.vocab_size = vocab_size
+        self.embedding_dim = embedding_dim
+        self.weight = weight
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.dequantize(
+            self.weight.weight[x],
+            self.weight.scales[x],
+            self.weight.biases[x],
+            self.weight.group_size,
+            self.weight.bits,
+        )
+
+    def as_linear(self, x: mx.array) -> mx.array:
+        return quantized_linear(x, self.weight)

--- a/src/tiny_llm_ref/qwen3_week2.py
+++ b/src/tiny_llm_ref/qwen3_week2.py
@@ -7,8 +7,8 @@ from .attention import (
 from .layer_norm import RMSNorm
 from .positional_encoding import RoPE
 from typing import Any
-from .embedding import Embedding
-from .quantize import dequantize_linear, QuantizedWeights, quantized_linear
+from .embedding import QuantizedEmbedding
+from .quantize import QuantizedWeights, quantized_linear
 from .kv_cache import TinyKvCache
 
 
@@ -200,10 +200,10 @@ class Qwen3ModelWeek2:
         precision = mx.bfloat16
         self.precision = precision
 
-        self.embedding = Embedding(
+        self.embedding = QuantizedEmbedding(
             vocab_size=self.vocab_size,
             embedding_dim=self.hidden_size,
-            weight=dequantize_linear(mlx_model.model.embed_tokens),
+            weight=QuantizedWeights.from_mlx_layer(mlx_model.model.embed_tokens),
         )
         self.layers_inner = []
 


### PR DESCRIPTION
## Summary

- add a Week 2 `QuantizedEmbedding` path for token embeddings
- keep `embed_tokens` as `QuantizedWeights` in the Week 2 reference loader instead of calling `dequantize_linear`
- dequantize only selected embedding rows for input lookup, and use the teaching `quantized_linear` kernel for tied `embedding.as_linear(...)`
- update the Week 2 quantized matmul lesson text so `QuantizedEmbedding` belongs to Task 1 and loader wiring stays in Task 4

## Performance Notes

Measured on local GPU with `tiny_llm_ref` and the teaching quantized matmul kernel:

- `qwen3-0.6b`: embedding first-use peak dropped from about 599 MiB to 302 MiB; single-request decode throughput improved from 48.5 to 57.0 tok/s; batch decode throughput improved from 106.7 to 115.8 tok/s.
- `qwen3-4b`: embedding/model peak memory dropped by roughly 742 MiB, but the short decode bench changed from 24.4 to 23.7 tok/s, so this is not a universal speed win with the teaching kernel.

The main reason to take this change is to keep Week 2 consistent with the no-full-dequantize path and reduce memory pressure. The small-model decode path also gets faster; larger models mainly benefit from memory.

