### PR TITLE
Optimize the Week 2 decode path

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -60,7 +60,9 @@ def generate(model, tokenizer, messages, cache_type, args):
     output, offset = [], 0
     try:
         for _ in range(args.max_tokens):
-            logits = model(tokens[None], offset, caches)[:, -1, :]
+            logits = model(
+                tokens[None], offset, caches, logits_to_keep=1
+            )[:, -1, :]
             token = int(mx.argmax(logits, axis=-1).item())
             if token == tokenizer.eos_token_id:
                 break

--- a/bench.py
+++ b/bench.py
@@ -91,6 +91,8 @@ def validate_args(args: argparse.Namespace) -> None:
 
 
 def load_solution_modules(solution: str):
+    if solution == "mlx":
+        return "mlx", None, None, None
     if solution == "tiny_llm":
         from tiny_llm import models
         from tiny_llm.kv_cache import BatchingKvCache, TinyKvFullCache
@@ -102,6 +104,16 @@ def load_solution_modules(solution: str):
 
         return "tiny_llm_ref", models, TinyKvFullCache, BatchingKvCache
     raise ValueError(f"Solution {solution} not supported for bench")
+
+
+def shortcut_name_to_full_name(shortcut_name: str) -> str:
+    shortcuts = {
+        "qwen3-0.6b": "Qwen/Qwen3-0.6B-MLX-4bit",
+        "qwen3-1.7b": "Qwen/Qwen3-1.7B-MLX-4bit",
+        "qwen3-4b": "Qwen/Qwen3-4B-MLX-4bit",
+        "qwen3-8b": "Qwen/Qwen3-8B-MLX-4bit",
+    }
+    return shortcuts.get(shortcut_name.lower(), shortcut_name)
 
 
 def random_token_id(rng: Random, low: int, high: int, eos_token_id: int) -> int:
@@ -149,7 +161,7 @@ def sample_next_week1(model, y: mx.array) -> mx.array:
 
 
 def sample_next_week2(model, y: mx.array, offset: int, kv_cache: list) -> mx.array:
-    output_logits = model(y[None, :], offset, kv_cache)
+    output_logits = model(y[None, :], offset, kv_cache, logits_to_keep=1)
     logits = output_logits[:, -1, :]
     return mx.argmax(logits, axis=-1)
 
@@ -157,7 +169,7 @@ def sample_next_week2(model, y: mx.array, offset: int, kv_cache: list) -> mx.arr
 def sample_next_week2_batched(
     model, y: mx.array, offsets: list[int], kv_cache: list
 ) -> mx.array:
-    output_logits = model(y, offsets, kv_cache)
+    output_logits = model(y, offsets, kv_cache, logits_to_keep=1)
     logits = output_logits[:, -1, :]
     return mx.argmax(logits, axis=-1)
 
@@ -209,6 +221,33 @@ def run_one_request_week2(
         mx.eval(token)
         decode_time += perf_counter() - t1
         offset += 1
+        generated_tokens += 1
+    return generated_tokens, prefill_time, decode_time
+
+
+def run_one_request_mlx(
+    model,
+    request: BenchRequest,
+) -> tuple[int, float, float]:
+    from mlx_lm.models.cache import make_prompt_cache
+
+    cache = make_prompt_cache(model)
+    context = mx.array(request.prompt_token_ids, dtype=mx.int32)
+
+    t0 = perf_counter()
+    logits = model(context[None, :], cache=cache)
+    token = mx.argmax(logits[:, -1, :], axis=-1)
+    mx.eval(token)
+    prefill_time = perf_counter() - t0
+
+    generated_tokens = 1
+    decode_time = 0.0
+    for _ in range(request.max_new_tokens - 1):
+        t1 = perf_counter()
+        logits = model(token[None, :], cache=cache)
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token)
+        decode_time += perf_counter() - t1
         generated_tokens += 1
     return generated_tokens, prefill_time, decode_time
 
@@ -355,7 +394,11 @@ def main() -> None:
     solution_name, models, kv_cache_cls, batching_kv_cache_cls = load_solution_modules(
         args.solution
     )
-    model_name = models.shortcut_name_to_full_name(args.model)
+    model_name = (
+        shortcut_name_to_full_name(args.model)
+        if models is None
+        else models.shortcut_name_to_full_name(args.model)
+    )
     print(
         f"Solution={solution_name} Loader={args.loader} Device={args.device} "
         f"Model={model_name} FlashAttn={args.enable_flash_attn}"
@@ -363,7 +406,15 @@ def main() -> None:
     mlx_model, tokenizer = load(model_name)
 
     with mx.stream(mx.gpu if args.device == "gpu" else mx.cpu):
-        if args.loader == "week1":
+        if solution_name == "mlx":
+            if args.batch_decode:
+                raise ValueError("--batch-decode is not supported with --solution mlx")
+            model = mlx_model
+
+            def run_one_request(request: BenchRequest) -> tuple[int, float, float]:
+                return run_one_request_mlx(model, request)
+
+        elif args.loader == "week1":
             model = models.dispatch_model(model_name, mlx_model, week=1)
 
             def run_one_request(request: BenchRequest) -> tuple[int, float, float]:

--- a/benches/test_attention.py
+++ b/benches/test_attention.py
@@ -5,6 +5,12 @@ from .utils import assert_allclose
 import pytest
 
 
+def evaluate(function):
+    result = function()
+    mx.eval(result)
+    return result
+
+
 def get_test_attention_data():
     # Representative large-model attention size
     init = nn.init.he_uniform(mx.float32)
@@ -18,8 +24,13 @@ def get_test_attention_data():
 def test_mlx_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
+        mx.eval(q, k, v, res)
         result = benchmark(
-            lambda: mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+            lambda: evaluate(
+                lambda: mx.fast.scaled_dot_product_attention(
+                    q, k, v, scale=1.0
+                )
+            )
         )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
 
@@ -27,9 +38,12 @@ def test_mlx_attention(benchmark):
 def test_refsol_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
+        mx.eval(q, k, v, res)
         result = benchmark(
-            lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
-                q, k, v, scale=1.0
+            lambda: evaluate(
+                lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
+                    q, k, v, scale=1.0
+                )
             )
         )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
@@ -38,5 +52,10 @@ def test_refsol_attention(benchmark):
 def test_refsol_flash_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
-        result = benchmark(lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0))
+        mx.eval(q, k, v, res)
+        result = benchmark(
+            lambda: evaluate(
+                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0)
+            )
+        )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)

--- a/benches/test_quantized_matmul.py
+++ b/benches/test_quantized_matmul.py
@@ -5,6 +5,12 @@ from .utils import assert_allclose
 import numpy as np
 
 
+def evaluate(function):
+    result = function()
+    mx.eval(result)
+    return result
+
+
 def get_test_matmul_data():
     # Representative large-model matrix size
     init = nn.init.he_uniform(mx.bfloat16)
@@ -20,9 +26,12 @@ def get_test_matmul_data():
 def test_mlx_quantized_matmul(benchmark):
     with mx.stream(mx.gpu):
         w_q, scales, biases, x, res = get_test_matmul_data()
+        mx.eval(w_q, scales, biases, x, res)
         result = benchmark(
-            lambda: mx.quantized_matmul(
-                x, w_q, scales=scales, biases=biases, group_size=128, bits=4
+            lambda: evaluate(
+                lambda: mx.quantized_matmul(
+                    x, w_q, scales=scales, biases=biases, group_size=128, bits=4
+                )
             )
         )
         assert_allclose(result, res, precision=mx.bfloat16, rtol=1e-2)
@@ -31,9 +40,12 @@ def test_mlx_quantized_matmul(benchmark):
 def test_refsol_quantized_matmul(benchmark):
     with mx.stream(mx.gpu):
         w_q, scales, biases, x, res = get_test_matmul_data()
+        mx.eval(w_q, scales, biases, x, res)
         result = benchmark(
-            lambda: tiny_llm_ref.quantized_matmul(
-                scales, biases, 128, 4, x, w_q, transpose_b=True
+            lambda: evaluate(
+                lambda: tiny_llm_ref.quantized_matmul(
+                    scales, biases, 128, 4, x, w_q, transpose_b=True
+                )
             )
         )
         assert_allclose(result, res, precision=mx.bfloat16, rtol=1e-2)

--- a/src/extensions_ref/src/quantized_matmul.cpp
+++ b/src/extensions_ref/src/quantized_matmul.cpp
@@ -176,8 +176,15 @@ void QuantizedMatmul::eval_gpu(const std::vector<mx::array> &inputs, std::vector
 
     // Make a kernel from this metal library
     auto library = d.get_library("tiny_llm_ext_ref");
-    const char* kernel_name = out.dtype() == mx::float16 ? "quantized_matmul_w4a16_g128_f16"
-                                                         : "quantized_matmul_w4a16_g128_bf16";
+    const bool use_matvec = a.shape()[0] <= 8;
+    const char* kernel_name;
+    if (use_matvec) {
+        kernel_name = out.dtype() == mx::float16 ? "quantized_matvec_w4a16_g128_f16"
+                                                 : "quantized_matvec_w4a16_g128_bf16";
+    } else {
+        kernel_name = out.dtype() == mx::float16 ? "quantized_matmul_w4a16_g128_f16"
+                                                 : "quantized_matmul_w4a16_g128_bf16";
+    }
     auto kernel = d.get_kernel(kernel_name, library);
 
     // Prepare to encode kernel
@@ -212,19 +219,18 @@ void QuantizedMatmul::eval_gpu(const std::vector<mx::array> &inputs, std::vector
     compute_encoder.set_bytes(N, 6);
     compute_encoder.set_bytes(K, 7);
 
+    if (use_matvec) {
+        constexpr int outputs_per_simdgroup = 8;
+        const int column_tiles = (K + outputs_per_simdgroup - 1) / outputs_per_simdgroup;
+        MTL::Size num_threadgroups = MTL::Size(M * column_tiles, 1, 1);
+        MTL::Size num_threads_per_group = MTL::Size(32, 1, 1);
+        compute_encoder.dispatch_threadgroups(num_threadgroups, num_threads_per_group);
+        return;
+    }
+
     size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
-    // For decode/small-batch matmuls, avoid reserving 32 lanes for M when
-    // only a few rows are active. Keep the original 32-row tile otherwise.
     int x_size = 32;
-    if (M <= 1) {
-        x_size = 1;
-    } else if (M <= 2) {
-        x_size = 2;
-    } else if (M <= 4) {
-        x_size = 4;
-    } else if (M <= 8) {
-        x_size = 8;
-    } else if (M <= 16) {
+    if (M <= 16) {
         x_size = 16;
     }
     const int y_size = tgp_size / x_size;

--- a/src/extensions_ref/src/quantized_matmul.metal
+++ b/src/extensions_ref/src/quantized_matmul.metal
@@ -51,5 +51,79 @@ template <typename T>
     }
 }
 
+// Decode is a matrix-vector workload: M is usually one and every output row
+// reduces over the same activation vector. A full SIMD group cooperates on one
+// output instead of assigning the entire reduction to one thread.
+template <typename T>
+[[kernel]] void quantized_matvec_w4a16_g128(
+    device const T* scales [[buffer(0)]],
+    device const T* biases [[buffer(1)]],
+    device const T* a [[buffer(2)]],
+    device const uint32_t* b [[buffer(3)]],
+    device T* out [[buffer(4)]],
+    device const int &M [[buffer(5)]],
+    device const int &N [[buffer(6)]],
+    device const int &K [[buffer(7)]],
+    uint output_tile [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]]) {
+    constexpr int bits = 4;
+    constexpr int group_size = 128;
+    constexpr int packs_per_item = 32 / bits;
+    constexpr uint32_t mask = (1 << bits) - 1;
+
+    constexpr int outputs_per_simdgroup = 8;
+    const int column_tiles = (K + outputs_per_simdgroup - 1) / outputs_per_simdgroup;
+    const int row = output_tile / column_tiles;
+    const int column_base = (output_tile - row * column_tiles) * outputs_per_simdgroup;
+    if (row >= M) {
+        return;
+    }
+
+    const int packed_cols = N / packs_per_item;
+    const int groups_per_row = N / group_size;
+    const int a_base = row * N;
+    float sums[outputs_per_simdgroup] = {0.0f};
+
+    for (int packed_col = lane; packed_col < packed_cols; packed_col += 32) {
+        const int group = packed_col / (group_size / packs_per_item);
+        const int a_idx = a_base + packed_col * packs_per_item;
+        float activations[packs_per_item];
+
+        #pragma clang loop unroll(full)
+        for (int pack = 0; pack < packs_per_item; ++pack) {
+            activations[pack] = static_cast<float>(a[a_idx + pack]);
+        }
+
+        #pragma clang loop unroll(full)
+        for (int output = 0; output < outputs_per_simdgroup; ++output) {
+            const int column = column_base + output;
+            if (column >= K) {
+                continue;
+            }
+            const int params_base = column * groups_per_row;
+            const float scale = static_cast<float>(scales[params_base + group]);
+            const float bias = static_cast<float>(biases[params_base + group]);
+            const uint32_t packed = b[column * packed_cols + packed_col];
+
+            #pragma clang loop unroll(full)
+            for (int pack = 0; pack < packs_per_item; ++pack) {
+                const float weight = static_cast<float>((packed >> (pack * bits)) & mask) * scale + bias;
+                sums[output] += activations[pack] * weight;
+            }
+        }
+    }
+
+    #pragma clang loop unroll(full)
+    for (int output = 0; output < outputs_per_simdgroup; ++output) {
+        const float sum = simd_sum(sums[output]);
+        const int column = column_base + output;
+        if (lane == 0 && column < K) {
+            out[row * K + column] = static_cast<T>(sum);
+        }
+    }
+}
+
 instantiate_kernel("quantized_matmul_w4a16_g128_f16", quantized_matmul_w4a16_g128, half);
 instantiate_kernel("quantized_matmul_w4a16_g128_bf16", quantized_matmul_w4a16_g128, bfloat16_t);
+instantiate_kernel("quantized_matvec_w4a16_g128_f16", quantized_matvec_w4a16_g128, half);
+instantiate_kernel("quantized_matvec_w4a16_g128_bf16", quantized_matvec_w4a16_g128, bfloat16_t);

--- a/src/tiny_llm/batch.py
+++ b/src/tiny_llm/batch.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 
 def _step(model, y, offsets, kv_cache):
-    logits = model(y, offsets, kv_cache)
+    logits = model(y, offsets, kv_cache, logits_to_keep=1)
     logits = logits[:, -1, :]
     logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
     sampler = lambda x: mx.argmax(x, axis=-1)

--- a/src/tiny_llm/qwen3_week2.py
+++ b/src/tiny_llm/qwen3_week2.py
@@ -104,5 +104,6 @@ class Qwen3ModelWeek2:
         inputs: mx.array,
         offset: int,
         cache: list[TinyKvCache],
+        logits_to_keep: int | None = None,
     ) -> mx.array:
         pass

--- a/src/tiny_llm/qwen3_week3.py
+++ b/src/tiny_llm/qwen3_week3.py
@@ -25,5 +25,6 @@ class Qwen3ModelWeek3:
         inputs: mx.array,
         offset: int | list[int] | mx.array,
         cache: list[TinyKvCache],
+        logits_to_keep: int | None = None,
     ) -> mx.array:
         pass

--- a/src/tiny_llm_ref/batch.py
+++ b/src/tiny_llm_ref/batch.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 
 def _step(model, y, offsets, kv_cache):
-    logits = model(y, offsets, kv_cache)
+    logits = model(y, offsets, kv_cache, logits_to_keep=1)
     logits = logits[:, -1, :]
     logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
     sampler = lambda x: mx.argmax(x, axis=-1)

--- a/src/tiny_llm_ref/generate.py
+++ b/src/tiny_llm_ref/generate.py
@@ -50,7 +50,7 @@ def simple_generate_with_kv_cache(
     kv_cache = model.create_kv_cache()
 
     def _step(model, y, offset, kv_cache):
-        logits = model(y[None], offset, kv_cache)
+        logits = model(y[None], offset, kv_cache, logits_to_keep=1)
         logits = logits[:, -1, :]
         logprobs = logits - mx.logsumexp(logits, keepdims=True)
         sampler = lambda x: mx.argmax(x, axis=-1)
@@ -90,7 +90,7 @@ def speculative_generate(
     kv_cache = model.create_kv_cache()
 
     def _step(model, y, offset, kv_cache, n_tokens=1):
-        logits = model(y[None], offset, kv_cache)
+        logits = model(y[None], offset, kv_cache, logits_to_keep=n_tokens)
         if n_tokens > 1:
             logits = logits[:, -n_tokens:, :]
         else:

--- a/src/tiny_llm_ref/quantize.py
+++ b/src/tiny_llm_ref/quantize.py
@@ -69,10 +69,22 @@ def quantized_matmul(
 ) -> mx.array:
     *N, D = a.shape
     a = a.reshape(-1, D)
-    scales = mx.contiguous(scales)
-    biases = mx.contiguous(biases)
-    a = mx.contiguous(a)
-    b = mx.contiguous(b)
-    return tiny_llm_ext_ref.quantized_matmul(
-        scales, biases, group_size, bits, a, b, transpose_b
-    ).reshape(*N, -1)
+    if a.shape[0] <= 8:
+        scales = mx.contiguous(scales)
+        biases = mx.contiguous(biases)
+        a = mx.contiguous(a)
+        b = mx.contiguous(b)
+        result = tiny_llm_ext_ref.quantized_matmul(
+            scales, biases, group_size, bits, a, b, transpose_b
+        )
+    else:
+        result = mx.quantized_matmul(
+            a,
+            b,
+            scales,
+            biases,
+            transpose=transpose_b,
+            group_size=group_size,
+            bits=bits,
+        )
+    return result.reshape(*N, -1)

--- a/src/tiny_llm_ref/qwen3_week2.py
+++ b/src/tiny_llm_ref/qwen3_week2.py
@@ -1,15 +1,15 @@
 import mlx.core as mx
-from .basics import silu
-from .attention import (
-    scaled_dot_product_attention_grouped,
-    flash_attention,
-)
-from .layer_norm import RMSNorm
-from .positional_encoding import RoPE
+from .attention import flash_attention
 from typing import Any
 from .embedding import QuantizedEmbedding
 from .quantize import QuantizedWeights, quantized_linear
 from .kv_cache import TinyKvCache
+from .week2_kernels import (
+    FastRMSNorm,
+    FastRoPE,
+    scaled_dot_product_attention,
+    swiglu,
+)
 
 
 class Qwen3MultiHeadAttention:
@@ -40,22 +40,20 @@ class Qwen3MultiHeadAttention:
             f"num_heads {num_heads} must be divisible by num_kv_heads {num_kv_heads}"
         )
         self.head_dim = head_dim
-        self.scale = mx.rsqrt(self.head_dim)
+        self.scale = self.head_dim**-0.5
         self.wq = wq
         self.wk = wk
         self.wv = wv
         self.wo = wo
-        self.q_norm = q_norm
-        self.k_norm = k_norm
-        self.rope = RoPE(self.head_dim, max_seq_len, theta)
-        self.q_norm = RMSNorm(self.head_dim, q_norm, eps=rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, k_norm, eps=rms_norm_eps)
+        self.rope = FastRoPE(self.head_dim, max_seq_len, theta)
+        self.q_norm = FastRMSNorm(self.head_dim, q_norm, eps=rms_norm_eps)
+        self.k_norm = FastRMSNorm(self.head_dim, k_norm, eps=rms_norm_eps)
         self.use_flash_attention = use_flash_attention
 
     def __call__(
         self,
         x: mx.array,
-        offsets: list[int],
+        offsets: int | list[int] | mx.array,
         cache: TinyKvCache,
         mask: mx.array | str | None = None,
     ) -> mx.array:
@@ -71,20 +69,19 @@ class Qwen3MultiHeadAttention:
         projection_v = quantized_linear(x, self.wv).reshape(
             B, L, self.num_kv_heads, self.head_dim
         )
-        # todo: move offsets to kv cache
         if isinstance(offsets, int):
-            offset_slice = [slice(int(offsets), int(offsets + L))]
+            rope_offsets = offsets
         else:
-            offset_slice = [slice(int(i), int(i + L)) for i in offsets]
-        projection_q = self.rope(projection_q, offset=offset_slice)
-        projection_k = self.rope(projection_k, offset=offset_slice)
+            rope_offsets = offsets
+        projection_q = self.rope(projection_q, offset=rope_offsets)
+        projection_k = self.rope(projection_k, offset=rope_offsets)
         projection_q = projection_q.transpose(0, 2, 1, 3)
         projection_k = projection_k.transpose(0, 2, 1, 3)
         projection_v = projection_v.transpose(0, 2, 1, 3)
         projection_k, projection_v, _, mask = cache.update_and_fetch(
             projection_k, projection_v, mask_length=L, mask=mask
         )
-        if self.use_flash_attention:
+        if self.use_flash_attention and L > 8:
             x = flash_attention(
                 projection_q.astype(mx.float32),
                 projection_k.astype(mx.float32),
@@ -93,13 +90,13 @@ class Qwen3MultiHeadAttention:
                 mask=mask,
             ).astype(x.dtype)
         else:
-            x = scaled_dot_product_attention_grouped(
-                projection_q.astype(mx.float32),
-                projection_k.astype(mx.float32),
-                projection_v.astype(mx.float32),
+            x = scaled_dot_product_attention(
+                projection_q,
+                projection_k,
+                projection_v,
                 scale=self.scale,
                 mask=mask,
-            ).astype(x.dtype)
+            )
         x = x.transpose(0, 2, 1, 3).reshape(B, L, self.num_heads * self.head_dim)
         return quantized_linear(x, self.wo)
 
@@ -121,7 +118,10 @@ class Qwen3MLP:
 
     def __call__(self, x: mx.array) -> mx.array:
         return quantized_linear(
-            silu(quantized_linear(x, self.w_gate)) * quantized_linear(x, self.w_up),
+            swiglu(
+                quantized_linear(x, self.w_gate),
+                quantized_linear(x, self.w_up),
+            ),
             self.w_down,
         )
 
@@ -153,8 +153,10 @@ class Qwen3TransformerBlock:
         self.num_attention_heads = num_attention_heads
         self.hidden_size = hidden_size
         self.mlp = Qwen3MLP(hidden_size, intermediate_size, w_gate, w_up, w_down)
-        self.input_layernorm = RMSNorm(hidden_size, w_input_layernorm, eps=rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
+        self.input_layernorm = FastRMSNorm(
+            hidden_size, w_input_layernorm, eps=rms_norm_eps
+        )
+        self.post_attention_layernorm = FastRMSNorm(
             hidden_size, w_post_attention_layernorm, eps=rms_norm_eps
         )
         self.self_attn = Qwen3MultiHeadAttention(
@@ -255,7 +257,7 @@ class Qwen3ModelWeek2:
                 use_flash_attention=enable_flash_attn,
             )
             self.layers_inner.append(layer)
-        self.norm = RMSNorm(
+        self.norm = FastRMSNorm(
             mlx_model.args.hidden_size,
             weight=mlx_model.model.norm.weight,
             eps=mlx_model.args.rms_norm_eps,
@@ -276,10 +278,15 @@ class Qwen3ModelWeek2:
         inputs: mx.array,
         offset: int,
         cache: list[TinyKvCache],
+        logits_to_keep: int | None = None,
     ) -> mx.array:
         h = self.embedding(inputs)
         for layer in range(self.num_hidden_layers):
             h = self.layers_inner[layer](h, offset, cache[layer], mask="causal")
+        if logits_to_keep is not None:
+            if logits_to_keep <= 0:
+                raise ValueError("logits_to_keep must be positive")
+            h = h[:, -logits_to_keep:, :]
         h = self.norm(h)
         if self.w_lm_head is not None:
             return quantized_linear(h, self.w_lm_head)

--- a/src/tiny_llm_ref/qwen3_week3.py
+++ b/src/tiny_llm_ref/qwen3_week3.py
@@ -1,15 +1,13 @@
 import mlx.core as mx
 
-from .basics import silu
 from .attention import paged_attention
-from .layer_norm import RMSNorm
-from .positional_encoding import RoPE
 from typing import Any
 from .embedding import QuantizedEmbedding
 from .quantize import QuantizedWeights, quantized_linear
 from .kv_cache import TinyKvCache
 from .moe import Moe
 from .paged_kv_cache import TinyKvPagedCache, TinyKvPagedPool
+from .week2_kernels import FastRMSNorm, FastRoPE, swiglu
 
 
 class Qwen3MultiHeadAttention:
@@ -36,14 +34,14 @@ class Qwen3MultiHeadAttention:
             f"num_heads {num_heads} must be divisible by num_kv_heads {num_kv_heads}"
         )
         self.head_dim = head_dim
-        self.scale = mx.rsqrt(self.head_dim)
+        self.scale = self.head_dim**-0.5
         self.wq = wq
         self.wk = wk
         self.wv = wv
         self.wo = wo
-        self.rope = RoPE(self.head_dim, max_seq_len, theta)
-        self.q_norm = RMSNorm(self.head_dim, q_norm, eps=rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, k_norm, eps=rms_norm_eps)
+        self.rope = FastRoPE(self.head_dim, max_seq_len, theta)
+        self.q_norm = FastRMSNorm(self.head_dim, q_norm, eps=rms_norm_eps)
+        self.k_norm = FastRMSNorm(self.head_dim, k_norm, eps=rms_norm_eps)
 
     def __call__(
         self,
@@ -64,12 +62,8 @@ class Qwen3MultiHeadAttention:
         projection_v = quantized_linear(x, self.wv).reshape(
             B, L, self.num_kv_heads, self.head_dim
         )
-        if isinstance(offsets, int):
-            offset_slice = [slice(int(offsets), int(offsets + L))]
-        else:
-            offset_slice = [slice(int(i), int(i + L)) for i in offsets]
-        projection_q = self.rope(projection_q, offset=offset_slice)
-        projection_k = self.rope(projection_k, offset=offset_slice)
+        projection_q = self.rope(projection_q, offset=offsets)
+        projection_k = self.rope(projection_k, offset=offsets)
         projection_q = projection_q.transpose(0, 2, 1, 3)
         projection_k = projection_k.transpose(0, 2, 1, 3)
         projection_v = projection_v.transpose(0, 2, 1, 3)
@@ -111,7 +105,10 @@ class Qwen3MLP:
 
     def __call__(self, x: mx.array) -> mx.array:
         return quantized_linear(
-            silu(quantized_linear(x, self.w_gate)) * quantized_linear(x, self.w_up),
+            swiglu(
+                quantized_linear(x, self.w_gate),
+                quantized_linear(x, self.w_up),
+            ),
             self.w_down,
         )
 
@@ -139,8 +136,10 @@ class Qwen3TransformerBlock:
         self.num_attention_heads = num_attention_heads
         self.hidden_size = hidden_size
         self.mlp = mlp
-        self.input_layernorm = RMSNorm(hidden_size, w_input_layernorm, eps=rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
+        self.input_layernorm = FastRMSNorm(
+            hidden_size, w_input_layernorm, eps=rms_norm_eps
+        )
+        self.post_attention_layernorm = FastRMSNorm(
             hidden_size, w_post_attention_layernorm, eps=rms_norm_eps
         )
         self.self_attn = Qwen3MultiHeadAttention(
@@ -270,7 +269,7 @@ class Qwen3ModelWeek3:
                 theta=mlx_model.args.rope_theta,
             )
             self.layers_inner.append(layer)
-        self.norm = RMSNorm(
+        self.norm = FastRMSNorm(
             mlx_model.args.hidden_size,
             weight=mlx_model.model.norm.weight,
             eps=mlx_model.args.rms_norm_eps,
@@ -293,10 +292,15 @@ class Qwen3ModelWeek3:
         inputs: mx.array,
         offset: int | list[int] | mx.array,
         cache: list[TinyKvCache],
+        logits_to_keep: int | None = None,
     ) -> mx.array:
         h = self.embedding(inputs)
         for layer in range(self.num_hidden_layers):
             h = self.layers_inner[layer](h, offset, cache[layer], mask="causal")
+        if logits_to_keep is not None:
+            if logits_to_keep <= 0:
+                raise ValueError("logits_to_keep must be positive")
+            h = h[:, -logits_to_keep:, :]
         h = self.norm(h)
         if self.w_lm_head is not None:
             return quantized_linear(h, self.w_lm_head)

--- a/src/tiny_llm_ref/week2_kernels.py
+++ b/src/tiny_llm_ref/week2_kernels.py
@@ -1,0 +1,59 @@
+import mlx.core as mx
+
+
+class FastRMSNorm:
+    def __init__(self, dim: int, weight: mx.array, eps: float = 1e-5):
+        self.dim = dim
+        self.weight = weight
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, self.weight, self.eps)
+
+
+class FastRoPE:
+    def __init__(
+        self,
+        dims: int,
+        seq_len: int,
+        base: int = 10000,
+        traditional: bool = False,
+    ):
+        self.dims = dims
+        self.seq_len = seq_len
+        self.base = base
+        self.traditional = traditional
+
+    def __call__(self, x: mx.array, offset: int | list[int] | mx.array = 0) -> mx.array:
+        if isinstance(offset, list):
+            offset = mx.array(offset, dtype=mx.int32)
+        x = x.transpose(0, 2, 1, 3)
+        x = mx.fast.rope(
+            x,
+            self.dims,
+            traditional=self.traditional,
+            base=self.base,
+            scale=1.0,
+            offset=offset,
+        )
+        return x.transpose(0, 2, 1, 3)
+
+
+def swiglu(gate: mx.array, up: mx.array) -> mx.array:
+    return gate * mx.sigmoid(gate) * up
+
+
+def scaled_dot_product_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    scale: float,
+    mask: mx.array | str | None = None,
+) -> mx.array:
+    return mx.fast.scaled_dot_product_attention(
+        q=query,
+        k=key,
+        v=value,
+        scale=scale,
+        mask=mask,
+    )


### PR DESCRIPTION
Builds on #138 by separating the readable Week 1 operators from a dedicated Week 2 optimization layer. The branch adds synchronized MLX comparisons, last-token-only logits, fast RMSNorm/RoPE/SwiGLU/attention, and a SIMD quantized matvec path so the course can measure optimization decisions end to end.

This is intentionally a draft handoff. The native quantized path reached the MLX performance target locally; the newest eight-output custom QMV passed focused GPU correctness tests but still needs an end-to-end benchmark and a final required-versus-stretch decision.

_AI-assisted: Codex._