### PR TITLE
Implement standalone Metal SIMD-matrix attention

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -30,8 +30,12 @@
         "dequantization",
         "dequantizes",
         "dtype",
+        "exponentials",
         "threadgroups",
         "threadgroup",
+        "autotune",
+        "autotuning",
+        "retuned",
     ],
     "ignoreRegExpList": [
         "`[^`]*`",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,11 @@ pdm run build-ext
 - Use `--` before pytest args (`-k`, `-q`, `--collect-only`, etc.).
 - `pdm run test --week X --day Y` auto-copies `tests_refsol/test_week_X_day_Y.py` into `tests/`.
 - Model-dependent tests (0.5B/1.5B/7B) skip when models are not downloaded locally.
+
+## GitHub CLI
+
+- The `gh` CLI is installed, authenticated, and expected to work in this
+  repository.
+- If a `gh` command fails because of sandbox or network restrictions, retry it
+  with the required authorization. Do not infer that GitHub or `gh` is
+  unavailable from a sandboxed failure.

--- a/benches/test_attention.py
+++ b/benches/test_attention.py
@@ -17,12 +17,12 @@ def get_test_attention_data():
     return q, k, v, res
 
 
-def get_prefill_attention_data(sequence_length):
-    # A single Qwen2 7B request with grouped-query attention.
-    init = nn.init.he_uniform(mx.float32)
-    q = init(mx.zeros((1, 28, sequence_length, 128)))
-    k = init(mx.zeros((1, 4, sequence_length, 128)))
-    v = init(mx.zeros((1, 4, sequence_length, 128)))
+def get_qwen3_4b_prefill_data(sequence_length):
+    # Qwen3-4B: 32 query heads, 8 KV heads, and head_dim=128.
+    init = nn.init.he_uniform(mx.bfloat16)
+    q = init(mx.zeros((1, 32, sequence_length, 128)))
+    k = init(mx.zeros((1, 8, sequence_length, 128)))
+    v = init(mx.zeros((1, 8, sequence_length, 128)))
     mx.eval(q, k, v)
     mx.synchronize()
     return q, k, v
@@ -70,52 +70,19 @@ def test_refsol_flash_attention(benchmark):
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
 
 
-def test_refsol_flash_attention_causal(benchmark):
+@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048, 4096])
+@pytest.mark.parametrize("implementation", ["mlx", "explicit", "simdgroup_matrix"])
+def test_qwen3_4b_causal_prefill(benchmark, sequence_length, implementation):
     with mx.stream(mx.gpu):
-        q, k, v, _ = get_test_attention_data()
-        res = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0, mask="causal")
-        mx.eval(res)
-        mx.synchronize()
-        result = benchmark(
-            lambda: evaluate_attention(
-                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0, mask="causal")
+        q, k, v = get_qwen3_4b_prefill_data(sequence_length)
+        if implementation == "mlx":
+            fn = lambda: mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=1.0, mask="causal"
             )
-        )
-        assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
-
-
-@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
-def test_mlx_attention_causal_prefill(benchmark, sequence_length):
-    with mx.stream(mx.gpu):
-        q, k, v = get_prefill_attention_data(sequence_length)
-        benchmark(
-            lambda: evaluate_attention(
-                lambda: mx.fast.scaled_dot_product_attention(
-                    q, k, v, scale=1.0, mask="causal"
-                )
+        elif implementation == "explicit":
+            fn = lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
+                q, k, v, scale=1.0, mask="causal"
             )
-        )
-
-
-@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
-def test_refsol_attention_causal_prefill(benchmark, sequence_length):
-    with mx.stream(mx.gpu):
-        q, k, v = get_prefill_attention_data(sequence_length)
-        benchmark(
-            lambda: evaluate_attention(
-                lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
-                    q, k, v, scale=1.0, mask="causal"
-                )
-            )
-        )
-
-
-@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
-def test_refsol_flash_attention_causal_prefill(benchmark, sequence_length):
-    with mx.stream(mx.gpu):
-        q, k, v = get_prefill_attention_data(sequence_length)
-        benchmark(
-            lambda: evaluate_attention(
-                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0, mask="causal")
-            )
-        )
+        else:
+            fn = lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0, mask="causal")
+        benchmark(lambda: evaluate_attention(fn))

--- a/benches/test_attention.py
+++ b/benches/test_attention.py
@@ -12,14 +12,25 @@ def get_test_attention_data():
     k = init(mx.zeros((10, 4, 1024, 128)))
     v = init(mx.zeros((10, 4, 1024, 128)))
     res = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+    mx.eval(q, k, v, res)
+    mx.synchronize()
     return q, k, v, res
+
+
+def evaluate_attention(fn):
+    result = fn()
+    mx.eval(result)
+    mx.synchronize()
+    return result
 
 
 def test_mlx_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
         result = benchmark(
-            lambda: mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+            lambda: evaluate_attention(
+                lambda: mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+            )
         )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
 
@@ -28,8 +39,10 @@ def test_refsol_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
         result = benchmark(
-            lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
-                q, k, v, scale=1.0
+            lambda: evaluate_attention(
+                lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
+                    q, k, v, scale=1.0
+                )
             )
         )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
@@ -38,5 +51,25 @@ def test_refsol_attention(benchmark):
 def test_refsol_flash_attention(benchmark):
     with mx.stream(mx.gpu):
         q, k, v, res = get_test_attention_data()
-        result = benchmark(lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0))
+        result = benchmark(
+            lambda: evaluate_attention(
+                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0)
+            )
+        )
+        assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
+
+
+def test_refsol_flash_attention_causal(benchmark):
+    with mx.stream(mx.gpu):
+        q, k, v, _ = get_test_attention_data()
+        res = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0, mask="causal")
+        mx.eval(res)
+        mx.synchronize()
+        result = benchmark(
+            lambda: evaluate_attention(
+                lambda: tiny_llm_ref.flash_attention(
+                    q, k, v, scale=1.0, mask="causal"
+                )
+            )
+        )
         assert_allclose(result, res, precision=mx.float32, rtol=1e-2)

--- a/benches/test_attention.py
+++ b/benches/test_attention.py
@@ -17,6 +17,17 @@ def get_test_attention_data():
     return q, k, v, res
 
 
+def get_prefill_attention_data(sequence_length):
+    # A single Qwen2 7B request with grouped-query attention.
+    init = nn.init.he_uniform(mx.float32)
+    q = init(mx.zeros((1, 28, sequence_length, 128)))
+    k = init(mx.zeros((1, 4, sequence_length, 128)))
+    v = init(mx.zeros((1, 4, sequence_length, 128)))
+    mx.eval(q, k, v)
+    mx.synchronize()
+    return q, k, v
+
+
 def evaluate_attention(fn):
     result = fn()
     mx.eval(result)
@@ -67,9 +78,44 @@ def test_refsol_flash_attention_causal(benchmark):
         mx.synchronize()
         result = benchmark(
             lambda: evaluate_attention(
-                lambda: tiny_llm_ref.flash_attention(
+                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0, mask="causal")
+            )
+        )
+        assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
+
+
+@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
+def test_mlx_attention_causal_prefill(benchmark, sequence_length):
+    with mx.stream(mx.gpu):
+        q, k, v = get_prefill_attention_data(sequence_length)
+        benchmark(
+            lambda: evaluate_attention(
+                lambda: mx.fast.scaled_dot_product_attention(
                     q, k, v, scale=1.0, mask="causal"
                 )
             )
         )
-        assert_allclose(result, res, precision=mx.float32, rtol=1e-2)
+
+
+@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
+def test_refsol_attention_causal_prefill(benchmark, sequence_length):
+    with mx.stream(mx.gpu):
+        q, k, v = get_prefill_attention_data(sequence_length)
+        benchmark(
+            lambda: evaluate_attention(
+                lambda: tiny_llm_ref.scaled_dot_product_attention_grouped(
+                    q, k, v, scale=1.0, mask="causal"
+                )
+            )
+        )
+
+
+@pytest.mark.parametrize("sequence_length", [128, 512, 1024, 2048])
+def test_refsol_flash_attention_causal_prefill(benchmark, sequence_length):
+    with mx.stream(mx.gpu):
+        q, k, v = get_prefill_attention_data(sequence_length)
+        benchmark(
+            lambda: evaluate_attention(
+                lambda: tiny_llm_ref.flash_attention(q, k, v, scale=1.0, mask="causal")
+            )
+        )

--- a/book/src/week2-04-flash-attention.md
+++ b/book/src/week2-04-flash-attention.md
@@ -312,6 +312,200 @@ implementation remains about 3.4× faster at 2048 tokens because it adds deeper
 specialization and scheduling work beyond merely using matrix instructions.
 Do not report memory efficiency as a latency speedup.
 
+### Why MLX Steel Is Much Faster
+
+The MLX 0.29.1 result in the table uses its classic Steel attention kernel. It
+uses the same public 8×8 `simdgroup_matrix` operation available to this course,
+so the difference is not a different attention algorithm or a larger matrix
+instruction. It is the accumulation of many smaller implementation choices.
+
+For D=128, MLX 0.29.1 dispatches a compile-time `BQ=32`, `BK=16`, `BD=128`
+specialization with four SIMD groups, or 128 threads. Compare its hot path with
+the course kernel:
+
+| Detail | Course kernel | MLX 0.29.1 Steel |
+| --- | --- | --- |
+| Q/K/V storage | BF16 | BF16 |
+| Matrix fragments | BF16 operands, FP32 result | BF16 loads converted to FP32 fragments |
+| Probability for PV | converted back to BF16 | remains in FP32 fragments |
+| Prefill tile | `64 × 32`, 256 threads | `32 × 16`, 128 threads |
+| Scale and exponent | scale every score tile, `fast::exp` | pre-scale Q once, `fast::exp2` |
+| Mask selection | runtime `mask_mode` branches | Metal function constants |
+| Aligned loads | bounds logic remains in the kernel | unrolled unchecked interior path |
+| Loop structure | compiler sees constant bounds | explicit compile-time unrolling |
+| V scheduling | load V after softmax | issue the V load before softmax, consume it after |
+
+#### Specialize Away Work That Is Not Needed
+
+Steel uses function constants for aligned Q, aligned K, mask presence, causal
+mode, and attention sinks. Metal compiles and caches a different pipeline for
+each relevant combination. A causal, aligned, no-additive-mask launch therefore
+does not execute runtime branches for the unused modes.
+
+It also distinguishes an aligned interior tile from a partial tail. Interior
+tiles use unchecked loads and stores; only the final tile pays bounds checks.
+The course kernel checks key and query validity inside every score fragment.
+
+#### Keep the Hot Fragments in FP32
+
+Steel stores BF16 Q/K/V in device and threadgroup memory, but converts values to
+FP32 when loading matrix fragments. Scores, probabilities, V fragments, and
+output accumulators then stay FP32 through both matrix multiplications.
+
+The course kernel converts FP32 probabilities back to BF16 fragments before
+PV. That saves registers, but adds conversions and loses precision. The Steel
+choice uses more registers, so it must be paired with its smaller tile and
+128-thread threadgroup to preserve occupancy.
+
+#### Move Repeated Arithmetic Out of the K/V Loop
+
+Softmax can be evaluated in base 2:
+
+```plain
+exp(x) = exp2(x × log2(e))
+```
+
+Steel multiplies Q by `scale × log2(e)` once when loading the Q tile. Every QK
+result is already in the units required by `fast::exp2`. The course kernel
+multiplies every score in every K/V tile by `scale`, then uses `fast::exp`.
+
+Pre-scaling Q is particularly valuable because Q remains resident while many
+K/V tiles stream past it.
+
+#### Use Compile-Time Cooperative Loaders
+
+Steel assigns each thread a compile-time rectangular slice and fully unrolls
+the aligned load loops. K is transposed cooperatively while entering threadgroup
+memory. Its Q, K, and V loaders advance their source pointers rather than
+recomputing full indices in the hot loop. Only the tail path executes validity
+checks and zero filling.
+
+Padding is chosen together with the vector width and fragment access pattern.
+A padding value is not independently “correct”; it must be evaluated with the
+loader, element type, bank mapping, and tile shape.
+
+#### Schedule Loads Around Independent Math
+
+In the Steel loop, the V load is issued after QK but before the softmax
+reductions and exponentials. V is not consumed until PV, so the GPU and compiler
+have independent work that can overlap the memory operation. The course kernel
+finishes softmax before beginning its V load.
+
+Steel also uses SIMD-group barriers where only one SIMD group needs ordering,
+and threadgroup barriers only when shared K/V storage is being reused. Barrier
+scope and placement matter as much as the raw barrier count.
+
+#### Production Dispatch Uses More Than One Kernel
+
+MLX 0.29.1 selects full tiled attention only when the query length is greater
+than eight. Short-query decode uses a separate vector kernel, with a two-pass
+variant for long K/V sequences. One prefill tile cannot also be the best decode
+mapping.
+
+Later MLX revisions add an optional NAX path using 16×16 cooperative tensors
+from MetalPerformancePrimitives. That is not the path measured in this chapter,
+and it is outside the course rule that only public `simdgroup_matrix` may be
+used for this optimization.
+
+The relevant MLX 0.29.1 sources are useful for comparison after implementing
+the exercise independently:
+
+- [host dispatch and tile selection](https://github.com/ml-explore/mlx/blob/v0.29.1/mlx/backend/metal/scaled_dot_product_attention.cpp)
+- [Steel attention loop](https://github.com/ml-explore/mlx/blob/v0.29.1/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h)
+- [cooperative block loaders](https://github.com/ml-explore/mlx/blob/v0.29.1/mlx/backend/metal/kernels/steel/attn/loader.h)
+- [8×8 fragment and MMA helpers](https://github.com/ml-explore/mlx/blob/v0.29.1/mlx/backend/metal/kernels/steel/attn/mma.h)
+
+### Follow-Up Performance Exercises
+
+Treat each item as an experiment: change one mechanism, rerun correctness on
+partial tiles and masks, and record the synchronized Qwen3-4B benchmark. Do not
+copy or include the Steel headers.
+
+#### 1. Compile-Time Mask Variants
+
+Create separate no-mask, causal, and additive-mask pipelines, either as kernel
+entry points or Metal function-constant specializations. For causal mode,
+compute the first tile that intersects the diagonal and apply element-level
+masking only from that tile onward. Earlier tiles are entirely valid.
+
+This is the smallest follow-up because it changes control flow without changing
+the fragment layout.
+
+#### 2. Pre-Scale Q and Use Base-2 Exponentials
+
+Multiply Q by `scale × log2(e)` during the one-time Q load and replace the
+online-softmax exponentials with `fast::exp2`. Verify both ordinary and cached
+causal attention, because additive masks must be converted to the same base-2
+units.
+
+Measure this separately from mask specialization so its effect is visible.
+
+#### 3. Keep Probabilities and V Fragments in FP32
+
+Keep BF16 in device/threadgroup memory, but load Q, K, and V into FP32 matrix
+fragments. Feed the FP32 score fragments directly into PV instead of converting
+probabilities back to BF16.
+
+Then retune BQ/BK: the additional registers may make a smaller threadgroup
+faster. Record numerical error as well as latency.
+
+#### 4. Add Aligned Vector Loaders
+
+Split cooperative loading into:
+
+- an aligned interior path using packed, unchecked reads; and
+- a safe tail path that zero-fills out-of-range elements.
+
+Precompute per-thread source and destination offsets and increment pointers
+between K/V tiles. Start with fully unrolled scalar loads, then test aligned
+packed reads where the source and destination layout permits them. Check
+generated memory transactions or Metal GPU counters; source-level vector syntax
+alone does not guarantee coalesced loads.
+
+#### 5. Pipeline V Loading with Softmax
+
+Issue the V load before row reductions and exponentials, then place the barrier
+immediately before PV consumes V. As a harder variant, double-buffer K/V tiles
+so tile `j+1` can be loaded while tile `j` is computed.
+
+Double buffering increases threadgroup memory and can lower occupancy, so it is
+an optimization only if the measured overlap exceeds that cost.
+
+#### 6. Autotune Tile and Threadgroup Shapes
+
+Benchmark at least these compile-time variants:
+
+```plain
+(BQ, BK, SIMD groups) =
+    (32, 16, 4)
+    (32, 32, 4)
+    (64, 16, 8)
+    (64, 32, 8)
+```
+
+Run every shape at 128, 512, 1024, 2048, and 4096 tokens. Track threadgroup
+memory and estimated register pressure alongside time. A tile may win at long
+prefill and regress badly at 128 tokens, so dispatching by sequence length can
+be better than choosing one global winner.
+
+#### 7. Reuse K/V Across GQA Query Heads
+
+Qwen3-4B has four query heads per KV head. Explore assigning multiple related
+query heads to one threadgroup so a staged K/V tile serves more than one Q head.
+This reduces K/V traffic but increases Q storage, output registers, and
+threadgroup size. It is a difficult exercise because those resource costs can
+erase the reuse benefit.
+
+#### 8. Add a Separate Decode Kernel
+
+Dispatch `L <= 8` to a vector-oriented kernel and consider a two-pass reduction
+for very long K/V caches. Do not judge a prefill kernel by one-token decode, or
+inflate the prefill kernel with decode-specific branches.
+
+The first four exercises stay close to the current code and are the best next
+steps for narrowing the Steel gap. Exercises 5–8 introduce scheduling or
+dispatch complexity closer to a production implementation.
+
 ### Does FlashAttention Make Sense on Metal?
 
 Yes for memory-bounded prefill, but not for exactly the same reasons or with

--- a/book/src/week2-04-flash-attention.md
+++ b/book/src/week2-04-flash-attention.md
@@ -83,6 +83,30 @@ including Qwen3-4B. Do not derive this value as `hidden_size / num_heads`:
 Qwen3 stores `head_dim` explicitly and its attention projection width can
 differ from `hidden_size`.
 
+### Week 2 Dtype Contract
+
+Yes: Week 2 uses BF16 by default. `Qwen3ModelWeek2` sets its model precision to
+`mx.bfloat16`, and the quantized projections produce BF16 Q, K, and V. The
+FlashAttention path must not upcast those complete tensors to FP32.
+
+Use mixed precision at these boundaries:
+
+| Value | Dtype | Reason |
+| --- | --- | --- |
+| Q, K, V in device memory | BF16 | matches the Week 2 model and halves traffic versus FP32 |
+| Q/K/V threadgroup tiles | BF16 | preserves the bandwidth and capacity benefit |
+| attention scale | FP32 | avoids rounding the scalar before repeated use |
+| score and output accumulators | FP32 | protects dot products and online softmax |
+| running max and sum | FP32 | numerical stability |
+| additive mask inside the extension | FP32 | preserves `-inf` and additive bias behavior |
+| final attention output | BF16 | feeds the next Week 2 layer without a full-tensor cast |
+
+“Use BF16” therefore does not mean performing the softmax recurrence in BF16.
+It means keeping model-sized tensors BF16 and promoting only register-resident
+arithmetic that benefits from FP32. A caller may supply a BF16 additive mask;
+the wrapper converts its contiguous broadcasted representation to FP32 at the
+extension boundary.
+
 ## Task 1: Implement the Python Wrapper
 
 ```plain
@@ -100,7 +124,8 @@ out:   B..., H_q, L, E
 ```
 
 Flatten batch and head dimensions before calling C++, then restore the original
-layout. Make Q, K, and V contiguous, but preserve their BF16 dtype.
+layout. Make Q, K, and V contiguous, but preserve their BF16 dtype. Keep the
+scalar `factor` in FP32 rather than casting it to the query dtype.
 
 Pass a small integer mask mode to the extension:
 
@@ -124,7 +149,8 @@ src/extensions/CMakeLists.txt
 
 Add the MLX primitive, binding, and CPU evaluator. The readable CPU path uses
 FP32 and tiled online softmax with `Br = 32` and `Bc = 32`. It is a correctness
-reference, not the performance path.
+reference, not the Week 2 model path. The intentional CPU exception keeps the
+algorithm easy to inspect; the required model-facing GPU path is BF16.
 
 Map grouped-query heads with:
 
@@ -171,14 +197,14 @@ cannot compensate for slow scalar arithmetic.
 
 ### Keep a General Fallback
 
-Use a small scalar kernel for FP32 head dimensions below 128. A useful mapping
-is a `16 × 32` query/key tile with 512 threads: one SIMD group owns one query
-row, and one lane owns one key. This path keeps the implementation general and
-testable.
+Use a small scalar kernel for FP32 correctness tests and head dimensions below
+128. A useful mapping is a `16 × 32` query/key tile with 512 threads: one SIMD
+group owns one query row, and one lane owns one key. This path keeps the
+implementation general and testable, but Qwen3 does not use it.
 
-The performance path is a separate BF16, `E = 128` specialization. Specialize
-the common model shape instead of adding branches and dynamic loops to its hot
-path.
+The required Week 2 GPU path is a separate BF16, `E = 128` specialization that
+returns BF16. Specialize the common model shape instead of adding branches and
+dynamic loops to its hot path.
 
 ### BF16 SIMD-Matrix Tile
 
@@ -270,10 +296,13 @@ softmax recurrence, storage layout, and synchronization directly.
 Test more than aligned self-attention:
 
 - no mask, additive mask, and causal mask;
-- BF16 D=128 and the FP32 fallback;
+- BF16 D=128 as the default GPU path and the FP32 fallback separately;
 - partial query and key tiles, such as `L=35, S=47`;
 - grouped-query attention;
 - `L != S` causal offsets.
+
+Assert that the BF16 GPU result is still BF16. A numerically close FP32 result
+would hide a model-sized upcast and fail the Week 2 dtype contract.
 
 Evaluate the lazy result before comparing it. A kernel can compile and appear
 to run while a lane-coordinate or partial-tile error remains hidden.
@@ -534,7 +563,9 @@ src/tiny_llm/qwen3_week2.py
 Connect the kernel to `Qwen3MultiHeadAttention` and propagate
 `enable_flash_attn` through the model. Preserve Q, K, V, and the result as BF16;
 do not cast the full tensors to FP32. Pass causal mode directly so the wrapper
-does not allocate an `L × S` mask.
+does not allocate an `L × S` mask. FP32 is limited to the scalar scale,
+additive-mask values, matrix accumulators, and online-softmax state inside the
+fused operation.
 
 Run generation with FlashAttention enabled:
 

--- a/book/src/week2-04-flash-attention.md
+++ b/book/src/week2-04-flash-attention.md
@@ -1,9 +1,10 @@
 # Week 2 Days 4-5: FlashAttention-2
 
-In this chapter, we will implement FlashAttention-2 for the Week 2 Qwen3
-serving pipeline. Its tiled algorithm avoids materializing the complete
-attention matrix, reducing memory traffic and improving throughput for long
-contexts.
+In this chapter, we will implement a small FlashAttention-style Metal kernel
+for the Week 2 Qwen3 serving pipeline. The goal is to learn the tiled,
+IO-aware algorithm and map both matrix multiplications to Metal's public
+`simdgroup_matrix` API. We will not reuse an MLX attention-kernel
+implementation.
 
 **📚 Readings**
 
@@ -11,52 +12,36 @@ contexts.
 - [FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness](https://arxiv.org/abs/2205.14135)
 - [FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning](https://arxiv.org/abs/2307.08691)
 - [MLX Extension Development Guide](https://ml-explore.github.io/mlx/build/html/dev/extensions.html)
-- [MLX steel attention kernel (reference)](https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h)
+- [Metal Shading Language Specification](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)
+- [Metal Feature Set Tables](https://developer.apple.com/metal/feature-sets/)
 
 ## Why FlashAttention?
 
-The central observation behind FlashAttention is that attention is often
-**IO-bound**, not compute-bound.
-
-In the standard implementation, we compute:
+Standard attention computes:
 
 1. `S = QK^T`
 2. `P = softmax(S + mask)`
 3. `O = PV`
 
-This path materializes large `L x S` score and probability tensors in device
-memory. At long context lengths, writing and reading these intermediates can
-dominate runtime.
+This path materializes an `L x S` score tensor, and sometimes a separate
+probability tensor, in device memory. FlashAttention instead streams K/V tiles
+through on-chip memory and combines them with online softmax. Its auxiliary
+memory is linear rather than quadratic in sequence length.
 
-For example, if `L = S = 4096`:
+For Qwen3-4B, one BF16 score tensor at `L = S = 4096` occupies:
 
 ```plain
-One L x S matrix: 4096 x 4096 = 16,777,216 elements
-float32 storage: ~64 MB per matrix per head
-Scores + probabilities: ~128 MB temporary memory per head
+1 batch × 32 query heads × 4096 × 4096 × 2 bytes = 1 GiB
 ```
 
-This is about 128 MB of temporary storage per head before accounting for Q, K,
-V, or the output.
-
-### IO-Aware Exact Attention
-
-FlashAttention processes Q, K, and V in tiles and combines them with **online
-softmax** updates. Instead of storing the complete attention matrix in device
-memory, it keeps per-row running statistics (`m` and `l`) and a partial output
-(`o`) in faster on-chip storage.
-
-This gives three practical benefits:
-
-- **Exactness**: It computes standard softmax attention rather than an
-  approximation.
-- **Lower memory**: activation memory scales linearly with sequence length instead of quadratically.
-- **Higher throughput**: fewer device-memory accesses, which are often the real
-  bottleneck.
+Avoiding that allocation is useful on unified-memory Apple silicon too.
+However, lower memory use does not automatically mean lower latency. Two
+optimized matrix multiplications can beat a fused kernel whose inner matrix
+multiplications are poorly mapped to the GPU.
 
 ## Online Softmax Recap
 
-For one query row, split keys/values into tiles `j = 1..T`:
+For one query row, split keys and values into tiles `j = 1..T`:
 
 $$
 m^{(j)} = \max\left(m^{(j-1)}, \max(s^{(j)})\right)
@@ -76,314 +61,298 @@ $$
 o = \frac{o^{(T)}}{l^{(T)}}
 $$
 
-Both kernels in this chapter use this recurrence. The remaining work maps it to
-CPU loops and Metal threadgroups.
+The running maximum prevents overflow. The correction factor
+`exp(old_max - new_max)` rescales both the previous denominator and the
+previous output when a later tile contains a larger score.
 
-## Task 1: Implement `flash_attention` Wrapper
+## The Qwen3 Target
 
+The optimized course path is deliberately specialized instead of pretending
+one kernel is ideal for every model:
+
+```plain
+Qwen3-4B attention
+query heads: 32
+KV heads:     8
+head_dim:     128
+dtype:        bfloat16
 ```
+
+The supported dense Qwen3 models used by this course have `head_dim = 128`,
+including Qwen3-4B. Do not derive this value as `hidden_size / num_heads`:
+Qwen3 stores `head_dim` explicitly and its attention projection width can
+differ from `hidden_size`.
+
+## Task 1: Implement the Python Wrapper
+
+```plain
 src/tiny_llm/attention.py
 ```
 
-Implement `flash_attention(query, key, value, scale=None, mask=None)` as the
-Python wrapper for the `tiny_llm_ext` extension API.
-
-Follow the same shape convention as Week 1 and Week 2 attention:
+Implement `flash_attention(query, key, value, scale=None, mask=None)` using the
+same model-facing layout as the earlier attention chapter:
 
 ```plain
 query: B..., H_q, L, E
 key:   B..., H,   S, E
 value: B..., H,   S, E
-mask:  B..., H_q, L, S
 out:   B..., H_q, L, E
 ```
 
-When `scale` is `None`, compute `factor` with `mx.rsqrt`. Flatten the batch and
-head dimensions before calling C++, then restore the original layout on return.
-Make `query`, `key`, and `value` contiguous before passing them to the
-extension. Broadcast the mask to `B..., H_q, L, S`, reshape it to `(N, L, S)`,
-and cast it to `float32` so both kernels receive the same representation. Use an
-all-zero mask when no mask is requested.
+Flatten batch and head dimensions before calling C++, then restore the original
+layout. Make Q, K, and V contiguous, but preserve their BF16 dtype.
 
-## Task 2: Implement `flash_attention` (CPU version)
+Pass a small integer mask mode to the extension:
 
-```
+| Mode | Meaning | Mask buffer |
+| ---: | --- | --- |
+| 0 | no mask | one-element placeholder |
+| 1 | causal | one-element placeholder |
+| 2 | additive mask | contiguous broadcasted `(N, L, S)` FP32 array |
+
+Do not construct a dense all-zero or causal mask. Doing so reintroduces the
+quadratic allocation that the fused kernel is intended to avoid.
+
+## Task 2: Implement the CPU Reference
+
+```plain
 src/extensions/src/tiny_llm_ext.h
 src/extensions/bindings.cpp
 src/extensions/src/flash_attention.cpp
 src/extensions/CMakeLists.txt
 ```
 
-Add the MLX primitive and its CPU implementation. As in the quantized-matmul
-chapter, declare the primitive in `tiny_llm_ext.h`, expose it in `bindings.cpp`,
-and register `flash_attention.cpp` in `CMakeLists.txt`.
+Add the MLX primitive, binding, and CPU evaluator. The readable CPU path uses
+FP32 and tiled online softmax with `Br = 32` and `Bc = 32`. It is a correctness
+reference, not the performance path.
 
-Before creating the lazy output array, validate all shape and dtype constraints
-in C++. The inputs must be 3D `float32` tensors, `num_heads` must be divisible
-by `num_kv_heads`, and the flattened batch dimensions for Q and KV must agree.
+Map grouped-query heads with:
 
-Implement `FlashAttention::eval_cpu(...)` with tiled online softmax. Use
-`Br = 32` and `Bc = 32`; the GPU section explains these tile sizes. Iterate
-over `(n, i, j)` tiles, map query heads to KV heads with
-`q_kv_heads_ratio = num_heads / num_kv_heads`, and accumulate in `float32`.
-Apply the mask to each score tile before updating `m_i` and `l_i`.
-
-Use causal mode for a block-level optimization. Skip a tile if every position in
-it is masked; if every position is valid, avoid reading and adding the mask.
-Causal attention may have `L != S`, so include the `S - L` offset when deciding
-whether a tile is valid.
-
-You can test your implementation by running:
-
-```bash
-pdm run build-ext
-pdm run test --week 2 --day 4 -- -k task_2
+```plain
+q_kv_ratio = num_heads / num_kv_heads
+kv_head = query_head / q_kv_ratio
 ```
 
-## Task 3: Implement `flash_attention` (GPU version)
+For causal attention, a key is visible when:
 
+```plain
+key_index <= query_index + (S - L)
 ```
+
+The `S - L` offset is required when Q contains only the new tokens but K/V also
+contain cached tokens. Skip a K/V tile entirely when all of its keys are in the
+future.
+
+## Task 3: Implement the Metal Kernels
+
+```plain
 src/extensions/src/flash_attention.metal
 src/extensions/src/flash_attention.cpp
 src/extensions/CMakeLists.txt
 ```
 
-Now implement the GPU path for the same algorithm.
+### Why the First Scalar Mapping Is Slow
 
-### GPU Parallelization Strategy
+A kernel can implement the FlashAttention recurrence correctly and still be
+slower than ordinary attention. The original mapping had four main problems:
 
-The key to an efficient GPU implementation is understanding how to map the tiled algorithm to Metal's execution model.
+- It launched `32 × 32 = 1024` threads per threadgroup. A hardware maximum is
+  a budget, not an occupancy target.
+- Each score used a serial 128-element dot product instead of a matrix
+  instruction.
+- `P @ V` looped over 128 output columns and performed a SIMD reduction for
+  every column.
+- Q/K/V were converted to FP32 and dense no-mask/causal arrays were created,
+  even though Week 2 Qwen activations are BF16.
 
-#### Why Br = 32 and Bc = 32?
+The ordinary implementation writes a quadratic score tensor, but its QK and
+PV operations are highly optimized matrix kernels. Eliminating the tensor
+cannot compensate for slow scalar arithmetic.
 
-The tile sizes follow the execution model used by this kernel:
+### Keep a General Fallback
 
-| Constraint | Source | Value |
-|------------|--------|-------|
-| SIMD width | Apple GPU fixed | 32 |
-| Max threads per threadgroup | Hardware limit | 1024 |
-| Bc | = SIMD width (for efficient `simd_sum`/`simd_max`) | 32 |
-| Br | = 1024 / 32 | 32 |
-| Threadgroup memory | 32 KB budget | Fits `q_local[32][128]` + `o_i[32][128]` |
+Use a small scalar kernel for FP32 head dimensions below 128. A useful mapping
+is a `16 × 32` query/key tile with 512 threads: one SIMD group owns one query
+row, and one lane owns one key. This path keeps the implementation general and
+testable.
 
-With `Br = 32` and `Bc = 32`, each threadgroup contains `32 x 32 = 1024`
-threads.
+The performance path is a separate BF16, `E = 128` specialization. Specialize
+the common model shape instead of adding branches and dynamic loops to its hot
+path.
 
-#### Grid and Threadgroup Layout
+### BF16 SIMD-Matrix Tile
 
-```plain
-Grid (num_threadgroups):
-┌───────────────────────┬───────────────────────┬───────────────────────┐
-│ TG(0, 0)              │ TG(1, 0)              │ TG(2, 0)              │
-│ head=0, qtile=0       │ head=1, qtile=0       │ head=2, qtile=0       │
-├───────────────────────┼───────────────────────┼───────────────────────┤
-│ TG(0, 1)              │ TG(1, 1)              │ TG(2, 1)              │
-│ head=0, qtile=1       │ head=1, qtile=1       │ head=2, qtile=1       │
-├───────────────────────┼───────────────────────┼───────────────────────┤
-│ ...                   │ ...                   │ ...                   │
-└───────────────────────┴───────────────────────┴───────────────────────┘
-     X: N (heads)         Y: Tr (query blocks)
-```
-
-Each threadgroup computes one `(head, Q-tile)` output block.
-
-#### Thread Mapping Within a Threadgroup
-
-Each threadgroup handles one `Br x E` Q block for one head:
+Use this tile on the optimized path:
 
 ```plain
-Threadgroup = 32 SIMD groups × 32 threads/group = 1024 threads
-
-┌────────────────────────────────────────────────┐
-│ SIMD group 0  → Q[0, :]  (handles row 0)       │ ← 32 threads
-│ SIMD group 1  → Q[1, :]  (handles row 1)       │ ← 32 threads
-│ SIMD group 2  → Q[2, :]  (handles row 2)       │ ← 32 threads
-│ ...                                             │
-│ SIMD group 31 → Q[31, :] (handles row 31)      │ ← 32 threads
-└────────────────────────────────────────────────┘
+BQ = 64 query rows
+BK = 32 key/value rows
+D  = 128
+8 SIMD groups × 32 lanes = 256 threads
 ```
 
-Inside that single threadgroup, the kernel runs a **serial** loop over all K/V tiles `j = 0..Tc-1`.
-
-#### Computing S = Q @ K^T
-
-Each thread computes one element of the 32×32 score matrix. Here's how the matrix multiplication maps to threads:
+Each SIMD group owns eight query rows. Metal's public
+`simdgroup_matrix<T, 8, 8>` distributes one 8×8 fragment across its 32 lanes,
+with two fragment elements per lane.
 
 ```plain
-Q block [Br=32, E=128]              K^T [E=128, Bc=32]
-┌───────────────────────┐           ┌───┬───┬───┬─...─┬───┐
-│ Q[0,:]  (128 elements)│           │   │   │   │     │   │
-├───────────────────────┤           │ K │ K │ K │     │ K │
-│ Q[1,:]                │           │[0]│[1]│[2]│ ... │[31]│
-├───────────────────────┤     @     │ T │ T │ T │     │ T │
-│ Q[2,:]                │           │   │   │   │     │   │
-├───────────────────────┤           │128│128│128│     │128│
-│ ...                   │           │   │   │   │     │   │
-├───────────────────────┤           │   │   │   │     │   │
-│ Q[31,:]               │           │   │   │   │     │   │
-└───────────────────────┘           └───┴───┴───┴─...─┴───┘
-        ↑                                 ↑
-   simd_gid = a                      simd_lid = b
-   (which row)                       (which column)
+one SIMD group
+
+Q fragment [8, 8] × Kᵀ fragment [8, 8] -> score fragment [8, 8]
+
+D=128: 16 multiply-accumulate steps
+BK=32: 4 score fragments
+
+P fragment [8, 8] × V fragment [8, 8] -> output fragment [8, 8]
+
+BK=32: 4 multiply-accumulate steps
+D=128: 16 output fragments
 ```
 
-The result is a `Br x Bc` score block with one element per thread:
+Use native `bfloat` matrix operands and FP32 accumulator fragments. Keep the
+row maxima, row sums, and online-softmax output accumulators in FP32, then
+convert only the final output to BF16. This matches the Week 2 model without
+whole-tensor dtype conversions.
+
+### Threadgroup Memory and Registers
+
+Stage Q once and stream K/V through a reused allocation:
 
 ```plain
-                    simd_lid (b)
-              0     1     2    ...   31
-            ┌─────┬─────┬─────┬─...─┬─────┐
-          0 │S0,0 │S0,1 │S0,2 │     │S0,31│  ← SIMD group 0 (32 threads)
-            ├─────┼─────┼─────┼─...─┼─────┤
-simd_gid  1 │S1,0 │S1,1 │S1,2 │     │S1,31│  ← SIMD group 1
-  (a)       ├─────┼─────┼─────┼─...─┼─────┤
-          2 │S2,0 │S2,1 │S2,2 │     │S2,31│  ← SIMD group 2
-            ├─────┼─────┼─────┼─...─┼─────┤
-        ... │ ... │ ... │ ... │     │ ... │
-            ├─────┼─────┼─────┼─...─┼─────┤
-         31 │S31,0│S31,1│S31,2│     │S31,31│ ← SIMD group 31
-            └─────┴─────┴─────┴─...─┴─────┘
-
-Thread (a=2, b=5) computes:
-  S[2,5] = Q[2,0]*K[5,0] + Q[2,1]*K[5,1] + ... + Q[2,127]*K[5,127]
-         = dot product of Q row 2 with K row 5 (128 multiply-adds)
+threadgroup BF16 Q tile:  64 × 130
+threadgroup BF16 K/V:    128 × 34
+total:                   about 25 KiB
 ```
 
-After computing `S[a,b]`, each thread holds one attention score. All 32 threads
-in a SIMD group cooperate on the row-wise reductions:
+K is transposed while loading so QK can consume ordinary row-major 8×8
+fragments. After QK and softmax, reuse the same allocation for row-major V.
+The output's 16 matrix fragments and online-softmax statistics remain in
+registers.
 
-```plain
-SIMD group 2 (threads with simd_gid=2):
-  Thread b=0 has S[2,0]
-  Thread b=1 has S[2,1]
-  ...
-  Thread b=31 has S[2,31]
+The two-element padding makes each BF16 row stride odd when measured in
+32-bit threadgroup-memory banks. Padding should be chosen from the element
+width and bank mapping; copying a padding value from an FP32 or CUDA kernel is
+not generally correct.
 
-  simd_max(s_a_b) → all 32 threads get max(S[2,0], S[2,1], ..., S[2,31])
-  simd_sum(p_a_b) → all 32 threads get sum(P[2,0], P[2,1], ..., P[2,31])
-```
+### Per-Tile Sequence
+
+For every K/V tile:
+
+1. Cooperatively load and transpose K into threadgroup memory.
+2. Compute four 8×8 score fragments with
+   `simdgroup_multiply_accumulate` over the 16 D fragments.
+3. Apply scale and mask, then reduce each eight-row fragment's maximum.
+4. Update online-softmax maxima and sums in FP32.
+5. Convert the probabilities to BF16 matrix fragments.
+6. Reuse the K allocation for V and compute all 16 output fragments.
+7. Rescale the previous output whenever the running maximum changes.
+
+For causal prefill, stop the K/V loop at the last tile that can contain a
+visible key. This avoids approximately half the matrix work when `L = S`.
+
+### Do Not Import an MLX Kernel
+
+The extension necessarily uses MLX's public C++ extension and command-encoder
+interfaces, but the Metal shader should include only public Metal headers:
 
 ```metal
-float rowmax = simd_max(s_a_b);  // max across 32 threads in same SIMD group
-float rowsum = simd_sum(p_a_b);  // sum across 32 threads in same SIMD group
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+#include <metal_stdlib>
 ```
 
-#### Computing O = P @ V inside a SIMD group
+Do not include MLX Steel headers or instantiate an MLX attention template. The
+point of this task is to implement and understand the fragment mapping,
+softmax recurrence, storage layout, and synchronization directly.
 
-After softmax, the kernel must accumulate the output tile. It cannot assign one
-thread to each output element as it did for `S = Q @ K^T`, because the output
-dimensions differ:
+### Correctness Cases
 
-```plain
-Q @ K^T:                         P @ V:
-┌─────────┐   ┌─────────┐       ┌─────────┐   ┌─────────────────┐
-│ Q       │   │ K^T     │       │ P       │   │ V               │
-│[Br, E]  │ @ │[E, Bc]  │       │[Br, Bc] │ @ │[Bc, E]          │
-│[32,128] │   │[128,32] │       │[32, 32] │   │[32, 128]        │
-└─────────┘   └─────────┘       └─────────┘   └─────────────────┘
-         ↓                               ↓
-   S [Br, Bc]                      O [Br, E]
-   [32, 32]                        [32, 128]
-   = 1024 elements                 = 4096 elements
-        ↓                               ↓
-   1024 threads ✓                  1024 threads ✗
-   (one per element)               (not enough!)
+Test more than aligned self-attention:
+
+- no mask, additive mask, and causal mask;
+- BF16 D=128 and the FP32 fallback;
+- partial query and key tiles, such as `L=35, S=47`;
+- grouped-query attention;
+- `L != S` causal offsets.
+
+Evaluate the lazy result before comparing it. A kernel can compile and appear
+to run while a lane-coordinate or partial-tile error remains hidden.
+
+### Benchmark the GPU Work, Not Graph Construction
+
+MLX evaluates lazily. Initialize Q/K/V before timing and force every iteration
+to complete:
+
+```python
+def evaluate_attention(fn):
+    result = fn()
+    mx.eval(result)
+    mx.synchronize()
+    return result
 ```
 
-`S = Q @ K^T` has 1,024 output elements and 1,024 threads. By contrast,
-`O = P @ V` has 4,096 output elements because **E = 128**, while **Bc = 32**.
+On an Apple M4 Pro with MLX 0.29.1, single-request Qwen3-4B causal prefill
+(`Hq=32`, `Hkv=8`, `D=128`, BF16) measured approximately:
 
-Instead, loop over the 128 output columns and use a SIMD reduction for each one:
+| Tokens | Explicit attention | MLX fused | Course SIMD-matrix kernel |
+| ---: | ---: | ---: | ---: |
+| 128 | 0.293 ms | 0.205 ms | 0.538 ms |
+| 512 | 1.272 ms | 0.569 ms | 1.899 ms |
+| 1024 | 4.755 ms | 1.635 ms | 5.418 ms |
+| 2048 | 17.084 ms | 5.584 ms | 19.015 ms |
+| 4096 | 66.724 ms | 21.181 ms | 72.717 ms |
 
-```plain
-For each output element O[a, c]:
-  
-  O[a, c] = sum over b: P[a, b] * V[b, c]
-            └───────────────────────────┘
-                   32 terms (Bc = 32)
-                         ↓
-            simd_sum can handle this!
+The standalone educational kernel does not beat the explicit implementation
+on this GPU. At 4096 tokens it is about 9% slower, but it avoids the explicit
+path's roughly 1 GiB score tensor. That is still a meaningful implementation:
+it demonstrates the correct IO-aware algorithm and has bounded scratch memory.
 
-  Thread assignment:
-    - simd_gid = a (which output row)
-    - simd_lid = b (which term in the sum)
-    
-  Code:
-    for c in 0..E-1:                      // loop 128 times
-        val = P[a, b] * V[b, c]           // each lane computes one term
-        result = simd_sum(val)            // reduce 32 terms → 1 result
-        if simd_lid == 0:
-            o_i[a, c] += result           // only lane 0 writes
-```
+It also shows why production FlashAttention kernels are complex. MLX's fused
+implementation remains about 3.4× faster at 2048 tokens because it adds deeper
+specialization and scheduling work beyond merely using matrix instructions.
+Do not report memory efficiency as a latency speedup.
 
-Although this mapping does not parallelize the `E` dimension, it does
-parallelize the 32-term reduction over `Bc`, which exactly matches the SIMD
-width.
+### Does FlashAttention Make Sense on Metal?
 
-#### Memory Hierarchy
+Yes for memory-bounded prefill, but not for exactly the same reasons or with
+the same implementation as an NVIDIA kernel.
 
-```plain
-┌─────────────────────────────────────────────────────────┐
-│ Device Memory                                           │
-│ Q[N, L, E], K[N_kv, S, E], V[N_kv, S, E]               │
-└─────────────────────────────────────────────────────────┘
-                    ↓ load once per Q block
-┌─────────────────────────────────────────────────────────┐
-│ Threadgroup Memory (SRAM, 32KB)                         │
-│ q_local[Br][E]  ← Q block, reused for all Tc iterations │
-│ o_i[Br][E]      ← accumulated output                    │
-└─────────────────────────────────────────────────────────┘
-                    ↓
-┌─────────────────────────────────────────────────────────┐
-│ Registers (per thread)                                  │
-│ m_i, l_i, s_a_b, p_a_b                                  │
-└─────────────────────────────────────────────────────────┘
-```
+Apple GPUs have unified memory, SIMD width 32, Metal threadgroup memory, and a
+public 8×8 SIMD-group matrix API. They do not expose the same warp-level tensor
+core and asynchronous-copy model as H100/H200. Tile size, bank padding,
+occupancy, and synchronization must therefore be retuned for Metal.
 
-K and V blocks are streamed from global memory in the inner loop over Tc. The Q block is loaded once into threadgroup memory and reused across all K/V tiles.
+Apple's feature tables list SIMD-scoped matrix multiply beginning with Apple
+GPU family 7, which includes M1-series GPUs. Check the runtime GPU family if the
+course is extended beyond Apple silicon rather than assuming this path exists
+on every Metal device.
 
-### Implementation
-
-In `flash_attention.metal`, implement `flash_attention_f32_e128` with one
-threadgroup per `(n, i)` tile, where `n` is the flattened batch-and-head index
-and `i` is the query-tile index. Store local Q and partial O in threadgroup
-memory, and use `simd_max` and `simd_sum` for row-wise reductions.
-
-In `eval_gpu(...)`, load the kernel, bind the inputs, output, and scalar
-constants (`N`, `L`, `S`, `E`, head counts, `scale`, and tile sizes), then
-dispatch over `(N, Tr, 1)`. Keep the same contiguity checks as the CPU path. Add
-`src/flash_attention.metal` to `mlx_build_metallib(...)` in `CMakeLists.txt`.
-
-You can test your implementation by running:
-
-```bash
-pdm run build-ext
-pdm run test --week 2 --day 4 -- -k task_3
-```
+FlashAttention is less compelling for one-token decode. Decode has almost no
+query-tile reuse and is closer to a matrix-vector problem; use a dedicated
+decode or paged-attention kernel for that phase.
 
 ## Task 4: Model Integration
 
-```
+```plain
 src/tiny_llm/qwen3_week2.py
 ```
 
-Finally, connect the kernel to the model. Keep grouped attention as the fallback,
-add `use_flash_attention` to `Qwen3MultiHeadAttention`, and propagate
-`enable_flash_attn` from the model constructor into each block. After updating
-the KV cache, construct the `L x S` causal mask, run attention in `float32`, and
-cast the result back to the activation dtype.
+Connect the kernel to `Qwen3MultiHeadAttention` and propagate
+`enable_flash_attn` through the model. Preserve Q, K, V, and the result as BF16;
+do not cast the full tensors to FP32. Pass causal mode directly so the wrapper
+does not allocate an `L × S` mask.
 
-You can run generation with FlashAttention enabled:
+Run generation with FlashAttention enabled:
 
 ```bash
-pdm run main --solution tiny_llm --loader week2 --model qwen3-0.6b --enable-flash-attn
+pdm run main --solution tiny_llm --loader week2 --model qwen3-4b --enable-flash-attn
 ```
 
-You can also benchmark throughput with and without FlashAttention:
+Benchmark both paths:
 
 ```bash
-pdm run bench --solution tiny_llm --loader week2 --model qwen3-0.6b
-pdm run bench --solution tiny_llm --loader week2 --model qwen3-0.6b --enable-flash-attn
+pdm run bench --solution tiny_llm --loader week2 --model qwen3-4b
+pdm run bench --solution tiny_llm --loader week2 --model qwen3-4b --enable-flash-attn
 ```
 
 {{#include copyright.md}}

--- a/book/src/week2-04-flash-attention.md
+++ b/book/src/week2-04-flash-attention.md
@@ -276,6 +276,55 @@ For every K/V tile:
 For causal prefill, stop the K/V loop at the last tile that can contain a
 visible key. This avoids approximately half the matrix work when `L = S`.
 
+### Implemented Optimization Inventory
+
+The following table is the complete inventory of performance choices in the
+course implementation. These are present in the Python wrapper, C++ dispatch,
+or Metal shader; they are not suggestions borrowed from the later Steel
+comparison.
+
+| Layer | Implemented optimization | What it saves or improves |
+| --- | --- | --- |
+| Python | Preserve BF16 Q/K/V and make only contiguous views | avoids three full-tensor FP32 conversions and keeps device traffic at two bytes per element |
+| Python | Represent no-mask and causal mode with an integer plus a one-element placeholder | avoids allocating and reading an `N × L × S` mask; only a real additive mask is broadcast and materialized |
+| C++ | Dispatch BF16 `D=128` directly to a dedicated kernel | removes dynamic head-dimension loops and dtype branches from the Qwen3 hot path |
+| C++ | Use a three-dimensional grid over query block, query head, and batch | gives each threadgroup one independent output tile without flattening/division work in the tile loop |
+| C++/Metal | Map a query head to its KV head with integer GQA indexing | reads the original eight Qwen3-4B KV heads instead of physically repeating K/V for all 32 query heads |
+| Metal | Use a `64 × 32` compile-time tile with 256 threads | replaces the original 1024-thread launch and gives each of eight SIMD groups ownership of eight query rows |
+| Metal | Use 8×8 `simdgroup_matrix` operations for both QKᵀ and PV | replaces serial dot products and per-output-column SIMD reductions with the GPU's matrix path |
+| Metal | Cooperatively stage Q once per query tile | reuses each Q element across every streamed K/V tile instead of rereading Q from device memory |
+| Metal | Transpose K while cooperatively loading it | produces the row-major `[D, BK]` layout required by QKᵀ without a separate transpose kernel or buffer |
+| Metal | Stream K and V through one padded threadgroup allocation | keeps total threadgroup storage near 25 KiB and avoids simultaneously reserving separate K and V tiles |
+| Metal | Pad BF16 threadgroup rows by two elements | changes the 32-bit bank stride from an even pattern and reduces systematic bank conflicts for fragment loads |
+| Metal | Keep score fragments, output fragments, and online-softmax state in registers | avoids round trips through threadgroup or device memory between QKᵀ, softmax, and PV |
+| Metal | Reduce each fragment row with two lane shuffles | uses the known 8×8 fragment lane mapping instead of a threadgroup reduction and synchronization |
+| Metal | Use online softmax and rescale the accumulated output when the running maximum changes | fuses exact softmax with PV and never materializes the quadratic score or probability tensor |
+| Metal | Convert only the four probability fragments per tile back to BF16 | enables BF16 PV matrix instructions while retaining FP32 scores, softmax state, and output accumulation |
+| Metal | Bound the causal K/V tile loop before entering it | skips every tile wholly to the right of the causal frontier; the current kernel still evaluates its runtime element-level causal condition in every processed tile |
+| Metal | Use `fast::exp` for register-resident softmax exponentials | selects Metal's lower-latency approximate exponential while the stable max subtraction controls the input range |
+| Metal | Zero-fill partial Q/K/V tiles during cooperative loads | lets one kernel handle arbitrary sequence tails without a second launch or out-of-bounds reads |
+| Metal | Synchronize only at shared-tile ownership transitions | barriers protect Q/K readiness, K-to-V reuse, V readiness, and V-to-next-K reuse; matrix and softmax register work needs no threadgroup barrier |
+| Metal | Divide by the online denominator only at the final BF16 store | avoids normalizing and rewriting the output after every K/V tile |
+| Dispatch | Keep the variable-`D` FP32 scalar kernel separate | preserves a readable correctness fallback without adding generality or extra branches to the Qwen3 specialization |
+
+Two details are easy to miss when reading the shader. First, the manual
+`matrix_coord` mapping gives every lane exactly two elements of each 8×8
+fragment. `row_max` and `row_sum` therefore need only the `xor(1)` and
+`xor(8)` exchanges that connect the lanes holding the same row; a reduction
+over all 32 lanes would mix different rows. Second, the final barrier in the
+K/V loop is required even though PV writes only registers: it prevents an
+early SIMD group from overwriting the shared V tile with the next K tile while
+another SIMD group is still reading V.
+
+The current implementation deliberately does **not** include function-constant
+mask variants, unchecked aligned interior loaders, Q pre-scaling with
+`fast::exp2`, FP32 probability/V fragments, overlapped or double-buffered V
+loads, GQA sharing within a threadgroup, tile autotuning, or a decode-specific
+kernel. Those are the follow-up exercises below. Keeping this boundary explicit
+is important: `simdgroup_matrix` alone delivers the largest structural fix,
+while these unimplemented scheduling and specialization techniques explain
+most of the remaining gap to MLX Steel.
+
 ### Do Not Import an MLX Kernel
 
 The extension necessarily uses MLX's public C++ extension and command-encoder

--- a/book/src/week2-04-flash-attention.md
+++ b/book/src/week2-04-flash-attention.md
@@ -1,5 +1,7 @@
 # Week 2 Days 4-5: FlashAttention-2
 
+> **Status:** Under review (WIP).
+
 In this chapter, we will implement a small FlashAttention-style Metal kernel
 for the Week 2 Qwen3 serving pipeline. The goal is to learn the tiled,
 IO-aware algorithm and map both matrix multiplications to Metal's public

--- a/src/extensions_ref/bindings.cpp
+++ b/src/extensions_ref/bindings.cpp
@@ -31,8 +31,8 @@ NB_MODULE(_ext, m) {
             array: ``a * b``
       )");
 
-    m.def("flash_attention", &tiny_llm_ext_ref::flash_attention, "query"_a, "key"_a, "value"_a, "mask"_a, "scale"_a = 1.0,
-          "is_causal"_a = false, "num_kv_heads"_a, "num_heads"_a, "stream"_a = nb::none(), R"(
+    m.def("flash_attention", &tiny_llm_ext_ref::flash_attention, "query"_a, "key"_a, "value"_a, "mask"_a,
+          "scale"_a = 1.0, "mask_mode"_a = 0, "num_kv_heads"_a, "num_heads"_a, "stream"_a = nb::none(), R"(
         Flash attention layer
 
         Args:
@@ -41,7 +41,7 @@ NB_MODULE(_ext, m) {
             value (array): Value array.
             mask (array): Mask array.
             scale (float): Scaling factor.
-            is_causal (bool): Enable causal-mask fast path.
+            mask_mode (int): 0 for no mask, 1 for causal, 2 for an additive mask.
 
         Returns:
             array: ``softmax(query @ key.T * scale) @ value``

--- a/src/extensions_ref/bindings.cpp
+++ b/src/extensions_ref/bindings.cpp
@@ -40,8 +40,11 @@ NB_MODULE(_ext, m) {
             key (array): Key array.
             value (array): Value array.
             mask (array): Mask array.
-            scale (float): Scaling factor.
+            scale (float): Float32 scaling factor.
             mask_mode (int): 0 for no mask, 1 for causal, 2 for an additive mask.
+
+        Q, K, V, and output preserve bfloat16 on the D=128 GPU path. The
+        additive mask and online-softmax accumulation use float32.
 
         Returns:
             array: ``softmax(query @ key.T * scale) @ value``

--- a/src/extensions_ref/src/flash_attention.cpp
+++ b/src/extensions_ref/src/flash_attention.cpp
@@ -25,8 +25,11 @@ mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::arra
     if (num_heads % num_kv_heads != 0) {
         throw std::runtime_error("flash_attention: num_heads must be divisible by num_kv_heads");
     }
-    if (mask.shape().size() != 3) {
-        throw std::runtime_error("flash_attention: mask must be 3D");
+    if (mask_mode < 0 || mask_mode > 2) {
+        throw std::runtime_error("flash_attention: mask_mode must be 0 (none), 1 (causal), or 2 (additive)");
+    }
+    if (mask_mode == 2 && mask.shape().size() != 3) {
+        throw std::runtime_error("flash_attention: an additive mask must be 3D");
     }
 
     // Q: [N, L, E]
@@ -47,10 +50,14 @@ mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::arra
     if (q.shape()[0] / num_heads != k.shape()[0] / num_kv_heads) {
         throw std::runtime_error("flash_attention: number of heads mismatch");
     }
+    if (k.shape()[0] != v.shape()[0]) {
+        throw std::runtime_error("flash_attention: k and v batch/head dimensions must match");
+    }
     if (k.shape()[1] != v.shape()[1]) {
         throw std::runtime_error("flash_attention: k.shape[1] must be equal to v.shape[1]");
     }
-    if (mask.shape()[0] != q.shape()[0] || mask.shape()[1] != q.shape()[1] || mask.shape()[2] != k.shape()[1]) {
+    if (mask_mode == 2 &&
+        (mask.shape()[0] != q.shape()[0] || mask.shape()[1] != q.shape()[1] || mask.shape()[2] != k.shape()[1])) {
         throw std::runtime_error("flash_attention: mask must be broadcastable to q, k, v");
     }
 
@@ -188,7 +195,9 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                             rowmax = std::max(rowmax, s_i[a * Bc + b]);
                         }
                         float max = std::max(m_i[a], rowmax);
-                        m_i_diff[a] = m_i[a] - max;
+                        m_i_diff[a] = m_i[a] == -std::numeric_limits<float>::infinity()
+                            ? -std::numeric_limits<float>::infinity()
+                            : m_i[a] - max;
                         m_i[a] = max;
                     }
 
@@ -196,7 +205,9 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                     std::vector<float> p(Br * Bc, 0.0);
                     for (int64_t a = 0; a < br_upper_bound; a++) {
                         for (int64_t b = 0; b < bc_upper_bound; b++) {
-                            p[a * Bc + b] = std::exp(s_i[a * Bc + b] - m_i[a]);
+                            p[a * Bc + b] = s_i[a * Bc + b] == -std::numeric_limits<float>::infinity()
+                                ? 0.0f
+                                : std::exp(s_i[a * Bc + b] - m_i[a]);
                         }
                     }
 
@@ -276,7 +287,7 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     compute_encoder.set_input_array(k, 1);
     compute_encoder.set_input_array(v, 2);
     compute_encoder.set_input_array(mask, 3);
-    compute_encoder.set_output_array(out, 4);    
+    compute_encoder.set_output_array(out, 4);
     compute_encoder.set_vector_bytes(mask.shape(), 5);
     compute_encoder.set_vector_bytes(mask.strides(), 6);
 
@@ -312,25 +323,17 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
     size_t simd_width = kernel->threadExecutionWidth();
 
-    const int Br = 32;
+    const int Br = 16;
     const int Bc = 32;
     if (simd_width * Br > tgp_size) {
-        throw std::runtime_error("flash_attention: simd_width * Br must be equal to tgp_size");
+        throw std::runtime_error("flash_attention: threadgroup exceeds the kernel thread limit");
     }
-    if (Bc > simd_width) {
-        throw std::runtime_error("flash_attention: Bc must be less than simd_width");
-    }
-
-    if (E > 128) {
-        throw std::runtime_error("flash_attention: E must be less than 128");
+    if (Bc != simd_width) {
+        throw std::runtime_error("flash_attention: the K/V tile width must match the SIMD width");
     }
 
-    if (Br > 32) {
-        throw std::runtime_error("flash_attention: Br must be less than 32");
-    }
-
-    if (Bc > 32) {
-        throw std::runtime_error("flash_attention: Bc must be less than 32");
+    if (E <= 0 || E > 128) {
+        throw std::runtime_error("flash_attention: E must be in the range [1, 128]");
     }
 
     const int Tr = (L + Br - 1) / Br;
@@ -342,7 +345,7 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     compute_encoder.set_bytes(Tc, 18);
 
     MTL::Size num_threadgroups = MTL::Size(N, Tr, 1);
-    MTL::Size num_threads_per_group = MTL::Size(Br, simd_width, 1);
+    MTL::Size num_threads_per_group = MTL::Size(simd_width, Br, 1);
 
     compute_encoder.dispatch_threadgroups(num_threadgroups, num_threads_per_group);
 }

--- a/src/extensions_ref/src/flash_attention.cpp
+++ b/src/extensions_ref/src/flash_attention.cpp
@@ -9,17 +9,17 @@
 
 #ifdef _METAL_
 #include "mlx/backend/metal/device.h"
-#include "mlx/backend/metal/kernels/steel/attn/params.h"
 #include "mlx/backend/metal/utils.h"
 #endif
 
 namespace tiny_llm_ext_ref {
 mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::array &v, const mx::array &mask,
-                          const float scale, const bool is_causal, const int num_kv_heads, const int num_heads,
+                          const float scale, const int mask_mode, const int num_kv_heads, const int num_heads,
                           mx::StreamOrDevice s) {
-    if (q.dtype() != mx::float32 || k.dtype() != mx::float32 || v.dtype() != mx::float32 ||
+    if ((q.dtype() != mx::float32 && q.dtype() != mx::bfloat16) || k.dtype() != q.dtype() || v.dtype() != q.dtype() ||
         mask.dtype() != mx::float32) {
-        throw std::runtime_error("flash_attention: all input arrays must be float32");
+        throw std::runtime_error(
+            "flash_attention: q, k, and v must have the same float32 or bfloat16 dtype; mask must be float32");
     }
     if (q.shape().size() != 3 || k.shape().size() != 3 || v.shape().size() != 3) {
         throw std::runtime_error("flash_attention: all input arrays must be 3D");
@@ -52,19 +52,19 @@ mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::arra
     if (q.shape()[0] / num_heads != k.shape()[0] / num_kv_heads) {
         throw std::runtime_error("flash_attention: number of heads mismatch");
     }
-    if (k.shape()[0] != v.shape()[0]) {
-        throw std::runtime_error("flash_attention: k and v batch/head dimensions must match");
-    }
     if (k.shape()[1] != v.shape()[1]) {
         throw std::runtime_error("flash_attention: k.shape[1] must be equal to v.shape[1]");
+    }
+    if (k.shape()[0] != v.shape()[0]) {
+        throw std::runtime_error("flash_attention: k and v batch/head dimensions must match");
     }
     if (mask_mode == 2 &&
         (mask.shape()[0] != q.shape()[0] || mask.shape()[1] != q.shape()[1] || mask.shape()[2] != k.shape()[1])) {
         throw std::runtime_error("flash_attention: mask must be broadcastable to q, k, v");
     }
 
-    return mx::array(q.shape(), mx::float32,
-                     std::make_shared<FlashAttention>(to_stream(s), scale, is_causal, num_kv_heads, num_heads),
+    return mx::array(q.shape(), q.dtype(),
+                     std::make_shared<FlashAttention>(to_stream(s), scale, mask_mode, num_kv_heads, num_heads),
                      {q, k, v, mask});
 }
 
@@ -76,7 +76,7 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
     auto &out = outputs[0];
 
     if (out.dtype() != mx::float32) {
-        throw std::runtime_error("flash_attention: output dtype must be float32");
+        throw std::runtime_error("flash_attention: the CPU path only supports float32");
     }
 
     out.set_data(mx::allocator::malloc(out.nbytes()));
@@ -102,7 +102,7 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
     encoder.dispatch([out_ptr = out.data<float>(), out_shape = out.shape(), q = mx::array::unsafe_weak_copy(q),
                       k = mx::array::unsafe_weak_copy(k), v = mx::array::unsafe_weak_copy(v),
                       mask = mx::array::unsafe_weak_copy(mask), num_heads = num_heads_, num_kv_heads = num_kv_heads_,
-                      scale = scale_, is_causal = is_causal_]() {
+                      scale = scale_, mask_mode = mask_mode_]() {
         const int64_t N = q.shape()[0];
         const int64_t L = q.shape()[1];
         const int64_t S = k.shape()[1];
@@ -141,8 +141,9 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                 for (int64_t j = 0; j < Tc; j++) {
                     int64_t row_max = i * Br + br_upper_bound - 1;
                     int64_t col_min = j * Bc;
-                    // Causal masking: if the entire block of K is masked out by causal mask, we can skip the computation for this block.
-                    if (is_causal && col_min > row_max + causal_offset) {
+                    // Causal masking: if the entire block of K is masked out by causal mask, we can skip the
+                    // computation for this block.
+                    if (mask_mode == 1 && col_min > row_max + causal_offset) {
                         continue;
                     }
                     int bc_upper_bound = std::min(S - j * Bc, Bc);
@@ -172,14 +173,12 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                     }
 
                     // Add mask and scale
-                    int64_t row_min = i * Br;
-                    int64_t col_max = j * Bc + bc_upper_bound - 1;
-                    bool block_all_valid = is_causal && (col_max <= row_min + causal_offset);
                     for (int64_t a = 0; a < br_upper_bound; a++) {
                         for (int64_t b = 0; b < bc_upper_bound; b++) {
                             s_i[a * Bc + b] *= scale;
-                            // If the block is all valid, we don't need to add mask because it's all zeros. Otherwise we need to add mask for each element.
-                            if (!block_all_valid) {
+                            if (mask_mode == 1 && j * Bc + b > i * Br + a + causal_offset) {
+                                s_i[a * Bc + b] = -std::numeric_limits<float>::infinity();
+                            } else if (mask_mode == 2) {
                                 int m_idx_1 = n;
                                 int m_idx_2 = i * Br + a;
                                 int m_idx_3 = j * Bc + b;
@@ -267,14 +266,13 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     const auto &mask = inputs[3];
     auto &out = outputs[0];
 
-    if (out.dtype() != mx::float32) {
-        throw std::runtime_error("flash_attention: output dtype must be float32");
-    }
-
     out.set_data(mx::allocator::malloc(out.nbytes()));
 
     auto &s = stream();
     auto &d = mx::metal::device(s.device);
+
+    auto library = d.get_library("tiny_llm_ext_ref");
+    auto &compute_encoder = d.get_command_encoder(s.index);
 
     if (!q.flags().row_contiguous) {
         throw std::runtime_error("flash_attention: q must be contiguous");
@@ -294,40 +292,53 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     const int S = k.shape()[1];
     const int E = q.shape()[2];
 
-    compute_encoder.set_bytes(static_cast<int>(is_causal_), 7);
-    compute_encoder.set_bytes(N, 8);
-    compute_encoder.set_bytes(L, 9);
-    compute_encoder.set_bytes(S, 10);
-    compute_encoder.set_bytes(E, 11);
-
-    // Make sure the data type matches with the metal kernel: otherwise you'll get flaky issues and stuck :(
-    compute_encoder.set_bytes(num_kv_heads_, 12);
-    compute_encoder.set_bytes(num_heads_, 13);
-    compute_encoder.set_bytes(scale_, 14);
-
-    size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
-    size_t simd_width = kernel->threadExecutionWidth();
-
-    const int Br = 16;
-    const int Bc = 32;
-    if (simd_width * Br > tgp_size) {
-        throw std::runtime_error("flash_attention: threadgroup exceeds the kernel thread limit");
-    }
-    if (Bc != simd_width) {
-        throw std::runtime_error("flash_attention: the K/V tile width must match the SIMD width");
+    if (E <= 0 || E > 128) {
+        throw std::runtime_error("flash_attention: E must be in the range [1, 128]");
     }
 
-    const int Tr = (L + Br - 1) / Br;
-    const int Tc = (S + Bc - 1) / Bc;
+    if (E == 128 && q.dtype() == mx::bfloat16) {
+        auto kernel = d.get_kernel("flash_attention_mma_bf16_d128", library);
+        compute_encoder.set_compute_pipeline_state(kernel);
+        compute_encoder.set_input_array(q, 0);
+        compute_encoder.set_input_array(k, 1);
+        compute_encoder.set_input_array(v, 2);
+        compute_encoder.set_input_array(mask, 3);
+        compute_encoder.set_output_array(out, 4);
+        compute_encoder.set_bytes(mask_mode_, 5);
+        compute_encoder.set_bytes(N, 6);
+        compute_encoder.set_bytes(L, 7);
+        compute_encoder.set_bytes(S, 8);
+        compute_encoder.set_bytes(num_kv_heads_, 9);
+        compute_encoder.set_bytes(num_heads_, 10);
+        compute_encoder.set_bytes(scale_, 11);
 
-    compute_encoder.set_bytes(Br, 15);
-    compute_encoder.set_bytes(Bc, 16);
-    compute_encoder.set_bytes(Tr, 17);
-    compute_encoder.set_bytes(Tc, 18);
+        const int batch_size = N / num_heads_;
+        const int query_blocks = (L + 63) / 64;
+        compute_encoder.dispatch_threadgroups(MTL::Size(query_blocks, num_heads_, batch_size), MTL::Size(32, 8, 1));
+        return;
+    }
 
-    MTL::Size num_threadgroups = MTL::Size(N, Tr, 1);
-    MTL::Size num_threads_per_group = MTL::Size(simd_width, Br, 1);
+    if (q.dtype() != mx::float32) {
+        throw std::runtime_error("flash_attention: bfloat16 GPU inputs require E == 128");
+    }
 
-    compute_encoder.dispatch_threadgroups(num_threadgroups, num_threads_per_group);
+    auto kernel = d.get_kernel("flash_attention_scalar_f32", library);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(q, 0);
+    compute_encoder.set_input_array(k, 1);
+    compute_encoder.set_input_array(v, 2);
+    compute_encoder.set_input_array(mask, 3);
+    compute_encoder.set_output_array(out, 4);
+    compute_encoder.set_bytes(mask_mode_, 5);
+    compute_encoder.set_bytes(N, 6);
+    compute_encoder.set_bytes(L, 7);
+    compute_encoder.set_bytes(S, 8);
+    compute_encoder.set_bytes(E, 9);
+    compute_encoder.set_bytes(num_kv_heads_, 10);
+    compute_encoder.set_bytes(num_heads_, 11);
+    compute_encoder.set_bytes(scale_, 12);
+
+    const int query_blocks = (L + 15) / 16;
+    compute_encoder.dispatch_threadgroups(MTL::Size(N, query_blocks, 1), MTL::Size(32, 16, 1));
 }
 }  // namespace tiny_llm_ext_ref

--- a/src/extensions_ref/src/flash_attention.cpp
+++ b/src/extensions_ref/src/flash_attention.cpp
@@ -9,6 +9,7 @@
 
 #ifdef _METAL_
 #include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels/steel/attn/params.h"
 #include "mlx/backend/metal/utils.h"
 #endif
 
@@ -16,7 +17,8 @@ namespace tiny_llm_ext_ref {
 mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::array &v, const mx::array &mask,
                           const float scale, const bool is_causal, const int num_kv_heads, const int num_heads,
                           mx::StreamOrDevice s) {
-    if (q.dtype() != mx::float32 || k.dtype() != mx::float32 || v.dtype() != mx::float32 || mask.dtype() != mx::float32) {
+    if (q.dtype() != mx::float32 || k.dtype() != mx::float32 || v.dtype() != mx::float32 ||
+        mask.dtype() != mx::float32) {
         throw std::runtime_error("flash_attention: all input arrays must be float32");
     }
     if (q.shape().size() != 3 || k.shape().size() != 3 || v.shape().size() != 3) {
@@ -196,8 +198,8 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                         }
                         float max = std::max(m_i[a], rowmax);
                         m_i_diff[a] = m_i[a] == -std::numeric_limits<float>::infinity()
-                            ? -std::numeric_limits<float>::infinity()
-                            : m_i[a] - max;
+                                          ? -std::numeric_limits<float>::infinity()
+                                          : m_i[a] - max;
                         m_i[a] = max;
                     }
 
@@ -206,8 +208,8 @@ void FlashAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                     for (int64_t a = 0; a < br_upper_bound; a++) {
                         for (int64_t b = 0; b < bc_upper_bound; b++) {
                             p[a * Bc + b] = s_i[a * Bc + b] == -std::numeric_limits<float>::infinity()
-                                ? 0.0f
-                                : std::exp(s_i[a * Bc + b] - m_i[a]);
+                                                ? 0.0f
+                                                : std::exp(s_i[a * Bc + b] - m_i[a]);
                         }
                     }
 
@@ -274,23 +276,6 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     auto &s = stream();
     auto &d = mx::metal::device(s.device);
 
-    // Make a kernel from this metal library
-    auto library = d.get_library("tiny_llm_ext_ref");
-    auto kernel = d.get_kernel("flash_attention_f32_e128", library);
-
-    // Prepare to encode kernel
-    auto &compute_encoder = d.get_command_encoder(s.index);
-    compute_encoder.set_compute_pipeline_state(kernel);
-
-    // Encode input arrays to kernel
-    compute_encoder.set_input_array(q, 0);
-    compute_encoder.set_input_array(k, 1);
-    compute_encoder.set_input_array(v, 2);
-    compute_encoder.set_input_array(mask, 3);
-    compute_encoder.set_output_array(out, 4);
-    compute_encoder.set_vector_bytes(mask.shape(), 5);
-    compute_encoder.set_vector_bytes(mask.strides(), 6);
-
     if (!q.flags().row_contiguous) {
         throw std::runtime_error("flash_attention: q must be contiguous");
     }
@@ -330,10 +315,6 @@ void FlashAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     }
     if (Bc != simd_width) {
         throw std::runtime_error("flash_attention: the K/V tile width must match the SIMD width");
-    }
-
-    if (E <= 0 || E > 128) {
-        throw std::runtime_error("flash_attention: E must be in the range [1, 128]");
     }
 
     const int Tr = (L + Br - 1) / Br;

--- a/src/extensions_ref/src/flash_attention.metal
+++ b/src/extensions_ref/src/flash_attention.metal
@@ -1,242 +1,403 @@
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
 #include <metal_stdlib>
-#include "mlx/backend/metal/kernels/utils.h"
-#include "mlx/backend/metal/kernels/steel/attn/attn.h"
-#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
 
 using namespace metal;
 
-[[kernel]] void flash_attention_f32_e128(
-    device const float* q [[buffer(0)]],
-    device const float* k [[buffer(1)]],
-    device const float* v [[buffer(2)]],
+namespace {
+
+constant constexpr int HEAD_DIM = 128;
+constant constexpr int MMA_SIZE = 8;
+
+inline ushort2 matrix_coord(ushort lane) {
+    const ushort quad = lane / 4;
+    const ushort row = (quad & 4) + ((lane / 2) % 4);
+    const ushort col = (quad & 2) * 2 + (lane % 2) * 2;
+    return ushort2(col, row);
+}
+
+template <typename T>
+inline void load_matrix(
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& matrix,
+    threadgroup const T* source,
+    int row_stride,
+    ushort lane) {
+    const ushort2 coord = matrix_coord(lane);
+    matrix.thread_elements()[0] = source[coord.y * row_stride + coord.x];
+    matrix.thread_elements()[1] = source[coord.y * row_stride + coord.x + 1];
+}
+
+template <int N>
+inline float row_max(
+    thread const simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>* matrices) {
+    float value = -INFINITY;
+    for (int fragment_idx = 0; fragment_idx < N; fragment_idx++) {
+        const auto values = matrices[fragment_idx].thread_elements();
+        value = max(value, max(values[0], values[1]));
+    }
+    value = max(value, simd_shuffle_xor(value, ushort(1)));
+    value = max(value, simd_shuffle_xor(value, ushort(8)));
+    return value;
+}
+
+template <int N>
+inline float row_sum(
+    thread const simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>* matrices) {
+    float value = 0.0f;
+    for (int fragment_idx = 0; fragment_idx < N; fragment_idx++) {
+        const auto values = matrices[fragment_idx].thread_elements();
+        value += values[0] + values[1];
+    }
+    value += simd_shuffle_xor(value, ushort(1));
+    value += simd_shuffle_xor(value, ushort(8));
+    return value;
+}
+
+inline void clear_matrix(thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& matrix) {
+    matrix.thread_elements()[0] = 0.0f;
+    matrix.thread_elements()[1] = 0.0f;
+}
+
+inline void scale_matrix_rows(
+    thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& matrix,
+    float scale) {
+    matrix.thread_elements()[0] *= scale;
+    matrix.thread_elements()[1] *= scale;
+}
+
+template <typename T>
+inline void matrix_multiply_accumulate(
+    thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& accumulator,
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& left,
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& right) {
+    simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> result;
+    simdgroup_multiply_accumulate(result, left, right, accumulator);
+    accumulator = result;
+}
+
+}  // namespace
+
+[[kernel, max_total_threads_per_threadgroup(256)]] void flash_attention_mma_bf16_d128(
+    device const bfloat* q [[buffer(0)]],
+    device const bfloat* k [[buffer(1)]],
+    device const bfloat* v [[buffer(2)]],
     device const float* mask [[buffer(3)]],
-    device float* out [[buffer(4)]],
-    constant const int* mask_shape [[buffer(5)]],
-    constant const int64_t* mask_strides [[buffer(6)]],
-    device const int &is_causal [[buffer(7)]],
-    device const int &N [[buffer(8)]],
-    device const int &L [[buffer(9)]],
-    device const int &S [[buffer(10)]],
-    device const int &E [[buffer(11)]],
-    device const int &num_kv_heads [[buffer(12)]],
-    device const int &num_heads [[buffer(13)]],
-    device const float &scale [[buffer(14)]],
-    device const int &Br [[buffer(15)]],
-    device const int &Bc [[buffer(16)]],
-    [[maybe_unused]] device const int &Tr [[buffer(17)]],
-    device const int &Tc [[buffer(18)]],
-    uint2 group_id [[threadgroup_position_in_grid]],
-    uint simd_gid [[simdgroup_index_in_threadgroup]],
-    uint simd_lid [[thread_index_in_simdgroup]]) {
+    device bfloat* out [[buffer(4)]],
+    constant const int& mask_mode [[buffer(5)]],
+    constant const int& N [[buffer(6)]],
+    constant const int& L [[buffer(7)]],
+    constant const int& S [[buffer(8)]],
+    constant const int& num_kv_heads [[buffer(9)]],
+    constant const int& num_heads [[buffer(10)]],
+    constant const float& scale [[buffer(11)]],
+    uint3 group_id [[threadgroup_position_in_grid]],
+    ushort simd_gid [[simdgroup_index_in_threadgroup]],
+    ushort lane [[thread_index_in_simdgroup]]) {
+    constexpr int BQ = 64;
+    constexpr int BK = 32;
+    constexpr int SIMD_GROUPS = 8;
+    constexpr int THREADS = SIMD_GROUPS * 32;
+    constexpr int LDQ = HEAD_DIM + 2;
+    constexpr int LDK = BK + 2;
+    constexpr int LDV = HEAD_DIM + 2;
+    constexpr int KV_STORAGE = HEAD_DIM * LDK;
+    constexpr int OUTPUT_FRAGMENTS = HEAD_DIM / MMA_SIZE;
+    constexpr int SCORE_FRAGMENTS = BK / MMA_SIZE;
 
-    constexpr int BR = 16;
-    constexpr int BC = 32;
-    constexpr int MAX_E = 128;
-    constexpr int OUTPUTS_PER_LANE = MAX_E / BC;
-    constexpr int THREADS_PER_GROUP = BR * BC;
-
-    const int n = group_id.x;
-    const int query_block = group_id.y;
-    const int query_row_in_block = simd_gid;
-    const int query_row = query_block * BR + query_row_in_block;
-    const int lane = simd_lid;
-    const int thread_idx = query_row_in_block * BC + lane;
-    const bool query_in_range = n < N && query_row < L;
-
+    const int query_block = group_id.x;
+    const int query_head = group_id.y;
+    const int batch = group_id.z;
+    const int n = batch * num_heads + query_head;
     const int q_kv_ratio = num_heads / num_kv_heads;
-    device const float* q_block = q + n * L * E + query_block * BR * E;
-    device const float* k_head = k + (n / q_kv_ratio) * S * E;
-    device const float* v_head = v + (n / q_kv_ratio) * S * E;
+    const int kv_head = query_head / q_kv_ratio;
+    const int thread_idx = simd_gid * 32 + lane;
+    const ushort2 coord = matrix_coord(lane);
+    const int query_row_in_block = simd_gid * MMA_SIZE + coord.y;
+    const int query_row = query_block * BQ + query_row_in_block;
+    const bool query_valid = n < N && query_row < L;
 
-    // Q remains resident for the whole K/V traversal. K and V reuse the same
-    // storage because P is materialized before the K tile is replaced by V.
-    threadgroup float q_tile[BR * MAX_E];
-    threadgroup float kv_tile[BC * MAX_E];
-    threadgroup float p_tile[BR * BC];
+    device const bfloat* q_head = q + n * L * HEAD_DIM;
+    device const bfloat* k_head = k + (batch * num_kv_heads + kv_head) * S * HEAD_DIM;
+    device const bfloat* v_head = v + (batch * num_kv_heads + kv_head) * S * HEAD_DIM;
 
-    for (int idx = thread_idx; idx < BR * MAX_E; idx += THREADS_PER_GROUP) {
-        const int row = idx / MAX_E;
-        const int dim = idx - row * MAX_E;
-        const bool valid = query_block * BR + row < L && dim < E;
-        q_tile[idx] = valid ? q_block[row * E + dim] : 0.0f;
+    threadgroup bfloat q_tile[BQ * LDQ];
+    threadgroup bfloat kv_tile[KV_STORAGE];
+
+    for (int idx = thread_idx; idx < BQ * HEAD_DIM; idx += THREADS) {
+        const int row = idx / HEAD_DIM;
+        const int dim = idx - row * HEAD_DIM;
+        const int global_row = query_block * BQ + row;
+        q_tile[row * LDQ + dim] = global_row < L ? q_head[global_row * HEAD_DIM + dim] : bfloat(0.0f);
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float output_frag[OUTPUTS_PER_LANE] = {0.0f, 0.0f, 0.0f, 0.0f};
-    float row_max = -INFINITY;
-    float row_sum = 0.0f;
+    simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> output[OUTPUT_FRAGMENTS];
+    for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+        clear_matrix(output[output_fragment]);
+    }
 
-    const int total_kv_tiles = (S + BC - 1) / BC;
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+
+    const int total_kv_tiles = (S + BK - 1) / BK;
     int kv_tile_limit = total_kv_tiles;
     if (mask_mode == 1) {
-        const int last_query = min((query_block + 1) * BR, L) - 1;
+        const int last_query = min((query_block + 1) * BQ, L) - 1;
         const int last_visible_key = last_query + (S - L);
-        kv_tile_limit = clamp((last_visible_key + 1 + BC - 1) / BC, 0, total_kv_tiles);
+        kv_tile_limit = clamp((last_visible_key + 1 + BK - 1) / BK, 0, total_kv_tiles);
     }
 
     for (int tile_idx = 0; tile_idx < kv_tile_limit; tile_idx++) {
-        for (int idx = thread_idx; idx < BC * MAX_E; idx += THREADS_PER_GROUP) {
-            const int row = idx / MAX_E;
-            const int dim = idx - row * MAX_E;
-            const int key_row = tile_idx * BC + row;
-            kv_tile[idx] = key_row < S && dim < E ? k_head[key_row * E + dim] : 0.0f;
-        }
-    }
-    
-    for (int j = 0; j < Tc; j++) {
-        // Causal masking: if the entire block of K is masked out by causal mask, we can skip the computation for this block.
-        if (is_causal) {
-            int row_max = min((i + 1) * Br - 1, L - 1);
-            int col_min = j * Bc;
-            if (col_min > row_max + (S - L)) {
-                continue;
-            }
-        }
-       
-        bool is_j_in_range = j * Bc + b < S && b < Bc;
-
-        device const float *k_ptr = k_ptr_base + j * Bc * E;
-        device const float *v_ptr = v_ptr_base + j * Bc * E;
-
-        // compute s_i = q_i @ k_j^T; store the result of each cell in thread local memory
-        float s_a_b = 0.0;
-        for (int c = 0; c < E; c++) {
-            if (is_i_in_range && is_j_in_range) {
-                s_a_b += q_local[a][c] * k_ptr[b * E + c];
-            }
-        }
-        s_a_b *= scale;
-        if (is_i_in_range && is_j_in_range) {
-            int row_min = i * Br;
-            int col_max = min((j + 1) * Bc - 1, S - 1);
-            bool block_all_valid = is_causal && (col_max <= row_min + (S - L));
-            if (!block_all_valid) {
-                int64_t m_idx_1 = n;
-                int64_t m_idx_2 = i * Br + a;
-                int64_t m_idx_3 = j * Bc + b;
-                int64_t m_idx_converted = elem_to_loc(m_idx_1 * L * S + m_idx_2 * S + m_idx_3, mask_shape, mask_strides, 3);
-                s_a_b += mask[m_idx_converted];
-            }
-        } else {
-            s_a_b = -1e9;
-        }
-
-        // for each cell, get the rowmax of the corresponding row, and compute m_i in each
-        // of the cells
-        float rowmax = simd_max(s_a_b);
-        float new_max = max(m_i, rowmax);
-        float m_i_diff = m_i - new_max;
-        float m_i_diff_exp = exp(m_i_diff);
-        m_i = new_max;
-
-        // compute matrix p_j for each of the cell
-        float p_a_b;
-        if (is_i_in_range && is_j_in_range) {
-            p_a_b = exp(s_a_b - m_i);
-        } else {
-            p_a_b = 0.0;
-        }
-
-        // compute l
-        // get the rowsum of each row of p_j in all of the cells
-        float rowsum = simd_sum(p_a_b);
-        l_i = m_i_diff_exp * l_i + rowsum;
-
-        // compute o_i, where O is Br x E; note that this does not align
-        // with the threadgroup we dispatch, so we have to do threadgroup sync
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        const int key_row = tile_idx * BC + lane;
-        bool score_is_valid = query_in_range && key_row < S;
-        if (mask_mode == 1) {
-            score_is_valid = score_is_valid && key_row <= query_row + (S - L);
-        }
-
-        float score = -INFINITY;
-        if (score_is_valid) {
-            score = 0.0f;
-            int dim = 0;
-            for (; dim + 3 < E; dim += 4) {
-                const int q_idx = query_row_in_block * MAX_E + dim;
-                const int k_idx = lane * MAX_E + dim;
-                const float4 qv = float4(q_tile[q_idx], q_tile[q_idx + 1], q_tile[q_idx + 2], q_tile[q_idx + 3]);
-                const float4 kv =
-                    float4(kv_tile[k_idx], kv_tile[k_idx + 1], kv_tile[k_idx + 2], kv_tile[k_idx + 3]);
-                score += dot(qv, kv);
-            }
-            for (; dim < E; dim++) {
-                score += q_tile[query_row_in_block * MAX_E + dim] * kv_tile[lane * MAX_E + dim];
-            }
-            score *= scale;
-
-            if (mask_mode == 2) {
-                const int64_t mask_idx =
-                    elem_to_loc(n * L * S + query_row * S + key_row, mask_shape, mask_strides, 3);
-                score += mask[mask_idx];
-            }
-        }
-
-        const float tile_row_max = simd_max(score);
-        const float new_row_max = max(row_max, tile_row_max);
-        const bool has_finite_score = new_row_max != -INFINITY;
-        const float previous_scale = row_max == -INFINITY ? 0.0f : fast::exp(row_max - new_row_max);
-        const float probability = score == -INFINITY || !has_finite_score ? 0.0f : fast::exp(score - new_row_max);
-        const float tile_row_sum = simd_sum(probability);
-
-        row_max = new_row_max;
-        row_sum = previous_scale * row_sum + tile_row_sum;
-        p_tile[query_row_in_block * BC + lane] = probability;
-
-        // All score reads from K and all writes to P must complete before the
-        // shared K buffer is reused for V.
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (int idx = thread_idx; idx < BC * MAX_E; idx += THREADS_PER_GROUP) {
-            const int row = idx / MAX_E;
-            const int dim = idx - row * MAX_E;
-            const int value_row = tile_idx * BC + row;
-            kv_tile[idx] = value_row < S && dim < E ? v_head[value_row * E + dim] : 0.0f;
+        // K is transposed while loading so each MMA fragment can consume an
+        // ordinary row-major [D, BK] matrix.
+        for (int idx = thread_idx; idx < BK * HEAD_DIM; idx += THREADS) {
+            const int key = idx / HEAD_DIM;
+            const int dim = idx - key * HEAD_DIM;
+            const int global_key = tile_idx * BK + key;
+            kv_tile[dim * LDK + key] = global_key < S
+                ? k_head[global_key * HEAD_DIM + dim]
+                : bfloat(0.0f);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
-        if (query_in_range) {
-            for (int frag = 0; frag < OUTPUTS_PER_LANE; frag++) {
-                const int dim = lane + frag * BC;
-                if (dim < E) {
-                    float partial = 0.0f;
-                    for (int key = 0; key < BC; key++) {
-                        partial += p_tile[query_row_in_block * BC + key] * kv_tile[key * MAX_E + dim];
+        simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> scores[SCORE_FRAGMENTS];
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            clear_matrix(scores[key_fragment]);
+        }
+
+        for (int dim = 0; dim < HEAD_DIM; dim += MMA_SIZE) {
+            simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> q_fragment;
+            load_matrix(
+                q_fragment,
+                q_tile + simd_gid * MMA_SIZE * LDQ + dim,
+                LDQ,
+                lane);
+            for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+                simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> k_fragment;
+                load_matrix(
+                    k_fragment,
+                    kv_tile + dim * LDK + key_fragment * MMA_SIZE,
+                    LDK,
+                    lane);
+                matrix_multiply_accumulate(scores[key_fragment], q_fragment, k_fragment);
+            }
+        }
+
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            thread auto& score_values = scores[key_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                const int key = tile_idx * BK + key_fragment * MMA_SIZE + coord.x + element;
+                bool valid = query_valid && key < S;
+                if (mask_mode == 1) {
+                    valid = valid && key <= query_row + (S - L);
+                }
+                if (!valid) {
+                    score_values[element] = -INFINITY;
+                } else {
+                    score_values[element] *= scale;
+                    if (mask_mode == 2) {
+                        score_values[element] += mask[n * L * S + query_row * S + key];
                     }
-                    output_frag[frag] = previous_scale * output_frag[frag] + partial;
                 }
             }
         }
 
-        // No thread may replace V with the next K tile while another SIMD
-        // group is still consuming it.
+        const float tile_max = row_max<SCORE_FRAGMENTS>(scores);
+        const float new_max = max(running_max, tile_max);
+        const bool finite_row = query_valid && new_max != -INFINITY;
+        const float previous_scale = running_max == -INFINITY || !finite_row
+            ? 0.0f
+            : fast::exp(running_max - new_max);
+
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            thread auto& score_values = scores[key_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                score_values[element] = score_values[element] == -INFINITY || !finite_row
+                    ? 0.0f
+                    : fast::exp(score_values[element] - new_max);
+            }
+        }
+
+        const float tile_sum = row_sum<SCORE_FRAGMENTS>(scores);
+        running_max = new_max;
+        running_sum = previous_scale * running_sum + tile_sum;
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            scale_matrix_rows(output[output_fragment], previous_scale);
+        }
+
+        simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> probabilities[SCORE_FRAGMENTS];
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            const auto score_values = scores[key_fragment].thread_elements();
+            probabilities[key_fragment].thread_elements()[0] = bfloat(score_values[0]);
+            probabilities[key_fragment].thread_elements()[1] = bfloat(score_values[1]);
+        }
+
+        // Scores now contain P. Reuse the K allocation for a row-major V tile.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BK * HEAD_DIM; idx += THREADS) {
+            const int key = idx / HEAD_DIM;
+            const int dim = idx - key * HEAD_DIM;
+            const int global_key = tile_idx * BK + key;
+            kv_tile[key * LDV + dim] = global_key < S
+                ? v_head[global_key * HEAD_DIM + dim]
+                : bfloat(0.0f);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+                simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> v_fragment;
+                load_matrix(
+                    v_fragment,
+                    kv_tile + key_fragment * MMA_SIZE * LDV + output_fragment * MMA_SIZE,
+                    LDV,
+                    lane);
+                matrix_multiply_accumulate(
+                    output[output_fragment], probabilities[key_fragment], v_fragment);
+            }
+        }
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
-    if (query_in_range) {
-        for (int frag = 0; frag < OUTPUTS_PER_LANE; frag++) {
-            const int dim = lane + frag * BC;
-            if (dim < E) {
-                out[n * L * E + query_row * E + dim] = output_frag[frag] / row_sum;
+    if (query_valid && running_sum != 0.0f) {
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            const auto output_values = output[output_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                const int dim = output_fragment * MMA_SIZE + coord.x + element;
+                out[n * L * HEAD_DIM + query_row * HEAD_DIM + dim] =
+                    bfloat(output_values[element] / running_sum);
             }
         }
     }
 }
 
-// The scalar kernel above is intentionally kept as a readable, general
-// fallback. The production head dimension uses Metal SIMD-matrix operations
-// through MLX's Steel attention building block.
-instantiate_kernel(
-    "flash_attention_steel_f32_bq32_bk16_bd128_wm4_wn1_maskfloat32",
-    attention,
-    float,
-    32,
-    16,
-    128,
-    4,
-    1,
-    float,
-    float)
+[[kernel]] void flash_attention_scalar_f32(
+    device const float* q [[buffer(0)]],
+    device const float* k [[buffer(1)]],
+    device const float* v [[buffer(2)]],
+    device const float* mask [[buffer(3)]],
+    device float* out [[buffer(4)]],
+    constant const int& mask_mode [[buffer(5)]],
+    constant const int& N [[buffer(6)]],
+    constant const int& L [[buffer(7)]],
+    constant const int& S [[buffer(8)]],
+    constant const int& E [[buffer(9)]],
+    constant const int& num_kv_heads [[buffer(10)]],
+    constant const int& num_heads [[buffer(11)]],
+    constant const float& scale [[buffer(12)]],
+    uint2 group_id [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]) {
+    constexpr int BQ = 16;
+    constexpr int BK = 32;
+    constexpr int MAX_E = 128;
+    constexpr int OUTPUTS_PER_LANE = MAX_E / BK;
+    constexpr int THREADS = BQ * BK;
+
+    const int n = group_id.x;
+    const int query_block = group_id.y;
+    const int query_row_in_block = simd_gid;
+    const int query_row = query_block * BQ + query_row_in_block;
+    const int thread_idx = query_row_in_block * BK + lane;
+    const bool query_valid = n < N && query_row < L;
+    const int q_kv_ratio = num_heads / num_kv_heads;
+    device const float* q_head = q + n * L * E;
+    device const float* k_head = k + (n / q_kv_ratio) * S * E;
+    device const float* v_head = v + (n / q_kv_ratio) * S * E;
+
+    threadgroup float q_tile[BQ * MAX_E];
+    threadgroup float kv_tile[BK * MAX_E];
+    threadgroup float probabilities[BQ * BK];
+
+    for (int idx = thread_idx; idx < BQ * MAX_E; idx += THREADS) {
+        const int row = idx / MAX_E;
+        const int dim = idx - row * MAX_E;
+        const int global_row = query_block * BQ + row;
+        q_tile[idx] = global_row < L && dim < E ? q_head[global_row * E + dim] : 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float output_fragment[OUTPUTS_PER_LANE] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+
+    const int total_kv_tiles = (S + BK - 1) / BK;
+    int kv_tile_limit = total_kv_tiles;
+    if (mask_mode == 1) {
+        const int last_query = min((query_block + 1) * BQ, L) - 1;
+        const int last_visible_key = last_query + (S - L);
+        kv_tile_limit = clamp((last_visible_key + 1 + BK - 1) / BK, 0, total_kv_tiles);
+    }
+
+    for (int tile_idx = 0; tile_idx < kv_tile_limit; tile_idx++) {
+        for (int idx = thread_idx; idx < BK * MAX_E; idx += THREADS) {
+            const int key = idx / MAX_E;
+            const int dim = idx - key * MAX_E;
+            const int global_key = tile_idx * BK + key;
+            kv_tile[idx] = global_key < S && dim < E ? k_head[global_key * E + dim] : 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const int key = tile_idx * BK + lane;
+        bool valid = query_valid && key < S;
+        if (mask_mode == 1) {
+            valid = valid && key <= query_row + (S - L);
+        }
+
+        float score = -INFINITY;
+        if (valid) {
+            score = 0.0f;
+            for (int dim = 0; dim < E; dim++) {
+                score += q_tile[query_row_in_block * MAX_E + dim] * kv_tile[lane * MAX_E + dim];
+            }
+            score *= scale;
+            if (mask_mode == 2) {
+                score += mask[n * L * S + query_row * S + key];
+            }
+        }
+
+        const float tile_max = simd_max(score);
+        const float new_max = max(running_max, tile_max);
+        const bool finite_row = new_max != -INFINITY;
+        const float previous_scale = running_max == -INFINITY || !finite_row
+            ? 0.0f
+            : fast::exp(running_max - new_max);
+        const float probability = score == -INFINITY || !finite_row ? 0.0f : fast::exp(score - new_max);
+        running_max = new_max;
+        running_sum = previous_scale * running_sum + simd_sum(probability);
+        probabilities[query_row_in_block * BK + lane] = probability;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BK * MAX_E; idx += THREADS) {
+            const int value_key = idx / MAX_E;
+            const int dim = idx - value_key * MAX_E;
+            const int global_key = tile_idx * BK + value_key;
+            kv_tile[idx] = global_key < S && dim < E ? v_head[global_key * E + dim] : 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (query_valid) {
+            for (int output_idx = 0; output_idx < OUTPUTS_PER_LANE; output_idx++) {
+                const int dim = lane + output_idx * BK;
+                if (dim < E) {
+                    float partial = 0.0f;
+                    for (int value_key = 0; value_key < BK; value_key++) {
+                        partial += probabilities[query_row_in_block * BK + value_key] *
+                            kv_tile[value_key * MAX_E + dim];
+                    }
+                    output_fragment[output_idx] = previous_scale * output_fragment[output_idx] + partial;
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (query_valid && running_sum != 0.0f) {
+        for (int output_idx = 0; output_idx < OUTPUTS_PER_LANE; output_idx++) {
+            const int dim = lane + output_idx * BK;
+            if (dim < E) {
+                out[n * L * E + query_row * E + dim] = output_fragment[output_idx] / running_sum;
+            }
+        }
+    }
+}

--- a/src/extensions_ref/src/flash_attention.metal
+++ b/src/extensions_ref/src/flash_attention.metal
@@ -27,38 +27,57 @@ using namespace metal;
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
 
-    int n = group_id.x;
-    int i = group_id.y; // loop over Tr
-    int a = simd_gid; // max=Br
-    int b = simd_lid; // max=Bc
+    constexpr int BR = 16;
+    constexpr int BC = 32;
+    constexpr int MAX_E = 128;
+    constexpr int OUTPUTS_PER_LANE = MAX_E / BC;
+    constexpr int THREADS_PER_GROUP = BR * BC;
 
-    bool is_i_in_range = i * Br + a < L && a < Br;
+    const int n = group_id.x;
+    const int query_block = group_id.y;
+    const int query_row_in_block = simd_gid;
+    const int query_row = query_block * BR + query_row_in_block;
+    const int lane = simd_lid;
+    const int thread_idx = query_row_in_block * BC + lane;
+    const bool query_in_range = n < N && query_row < L;
+
     const int q_kv_ratio = num_heads / num_kv_heads;
-    device const float *q_ptr = q + n * L * E + i * Br * E;
-    device const float *k_ptr_base = k + (n / q_kv_ratio) * S * E;
-    device const float *v_ptr_base = v + (n / q_kv_ratio) * S * E;
-    threadgroup float o_i[128 * 32]; // assume max(E) = 128, max(Br) = 32, only lane 0 writes to it
+    device const float* q_block = q + n * L * E + query_block * BR * E;
+    device const float* k_head = k + (n / q_kv_ratio) * S * E;
+    device const float* v_head = v + (n / q_kv_ratio) * S * E;
 
-    if (simd_lid == 0) {
-        for (int c = 0; c < E; c++) {
-            o_i[a * E + c] = 0.0;
-        }
+    // Q remains resident for the whole K/V traversal. K and V reuse the same
+    // storage because P is materialized before the K tile is replaced by V.
+    threadgroup float q_tile[BR * MAX_E];
+    threadgroup float kv_tile[BC * MAX_E];
+    threadgroup float p_tile[BR * BC];
+
+    for (int idx = thread_idx; idx < BR * MAX_E; idx += THREADS_PER_GROUP) {
+        const int row = idx / MAX_E;
+        const int dim = idx - row * MAX_E;
+        const bool valid = query_block * BR + row < L && dim < E;
+        q_tile[idx] = valid ? q_block[row * E + dim] : 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float output_frag[OUTPUTS_PER_LANE] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float row_max = -INFINITY;
+    float row_sum = 0.0f;
+
+    const int total_kv_tiles = (S + BC - 1) / BC;
+    int kv_tile_limit = total_kv_tiles;
+    if (mask_mode == 1) {
+        const int last_query = min((query_block + 1) * BR, L) - 1;
+        const int last_visible_key = last_query + (S - L);
+        kv_tile_limit = clamp((last_visible_key + 1 + BC - 1) / BC, 0, total_kv_tiles);
     }
 
-    threadgroup float q_local[32][128]; // assume max(E) = 128, max(Br) = 32, access by a, c
-    // q_ptr: L * E
-    // k_ptr: S * E
-    // v_ptr: S * E
-    // To access q[a, c]: use a * E + c
-    // To access k/v[b, c]: use b * E + c
-
-    float m_i = -1e9; // per thread; sync to threadgroup memory later
-    float l_i = 0.0; // per thread; sync to threadgroup memory later
-
-    // load q_local
-    if (simd_lid == 0) {
-        for (int c = 0; c < E; c++) {
-            q_local[a][c] = q_ptr[a * E + c];
+    for (int tile_idx = 0; tile_idx < kv_tile_limit; tile_idx++) {
+        for (int idx = thread_idx; idx < BC * MAX_E; idx += THREADS_PER_GROUP) {
+            const int row = idx / MAX_E;
+            const int dim = idx - row * MAX_E;
+            const int key_row = tile_idx * BC + row;
+            kv_tile[idx] = key_row < S && dim < E ? k_head[key_row * E + dim] : 0.0f;
         }
     }
     
@@ -124,29 +143,82 @@ using namespace metal;
         // compute o_i, where O is Br x E; note that this does not align
         // with the threadgroup we dispatch, so we have to do threadgroup sync
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (int c = 0; c < E; c++) {
-            float v;
-            if (is_i_in_range && is_j_in_range) {
-                v = p_a_b * v_ptr[b * E + c];
-            } else {
-                v = 0.0;
+
+        const int key_row = tile_idx * BC + lane;
+        bool score_is_valid = query_in_range && key_row < S;
+        if (mask_mode == 1) {
+            score_is_valid = score_is_valid && key_row <= query_row + (S - L);
+        }
+
+        float score = -INFINITY;
+        if (score_is_valid) {
+            score = 0.0f;
+            int dim = 0;
+            for (; dim + 3 < E; dim += 4) {
+                const int q_idx = query_row_in_block * MAX_E + dim;
+                const int k_idx = lane * MAX_E + dim;
+                const float4 qv = float4(q_tile[q_idx], q_tile[q_idx + 1], q_tile[q_idx + 2], q_tile[q_idx + 3]);
+                const float4 kv =
+                    float4(kv_tile[k_idx], kv_tile[k_idx + 1], kv_tile[k_idx + 2], kv_tile[k_idx + 3]);
+                score += dot(qv, kv);
             }
-            float res = simd_sum(v); // res = sum(p_a_b * v_j) on each cell
-            // only lane 0 will write to threadgroup memory
-            if (simd_lid == 0 && is_i_in_range && is_j_in_range) {
-                o_i[a * E + c] = m_i_diff_exp * o_i[a * E + c] + res;
+            for (; dim < E; dim++) {
+                score += q_tile[query_row_in_block * MAX_E + dim] * kv_tile[lane * MAX_E + dim];
+            }
+            score *= scale;
+
+            if (mask_mode == 2) {
+                const int64_t mask_idx =
+                    elem_to_loc(n * L * S + query_row * S + key_row, mask_shape, mask_strides, 3);
+                score += mask[mask_idx];
             }
         }
+
+        const float tile_row_max = simd_max(score);
+        const float new_row_max = max(row_max, tile_row_max);
+        const bool has_finite_score = new_row_max != -INFINITY;
+        const float previous_scale = row_max == -INFINITY ? 0.0f : fast::exp(row_max - new_row_max);
+        const float probability = score == -INFINITY || !has_finite_score ? 0.0f : fast::exp(score - new_row_max);
+        const float tile_row_sum = simd_sum(probability);
+
+        row_max = new_row_max;
+        row_sum = previous_scale * row_sum + tile_row_sum;
+        p_tile[query_row_in_block * BC + lane] = probability;
+
+        // All score reads from K and all writes to P must complete before the
+        // shared K buffer is reused for V.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BC * MAX_E; idx += THREADS_PER_GROUP) {
+            const int row = idx / MAX_E;
+            const int dim = idx - row * MAX_E;
+            const int value_row = tile_idx * BC + row;
+            kv_tile[idx] = value_row < S && dim < E ? v_head[value_row * E + dim] : 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (query_in_range) {
+            for (int frag = 0; frag < OUTPUTS_PER_LANE; frag++) {
+                const int dim = lane + frag * BC;
+                if (dim < E) {
+                    float partial = 0.0f;
+                    for (int key = 0; key < BC; key++) {
+                        partial += p_tile[query_row_in_block * BC + key] * kv_tile[key * MAX_E + dim];
+                    }
+                    output_frag[frag] = previous_scale * output_frag[frag] + partial;
+                }
+            }
+        }
+
+        // No thread may replace V with the next K tile while another SIMD
+        // group is still consuming it.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
-    // write to output
-    if (simd_lid == 0) {
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (int c = 0; c < E; c++) {
-            if (is_i_in_range && n < N) {
-                float o_i_c = o_i[a * E + c];
-                o_i_c /= l_i;
-                out[n * L * E + (i * Br + a) * E + c] = o_i_c;
+    if (query_in_range) {
+        for (int frag = 0; frag < OUTPUTS_PER_LANE; frag++) {
+            const int dim = lane + frag * BC;
+            if (dim < E) {
+                out[n * L * E + query_row * E + dim] = output_frag[frag] / row_sum;
             }
         }
     }

--- a/src/extensions_ref/src/flash_attention.metal
+++ b/src/extensions_ref/src/flash_attention.metal
@@ -93,6 +93,8 @@ inline void matrix_multiply_accumulate(
     uint3 group_id [[threadgroup_position_in_grid]],
     ushort simd_gid [[simdgroup_index_in_threadgroup]],
     ushort lane [[thread_index_in_simdgroup]]) {
+    // Week 2 Qwen keeps Q/K/V and output in BF16. Scores, online-softmax
+    // statistics, and output accumulators remain FP32 for numerical stability.
     constexpr int BQ = 64;
     constexpr int BK = 32;
     constexpr int SIMD_GROUPS = 8;

--- a/src/extensions_ref/src/flash_attention.metal
+++ b/src/extensions_ref/src/flash_attention.metal
@@ -1,5 +1,7 @@
 #include <metal_stdlib>
 #include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/attn/attn.h"
+#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
 
 using namespace metal;
 
@@ -223,3 +225,18 @@ using namespace metal;
         }
     }
 }
+
+// The scalar kernel above is intentionally kept as a readable, general
+// fallback. The production head dimension uses Metal SIMD-matrix operations
+// through MLX's Steel attention building block.
+instantiate_kernel(
+    "flash_attention_steel_f32_bq32_bk16_bd128_wm4_wn1_maskfloat32",
+    attention,
+    float,
+    32,
+    16,
+    128,
+    4,
+    1,
+    float,
+    float)

--- a/src/extensions_ref/src/tiny_llm_ext.h
+++ b/src/extensions_ref/src/tiny_llm_ext.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "mlx/utils.h"
 #include "mlx/primitives.h"
+#include "mlx/utils.h"
 
 namespace mx = mlx::core;
 
@@ -35,17 +35,18 @@ public:
 };
 
 mx::array flash_attention(const mx::array &q, const mx::array &k, const mx::array &v, const mx::array &mask,
-                          const float scale, const bool is_causal, const int num_kv_heads, const int num_heads,
+                          const float scale, const int mask_mode, const int num_kv_heads, const int num_heads,
                           mx::StreamOrDevice s = {});
-
-mx::array flash_attention_no_mask(const mx::array &q, const mx::array &k, const mx::array &v,
-                                  const float scale, const int num_kv_heads, const int num_heads, mx::StreamOrDevice s = {});
 
 class FlashAttention : public mx::Primitive {
 public:
-    explicit FlashAttention(mx::Stream stream, const float scale, const bool is_causal, const int num_kv_heads,
+    explicit FlashAttention(mx::Stream stream, const float scale, const int mask_mode, const int num_kv_heads,
                             const int num_heads)
-        : mx::Primitive(stream), scale_(scale), is_causal_(is_causal), num_kv_heads_(num_kv_heads), num_heads_(num_heads) {};
+        : mx::Primitive(stream),
+          scale_(scale),
+          mask_mode_(mask_mode),
+          num_kv_heads_(num_kv_heads),
+          num_heads_(num_heads) {};
 
     void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
     void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
@@ -59,7 +60,7 @@ public:
 
 private:
     float scale_;
-    bool is_causal_;
+    int mask_mode_;
     int num_kv_heads_;
     int num_heads_;
 };
@@ -72,7 +73,11 @@ class PagedAttention : public mx::Primitive {
 public:
     explicit PagedAttention(mx::Stream stream, const float scale, const bool is_causal, const int num_kv_heads,
                             const int num_heads)
-        : mx::Primitive(stream), scale_(scale), is_causal_(is_causal), num_kv_heads_(num_kv_heads), num_heads_(num_heads) {};
+        : mx::Primitive(stream),
+          scale_(scale),
+          is_causal_(is_causal),
+          num_kv_heads_(num_kv_heads),
+          num_heads_(num_heads) {};
 
     void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
     void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -55,7 +55,7 @@ def scaled_dot_product_attention_grouped(
 
     scores = mx.matmul(query, key.swapaxes(-2, -1)) * factor
     if mask is not None:
-        if mask == "causal":
+        if isinstance(mask, str) and mask == "causal":
             mask = causal_mask(L, S, scores.dtype)
             scores = scores + mask
         else:
@@ -125,6 +125,8 @@ def flash_attention(
 
     *B, H_q, L, E = query.shape
     _, H, S, _ = key.shape
+    assert key.shape == value.shape
+    assert query.shape[:-3] == key.shape[:-3]
     assert H_q % H == 0
     query = query.reshape(-1, L, E)
     key = key.reshape(-1, S, E)

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -121,7 +121,7 @@ def flash_attention(
     mask: mx.array | str | None = None,
 ) -> mx.array:
     factor = mx.rsqrt(query.shape[-1]) if scale is None else mx.array(scale)
-    factor = factor.astype(query.dtype)
+    factor = factor.astype(mx.float32)
 
     *B, H_q, L, E = query.shape
     _, H, S, _ = key.shape

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -55,7 +55,7 @@ def scaled_dot_product_attention_grouped(
 
     scores = mx.matmul(query, key.swapaxes(-2, -1)) * factor
     if mask is not None:
-        if isinstance(mask, str) and mask == "causal":
+        if mask == "causal":
             mask = causal_mask(L, S, scores.dtype)
             scores = scores + mask
         else:
@@ -125,8 +125,6 @@ def flash_attention(
 
     *B, H_q, L, E = query.shape
     _, H, S, _ = key.shape
-    assert key.shape == value.shape
-    assert query.shape[:-3] == key.shape[:-3]
     assert H_q % H == 0
     query = query.reshape(-1, L, E)
     key = key.reshape(-1, S, E)
@@ -134,22 +132,27 @@ def flash_attention(
     query = mx.contiguous(query)
     key = mx.contiguous(key)
     value = mx.contiguous(value)
-    is_causal = mask == "causal"
     N = query.shape[0]
-    if is_causal:
-        mask = mx.broadcast_to(causal_mask(L, S, mx.float32), (*B, H_q, L, S))
-    elif mask is None:
-        mask = mx.broadcast_to(mx.zeros((L, S), dtype=mx.float32), (*B, H_q, L, S))
+    if mask is None:
+        mask_mode = 0
+        mask = mx.zeros((1,), dtype=mx.float32)
+    elif isinstance(mask, str):
+        if mask != "causal":
+            raise ValueError(f"unsupported attention mask mode: {mask}")
+        mask_mode = 1
+        mask = mx.zeros((1,), dtype=mx.float32)
     else:
-        mask = mx.broadcast_to(mask, (*B, H_q, L, S))
-    mask = mx.contiguous(mask.reshape(N, L, S)).astype(mx.float32)
+        mask_mode = 2
+        mask = mx.contiguous(
+            mx.broadcast_to(mask, (*B, H_q, L, S)).reshape(N, L, S)
+        ).astype(mx.float32)
     result = tiny_llm_ext_ref.flash_attention(
         query,
         key,
         value,
         mask,
         factor,
-        is_causal=is_causal,
+        mask_mode=mask_mode,
         num_heads=H_q,
         num_kv_heads=H,
     )

--- a/src/tiny_llm_ref/qwen3_week2.py
+++ b/src/tiny_llm_ref/qwen3_week2.py
@@ -93,6 +93,8 @@ class Qwen3MultiHeadAttention:
                 mask=mask,
             ).astype(x.dtype)
         else:
+            if isinstance(mask, str) and mask == "causal":
+                mask = causal_mask(L, projection_k.shape[-2], mx.float32)
             x = scaled_dot_product_attention_grouped(
                 projection_q.astype(mx.float32),
                 projection_k.astype(mx.float32),

--- a/src/tiny_llm_ref/qwen3_week2.py
+++ b/src/tiny_llm_ref/qwen3_week2.py
@@ -86,19 +86,17 @@ class Qwen3MultiHeadAttention:
         )
         if self.use_flash_attention:
             x = flash_attention(
-                projection_q.astype(mx.float32),
-                projection_k.astype(mx.float32),
-                projection_v.astype(mx.float32),
+                projection_q,
+                projection_k,
+                projection_v,
                 scale=self.scale,
                 mask=mask,
             ).astype(x.dtype)
         else:
-            if isinstance(mask, str) and mask == "causal":
-                mask = causal_mask(L, projection_k.shape[-2], mx.float32)
             x = scaled_dot_product_attention_grouped(
-                projection_q.astype(mx.float32),
-                projection_k.astype(mx.float32),
-                projection_v.astype(mx.float32),
+                projection_q,
+                projection_k,
+                projection_v,
                 scale=self.scale,
                 mask=mask,
             ).astype(x.dtype)

--- a/tests_refsol/test_week_2_day_4.py
+++ b/tests_refsol/test_week_2_day_4.py
@@ -49,6 +49,7 @@ def attention_helper(
                 mask=mask,
             )
             mx.eval(user_output)  # so that any error will be caught here
+            assert user_output.dtype == precision
             comparison_precision = (
                 mx.bfloat16 if precision == mx.bfloat16 else mx.float16
             )
@@ -88,8 +89,8 @@ def assert_causal_mask_faster_than_all_zero_mask(
     s: int,
     e: int,
     scale: float = 0.9,
+    precision=mx.float32,
 ):
-    precision = mx.float32
     q_shape = (batch, h_q, l, e)
     kv_shape = (batch, h, s, e)
     mask_shape = (batch, h_q, l, s)
@@ -98,7 +99,7 @@ def assert_causal_mask_faster_than_all_zero_mask(
         query = mx.random.uniform(shape=q_shape, dtype=precision)
         key = mx.random.uniform(shape=kv_shape, dtype=precision)
         value = mx.random.uniform(shape=kv_shape, dtype=precision)
-        zero_mask = mx.zeros(shape=mask_shape, dtype=precision)
+        zero_mask = mx.zeros(shape=mask_shape, dtype=mx.float32)
 
         for _ in range(3):
             mx.eval(flash_attention(query, key, value, scale=scale, mask="causal"))
@@ -182,16 +183,11 @@ def test_task_3_flash_attention_gpu(mask_mode: str):
 
 @pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
 def test_task_3_flash_attention_gpu_large(mask_mode: str):
-    attention_helper(mx.gpu, 28, 4, 16, 128, 16, 3, mask_mode)
+    attention_helper(mx.gpu, 28, 4, 16, 128, 16, 3, mask_mode, precision=mx.bfloat16)
 
 
 @pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
 def test_task_3_flash_attention_gpu_d128_partial_tiles(mask_mode: str):
-    attention_helper(mx.gpu, 8, 2, 35, 128, 47, 1, mask_mode)
-
-
-@pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
-def test_task_3_flash_attention_gpu_bf16_d128(mask_mode: str):
     attention_helper(mx.gpu, 8, 2, 35, 128, 47, 1, mask_mode, precision=mx.bfloat16)
 
 
@@ -204,4 +200,5 @@ def test_task_3_flash_attention_gpu_causal_mask_faster_than_all_zero_mask():
         l=512,
         s=512,
         e=128,
+        precision=mx.bfloat16,
     )

--- a/tests_refsol/test_week_2_day_4.py
+++ b/tests_refsol/test_week_2_day_4.py
@@ -1,8 +1,9 @@
 import pytest
 import time
 import mlx.core as mx
-from .tiny_llm_base import *
-from .utils import *
+from tiny_llm_ref import flash_attention
+
+from .utils import AVAILABLE_STREAMS, AVAILABLE_STREAMS_IDS, assert_allclose
 
 
 def attention_helper(stream: mx.Stream, H_q, H, L, E, S, BATCH, mask_mode: str):

--- a/tests_refsol/test_week_2_day_4.py
+++ b/tests_refsol/test_week_2_day_4.py
@@ -1,13 +1,21 @@
 import pytest
 import time
 import mlx.core as mx
-from tiny_llm_ref import flash_attention
+from .tiny_llm_base import *
+from .utils import *
 
-from .utils import AVAILABLE_STREAMS, AVAILABLE_STREAMS_IDS, assert_allclose
 
-
-def attention_helper(stream: mx.Stream, H_q, H, L, E, S, BATCH, mask_mode: str):
-    precision = mx.float32
+def attention_helper(
+    stream: mx.Stream,
+    H_q,
+    H,
+    L,
+    E,
+    S,
+    BATCH,
+    mask_mode: str,
+    precision=mx.float32,
+):
     with mx.stream(stream):
         q_shape = (BATCH, H_q, L, E)
         kv_shape = (BATCH, H, S, E)
@@ -41,7 +49,12 @@ def attention_helper(stream: mx.Stream, H_q, H, L, E, S, BATCH, mask_mode: str):
                 mask=mask,
             )
             mx.eval(user_output)  # so that any error will be caught here
-            assert_allclose(user_output, reference_output, precision=mx.float16)
+            comparison_precision = (
+                mx.bfloat16 if precision == mx.bfloat16 else mx.float16
+            )
+            assert_allclose(
+                user_output, reference_output, precision=comparison_precision
+            )
 
 
 def time_flash_attention(
@@ -170,6 +183,16 @@ def test_task_3_flash_attention_gpu(mask_mode: str):
 @pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
 def test_task_3_flash_attention_gpu_large(mask_mode: str):
     attention_helper(mx.gpu, 28, 4, 16, 128, 16, 3, mask_mode)
+
+
+@pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
+def test_task_3_flash_attention_gpu_d128_partial_tiles(mask_mode: str):
+    attention_helper(mx.gpu, 8, 2, 35, 128, 47, 1, mask_mode)
+
+
+@pytest.mark.parametrize("mask_mode", ["no_mask", "mask", "causal"])
+def test_task_3_flash_attention_gpu_bf16_d128(mask_mode: str):
+    attention_helper(mx.gpu, 8, 2, 35, 128, 47, 1, mask_mode, precision=mx.bfloat16)
 
 
 def test_task_3_flash_attention_gpu_causal_mask_faster_than_all_zero_mask():


### PR DESCRIPTION
## Why

The existing Metal kernel follows the FlashAttention dataflow but performs QKᵀ and PV with scalar arithmetic. It saves quadratic memory but gives up enough matrix throughput to be slower than explicit attention. Week 2 also unnecessarily upcasts Qwen's BF16 attention activations to FP32.

## What changed

- Replace the MLX Steel experiment with a standalone D=128 BF16 Metal kernel built only from public `simdgroup_matrix` operations.
- Compute QKᵀ and PV as 8×8 matrix fragments with FP32 softmax statistics and accumulation, a 64×32 tile, causal tile skipping, GQA mapping, and about 25 KiB of reused threadgroup storage.
- Preserve BF16 Q/K/V and output through Qwen3 attention, keep scale, masks, softmax state, and matrix accumulation in FP32, and avoid dense causal or no-op masks.
- Make BF16 the default tested D=128 GPU contract while keeping a readable FP32 scalar correctness fallback, with partial-tile, GQA, additive-mask, and causal-offset coverage.
- Add synchronized Qwen3-4B prefill benchmarks and update the existing FlashAttention chapter with the standalone implementation, the exact MLX 0.29.1 Steel performance differences, eight ordered follow-up exercises, and measured Metal tradeoffs.
- Add a 21-item inventory of every implemented optimization across the Python wrapper, C++ dispatch, and Metal shader, including the less-visible lane reductions, barrier placement, tail handling, and final normalization; explicitly separate these from techniques that remain follow-up exercises.
- Record that `gh` is available in this repository's agent guidance.

## Measured impact

On Apple M4 Pro with MLX 0.29.1, single-request Qwen3-4B causal BF16 prefill takes 19.015 ms at 2048 tokens and 72.717 ms at 4096 tokens. Explicit attention takes 17.084 ms and 66.724 ms respectively, so this educational kernel does not claim a latency win. It does avoid the quadratic score tensor, which is about 1 GiB at 4096 tokens; MLX fused attention remains the production-performance reference at 5.584 ms and 21.181 ms.

Validation: 23 Week 2 Day 4 tests, 3 cached Qwen3-4B integration tests, 15 Qwen3-4B benchmark cases, extension build, and mdBook build all pass.

_AI-assisted: Codex._
