### PR TITLE
Optimize Week 3 paged attention

### DIFF
--- a/batch-main.py
+++ b/batch-main.py
@@ -42,12 +42,23 @@ parser.add_argument("--device", type=str, default="gpu")
 parser.add_argument("--batch-size", type=int, default=5)
 parser.add_argument("--prefill-step", type=int, default=128)
 parser.add_argument("--max-seq-len", type=int, default=512)
-parser.add_argument("--enable-flash-attn", action="store_true")
+flash_group = parser.add_mutually_exclusive_group()
+flash_group.add_argument(
+    "--enable-flash-attn", dest="enable_flash_attn", action="store_true"
+)
+flash_group.add_argument(
+    "--disable-flash-attn", dest="enable_flash_attn", action="store_false"
+)
+parser.set_defaults(enable_flash_attn=None)
 parser.add_argument("--enable-performance-lab", action="store_true")
 parser.add_argument("--enable-thinking", action="store_true")
 args = parser.parse_args()
 
-if args.loader == "week3" and args.enable_flash_attn and args.device != "gpu":
+if (
+    args.loader == "week3"
+    and args.enable_flash_attn is not False
+    and args.device != "gpu"
+):
     parser.error("Week 3 FlashAttention requires --device gpu")
 
 if args.solution == "tiny_llm":

--- a/bench.py
+++ b/bench.py
@@ -40,7 +40,14 @@ def parse_args() -> argparse.Namespace:
         default="week2",
         choices=["week1", "week2", "week3"],
     )
-    parser.add_argument("--enable-flash-attn", action="store_true")
+    flash_group = parser.add_mutually_exclusive_group()
+    flash_group.add_argument(
+        "--enable-flash-attn", dest="enable_flash_attn", action="store_true"
+    )
+    flash_group.add_argument(
+        "--disable-flash-attn", dest="enable_flash_attn", action="store_false"
+    )
+    parser.set_defaults(enable_flash_attn=None)
     parser.add_argument("--enable-performance-lab", action="store_true")
     parser.add_argument(
         "--disable-paged-attention",
@@ -106,7 +113,7 @@ def validate_args(args: argparse.Namespace) -> None:
     if (
         args.solution != "mlx"
         and args.loader == "week3"
-        and args.enable_flash_attn
+        and args.enable_flash_attn is not False
         and args.device != "gpu"
     ):
         raise ValueError("Week 3 FlashAttention requires --device gpu")

--- a/bench_course_progression.py
+++ b/bench_course_progression.py
@@ -34,7 +34,13 @@ MLX_VARIANT = Variant("mlx", "MLX", "mlx", "week2")
 COURSE_VARIANTS = (
     WEEK1_VARIANT,
     Variant("week2", "Week 2 decode", "ref", "week2"),
-    Variant("week3-paged", "Week 3 paged (Flash off)", "ref", "week3"),
+    Variant(
+        "week3-paged",
+        "Week 3 paged (Flash off)",
+        "ref",
+        "week3",
+        ("--disable-flash-attn",),
+    ),
     Variant(
         "week3-flash",
         "Week 3 paged + FlashAttention",
@@ -47,7 +53,7 @@ COURSE_VARIANTS = (
         "Week 3 paged + lab",
         "ref",
         "week3",
-        ("--enable-performance-lab",),
+        ("--disable-flash-attn", "--enable-performance-lab"),
     ),
     Variant(
         "week3-flash-lab",

--- a/book/src/appendix-performance.md
+++ b/book/src/appendix-performance.md
@@ -67,22 +67,23 @@ introduce the features.
 
 | Checkpoint | Prefill tok/s | Versus Week 1 | Gap to MLX | Decode tok/s | Versus Week 1 | Gap to MLX |
 |---|---:|---:|---:|---:|---:|---:|
-| Week 1 readable model | 3,340.46 | baseline | 24.2% slower | 19.48 | baseline | 94.0% slower |
-| Week 2 decode checkpoint | 778.71 | 76.7% slower | 82.3% slower | 239.48 | 12.29x | 26.5% slower |
-| Week 3 paged stack (Flash off) | 655.47 | 80.4% slower | 85.1% slower | 37.82 | 1.94x | 88.4% slower |
-| Week 3 paged stack + FlashAttention | 742.93 | 77.8% slower | 83.1% slower | 37.67 | 1.93x | 88.4% slower |
-| Week 3 paged stack + performance lab | 1,118.09 | 66.5% slower | 74.6% slower | 37.84 | 1.94x | 88.4% slower |
-| Week 3 paged stack + FlashAttention + performance lab | 1,420.27 | 57.5% slower | 67.8% slower | 37.70 | 1.94x | 88.4% slower |
-| MLX | 4,407.38 | 1.32x | baseline | 325.70 | 16.72x | baseline |
+| Week 1 readable model | 3,342.45 | baseline | 24.1% slower | 19.49 | baseline | 93.4% slower |
+| Week 2 decode checkpoint | 1,012.27 | 69.7% slower | 77.0% slower | 240.17 | 12.32x | 18.5% slower |
+| Week 3 paged stack (Flash off) | 987.25 | 70.5% slower | 77.6% slower | 206.96 | 10.62x | 29.8% slower |
+| Week 3 paged stack + FlashAttention | 983.90 | 70.6% slower | 77.7% slower | 206.33 | 10.59x | 30.0% slower |
+| Week 3 paged stack + performance lab | 1,948.88 | 41.7% slower | 55.7% slower | 205.40 | 10.54x | 30.3% slower |
+| Week 3 paged stack + FlashAttention + performance lab | 1,956.79 | 41.5% slower | 55.6% slower | 204.80 | 10.51x | 30.5% slower |
+| MLX | 4,402.94 | 1.32x | baseline | 294.75 | 15.12x | baseline |
 
 Week 1 prefill is fast because it materializes dense 16-bit weights and uses
 efficient dense matrix multiplication. Week 2 deliberately optimizes the
 memory-bound one-token decode shape first; its readable scalar quantized
 prefill path therefore regresses. Week 3's optional SIMD-matrix lab recovers
-part of that prefill gap. The current paged-attention kernel dominates Week 3
-decode and is a teaching implementation, not a claim of production speed. The
-runner releases every request cache, including warmups, so paged checkpoints
-reuse allocator capacity rather than timing pool growth left by an earlier run.
+part of that prefill gap. The paged vector decode kernel now stays close to the
+dense course kernel, while page-cache and serving-runtime overhead leave the
+single-request checkpoint about 13.8% behind Week 2 decode. The runner releases
+every request cache, including warmups, so paged checkpoints reuse allocator
+capacity rather than timing pool growth left by an earlier run.
 
 ## Week 1: Establish the Readable Baseline
 
@@ -111,20 +112,20 @@ reuse allocator capacity rather than timing pool growth left by an earlier run.
 
 | Chapter | What improves | Performance reality |
 |---|---|---|
-| 3.1 Continuous Batching | Reuses decode slots as requests finish and keeps multiple requests active. | Improves aggregate utilization, not single-request latency. In one four-request snapshot, dense batching reached 288.4 aggregate decode tok/s versus 240.4 for one Week 2 request; do not treat different batch sizes as a kernel speedup. |
-| 3.2 FlashAttention | Streams K/V tiles with online softmax and bounds scratch memory instead of materializing `L x S`. | As a reverse ablation inside the completed paged stack, enabling it improved prefill from 655.47 to 742.93 tok/s (+13.3%) but remained 83.1% below MLX. Decode did not move. The standalone course kernel is about 9% slower than explicit attention at 4096 tokens and about 3.4x slower than MLX at 2048, while avoiding roughly 1 GiB of scores at the documented 4096-token Qwen3-4B shape. |
+| 3.1 Continuous Batching | Reuses decode slots as requests finish and keeps multiple requests active. | Improves aggregate utilization, not single-request latency. In one four-request snapshot, dense batching reached 305.3 aggregate decode tok/s versus 240.2 for one Week 2 request; do not treat different batch sizes as a kernel speedup. |
+| 3.2 FlashAttention | Streams K/V tiles with online softmax and bounds scratch memory instead of materializing `L x S`. | At the short 128-token progression shape, enabling dense FlashAttention left prefill effectively unchanged at 987.25 versus 983.90 tok/s. Its opportunity is long prefill, and Day 5 reuses its BF16 SIMD-matrix recurrence for paged prefill. Decode uses a separate vector kernel. |
 | 3.3 Chunked Prefill | Bounds how long a prompt can delay active decoders. | Primarily improves fairness and time-to-next-token. Smaller chunks add launches and may reduce aggregate throughput; report both latency and throughput. |
-| 3.4 Paged Attention, Part 1 | Allocates a paged KV cache with fixed-size reusable pages and separates logical context from physical storage. | Improves capacity, reuse, removal, and fragmentation. It is an allocator/usability gain; no raw kernel speedup is claimed. |
-| 3.5 Paged Attention, Part 2 | Reads K/V through page tables without rebuilding dense per-request K/V. | The current operator is about 4.4-16.7x slower than MLX across the documented batch/context cases. The end-to-end paged model reached 37.82 decode tok/s, about 88.4% below MLX. |
+| 3.4 Paged Attention, Part 1 | Allocates a paged KV cache with fixed-size reusable pages and separates logical context from physical storage. | Per-layer pools grow geometrically and share storage across requests in that layer. This improves capacity, reuse, removal, and fragmentation without serializing every layer through one backing tensor. |
+| 3.5 Paged Attention, Part 2 | Reads K/V through page tables without rebuilding dense per-request K/V. | The BF16 decode operator is approximately matched with the dense course kernel across the documented batch/context cases. The single-request paged checkpoint reached 206.96 decode tok/s, 29.8% below MLX; the matched four-request serving run reached 348.75 aggregate decode tok/s. |
 | 3.6 Optional MoE | Routes tokens through selected experts and supports sparse Qwen3 variants. | Expands model coverage and can reduce active parameter work, but the course has no controlled dense-versus-MoE speed claim. |
-| 3.7 Optional Performance Lab | Adds SIMD-matrix quantized prefill, direct quantized embedding, and last-token projection analysis. | Without FlashAttention, it improved the completed paged stack from 655.47 to 1,118.09 prefill tok/s (+70.6%) and remained 74.6% below MLX. With FlashAttention, it improved 742.93 to 1,420.27 prefill tok/s (+91.2%) and remained 67.8% below MLX. Paged decode remained about 37.8 tok/s. |
+| 3.7 Optional Performance Lab | Adds SIMD-matrix quantized prefill, direct quantized embedding, and last-token projection analysis. | Without dense FlashAttention, it improved the completed paged stack from 987.25 to 1,948.88 prefill tok/s (+97.4%) and remained 55.7% below MLX. With FlashAttention, it improved 983.90 to 1,956.79 tok/s (+98.9%) and remained 55.6% below MLX. Paged decode remained about 205 tok/s. |
 | 3.8 Optional Speculative Decoding | Drafts several tokens and verifies them with the target model. | Work in progress. Speed depends on acceptance rate and cache-rewind cost; no result should be claimed yet. |
 
-Paged attention is currently slower even under batching. In one matched
-four-request snapshot, the dense compatibility path reached 288.4 aggregate
-decode tok/s while the Week 3 paged path reached 26.6 tok/s. Paging still
-teaches the correct ownership and memory-management structure, but the page
-walker needs a decode-specific schedule before it becomes a performance win.
+In one matched four-request snapshot, the dense path reached 305.31 aggregate
+decode tok/s while the Week 3 paged path reached 348.75 tok/s. This is not a
+universal paged-kernel speedup: it is an end-to-end serving result that includes
+avoided repacking and cache reuse. The isolated operator remains close to the
+dense course kernel and behind MLX.
 
 ## Week 4: Measure Application Quality Separately
 

--- a/book/src/week3-04-paged-attention-part1.md
+++ b/book/src/week3-04-paged-attention-part1.md
@@ -117,6 +117,15 @@ Keep logical `num_pages` separate from physical capacity so callers still see
 only allocated pages while pool growth copies old storage logarithmically many
 times.
 
+Growing an exact-size slab from `p` to `p + 1` pages copies approximately
+`1 + 2 + ... + p` old pages, which is quadratic in the final page count.
+Starting with four pages and doubling capacity copies fewer than twice the
+eventual capacity across all growth events. Splitting the slab by transformer
+layer also prevents a new page in layer 0 from replacing the storage object
+used by every other layer. These two changes amortize allocator-copy work so
+most new-page allocations do not copy old pages, without changing the logical
+page table.
+
 In the reference solution, this becomes `TinyKvPagedPool`.
 
 ## 2. `PagedRequestCache`
@@ -270,6 +279,11 @@ Design layer-owned page pools that:
 - supports writing a chunk into page storage,
 - grows backing capacity geometrically,
 - is shared by all request caches for that layer, but not by other layers.
+
+Test logical size and physical capacity separately. Allocating the fifth page,
+for example, may create capacity for eight pages, but `key_pages` and
+`value_pages` exposed to the attention runtime should contain only the five
+allocated page ids.
 
 ## Task 2: Design `PagedRequestCache`
 

--- a/book/src/week3-04-paged-attention-part1.md
+++ b/book/src/week3-04-paged-attention-part1.md
@@ -76,7 +76,11 @@ page  3 -> tokens 8..9
 
 The logical sequence is still length 10. The difference is that the runtime is no longer forced to represent it as one contiguous tensor.
 
-In our Part 1 teaching implementation, those fixed-size pages live in one shared **page pool** owned by the model. Every layer cache receives that same pool, but each layer cache keeps its own `page_ids`, `page_lens`, and `offset`.
+In our Part 1 teaching implementation, the model owns one physical **page
+pool per transformer layer**. Request caches for the same layer share its pool,
+while every request-and-layer cache keeps its own `page_ids`, `page_lens`, and
+`offset`. A page id is therefore local to one layer, matching the K/V storage
+buffer that the attention kernel receives.
 
 In the reference solution, `page_size` is the physical page capacity. Unused tail slots are not part of the logical sequence; `page_lens` decides which prefix of each page is valid.
 
@@ -85,7 +89,7 @@ In the reference solution, `page_size` is the physical page capacity. Unused tai
 The page abstraction gives us two immediate wins:
 
 1. Appending a token usually updates only the current tail page in the pool.
-2. Finished requests can return their pages to a shared free list.
+2. Finished requests can return their pages to the layer's shared free list.
 
 This is the key memory-management idea behind paged attention systems such as vLLM.
 
@@ -93,15 +97,25 @@ This is the key memory-management idea behind paged attention systems such as vL
 
 ## 1. `PagePool`
 
-The model should own one pool with a model-wide page allocator and flat K/V page storage:
+The model should own one pool per layer, each with a free-page allocator and
+flat K/V page storage:
 
 ```plain
-free_pages: available page ids for the whole model
+free_pages: available page ids for this layer
 keys[page_id]:   physical key page
 values[page_id]: physical value page
 ```
 
-Each layer still has distinct K/V contents because each layer cache allocates its own physical pages. In this teaching version, each layer cache also has its own logical page table. That is simpler than nano-vllm's shared block table: layer 0 might own pages `[0, 1]`, while layer 1 owns pages `[2, 3]`, but both page sets came from the same model-owned pool.
+Requests share physical storage only when they are executing the same layer.
+Layer 0 and layer 1 may both use page ids `[0, 1]` because those ids address
+different buffers. Keeping the layer dimension outside `page_id` prevents a
+one-token write in one layer from copying or serializing the page storage for
+every other layer.
+
+The backing slab should grow geometrically rather than by exactly one page.
+Keep logical `num_pages` separate from physical capacity so callers still see
+only allocated pages while pool growth copies old storage logarithmically many
+times.
 
 In the reference solution, this becomes `TinyKvPagedPool`.
 
@@ -186,7 +200,7 @@ The cleanest first implementation is **paged storage with dense gather**.
 
 That means:
 
-- pages in the shared pool are the source of truth,
+- pages in each layer pool are the source of truth,
 - layer caches stop owning one monolithic K/V tensor,
 - layer caches only track page metadata,
 - attention still receives dense K/V reconstructed from pages.
@@ -238,8 +252,9 @@ Before implementing, make sure the following are clear:
 1. What page size should this repo use for teaching?
 2. How do we represent the free-page allocator?
 3. How do we prove that paged storage reconstructs the same logical KV as `TinyKvFullCache`?
-4. How do layer cache handles share one pool while keeping their own page metadata?
+4. How do request cache handles share a layer pool while keeping their own page metadata?
 5. When do we materialize page writes to avoid MLX lazy-graph growth?
+6. How do we grow physical capacity without copying all old pages on every allocation?
 
 ## Task 1: Design `PagePool`
 
@@ -247,13 +262,14 @@ Before implementing, make sure the following are clear:
 src/tiny_llm/paged_kv_cache.py
 ```
 
-Design a model-owned page pool that:
+Design layer-owned page pools that:
 
-- owns the model-wide free-page allocator,
+- own one free-page allocator per layer,
 - stores flat fixed-size K/V pages,
 - allocates and frees page ids,
 - supports writing a chunk into page storage,
-- is shared by every layer cache created by the model.
+- grows backing capacity geometrically,
+- is shared by all request caches for that layer, but not by other layers.
 
 ## Task 2: Design `PagedRequestCache`
 

--- a/book/src/week3-05-paged-attention-part2.md
+++ b/book/src/week3-05-paged-attention-part2.md
@@ -4,7 +4,15 @@
 
 In this chapter, we move from **paged KV storage** to the runtime metadata and execution path needed for **real paged attention**.
 
-Part 1 introduced fixed-size pages, a model-owned page pool shared by layer caches, and per-layer page metadata. That change already improves the storage abstraction, but it does not yet remove the dense gather before attention. To get the full benefit, the attention path itself must understand how to read from pages.
+Part 1 introduced fixed-size pages, one model-owned physical pool per layer,
+and request-local page metadata. That change already improves the storage
+abstraction, but it does not yet remove the dense gather before attention. To
+get the full benefit, the attention path itself must understand how to read
+from pages.
+
+> **Prerequisite:** Complete Day 2 FlashAttention before this chapter. Paged
+> prefill reuses its BF16 SIMD-matrix tiles and online-softmax recurrence; the
+> new concept here is translating logical K/V positions through a block table.
 
 ## Paged KV Cache vs Paged Attention
 
@@ -150,7 +158,15 @@ logical key position -> logical page -> physical page id -> slot in page
 ```
 
 After that lookup, the online-softmax update is the same idea as Day 2
-FlashAttention. We still avoid a dense K/V gather before attention.
+FlashAttention. For BF16 prefill, reuse the Day 2 SIMD-matrix tile directly and
+replace only its dense K/V loads with page-table loads. We still avoid a dense
+K/V gather before attention.
+
+One-token decode needs a different work decomposition. A 64-row prefill tile
+would leave almost every query row idle, so dispatch short queries to a
+vector-oriented kernel that partitions the context across SIMD groups and
+merges their partial online-softmax states. Do not run decode through a fixed
+32-row scalar prefill tile.
 
 The page pool should therefore expose contiguous physical storage:
 
@@ -229,7 +245,7 @@ src/extensions/src/paged_attention.cpp
 src/extensions/src/paged_attention.metal
 ```
 
-Add a paged attention interface whose inputs come from the paged runtime rather than a dense reconstructed `S` dimension.
+Add a paged attention interface whose inputs come from the paged runtime rather than a dense reconstructed `S` dimension. Preserve BF16 Q/K/V and output; scores, softmax statistics, and output accumulators remain FP32.
 
 The reference solution walks every request's block table and keeps online
 softmax state:
@@ -244,6 +260,15 @@ After all visible pages are consumed, divide `output` by `running_sum`.
 This is the key idea that lets the kernel avoid materializing dense K/V while
 still producing the same result as dense attention.
 
+Implement two GPU dispatches:
+
+1. For `L <= 8`, partition logical context positions across SIMD groups and
+   merge their partial `(max, sum, output)` states in threadgroup memory.
+2. For BF16 `D == 128` prefill, start from Day 2's SIMD-matrix FlashAttention
+   kernel and resolve each staged K/V row through `block_table`.
+
+Keep a scalar FP32 path for small correctness fixtures and the CPU reference.
+
 ## Task 3: Dispatch from the Model
 
 ```
@@ -252,14 +277,14 @@ src/tiny_llm/qwen3_week3.py
 
 Update the model so it can route to paged attention when the cache provides paged runtime metadata.
 
-The optional dense FlashAttention prefill and the paged decode path must share
-one request cache. When `enable_flash_attn=True` and the current query has more
-than eight tokens, append BF16 K/V to the paged cache, gather its logical dense
-view, and run the Week 3 FlashAttention kernel. Subsequent short decode steps
-append the same BF16 dtype and pass page metadata directly to paged attention.
-The paged wrapper may promote values at its extension boundary, but changing
-the cache dtype between prefill and decode is an error. Keep this dispatch
-behind the Week 3 model so Week 2 remains independent.
+The optional dense FlashAttention prefill and the paged paths must share one
+request cache. When `enable_flash_attn=True` and the current query has more than
+eight tokens, append BF16 K/V to the paged cache, gather its logical dense view,
+and run the Day 2 FlashAttention kernel. Otherwise, pass page metadata to the
+paged BF16 prefill kernel. Subsequent short decode steps always use the
+vector-oriented paged kernel. Neither path may upcast the complete Q/K/V
+tensors or change cache dtype. Keep this dispatch behind the Week 3 model so
+Week 2 remains independent.
 
 ## Task 4: Connect It to Continuous Batching
 
@@ -271,32 +296,30 @@ Update request admission, slot reuse, and request removal so that:
 
 - finished requests free their pages,
 - in this teaching implementation, that means freeing pages from every layer cache,
-- new requests allocate from the shared pool,
+- new requests allocate from the corresponding layer pool,
 - active decode steps reuse page metadata instead of rebuilding dense K/V.
 
 After this chapter, the serving stack has the right structure for a real high-throughput runtime: paging is no longer just a storage trick, but part of the execution model itself.
 
 ## Performance Reality on Apple Silicon
 
-The current course kernel proves that attention can walk pages without a dense
-K/V repack, but it is not faster yet. On the same M4 Pro operator benchmark,
-representative timings were:
+The optimized course kernel shows that page walking itself can be close to the
+dense decode path when both use the same BF16/vector decomposition. On an M4
+Pro operator benchmark, representative synchronized decode timings were:
 
 | Batch / context | Dense course attention | Course paged attention | MLX attention |
 |---|---:|---:|---:|
-| 1 / 128 | 175 µs | 784 µs | 144 µs |
-| 1 / 512 | 217 µs | 694 µs | 157 µs |
-| 1 / 2048 | 315 µs | 2,100 µs | 204 µs |
-| 8 / 512 | 489 µs | 3,553 µs | 304 µs |
-| 8 / 2048 | 1,371 µs | 13,611 µs | 816 µs |
+| 1 / 128 | 226 µs | 219 µs | 170 µs |
+| 1 / 512 | 300 µs | 309 µs | 192 µs |
+| 1 / 2048 | 729 µs | 726 µs | 263 µs |
+| 8 / 512 | 800 µs | 626 µs | 225 µs |
+| 8 / 2048 | 1,347 µs | 1,322 µs | 460 µs |
 
-The page-table loads and irregular access are real costs. Paged attention can
-improve a Mac serving system when it avoids repeated dense repacks, admits more
-concurrent requests, and reuses pages over many scheduling steps. To improve
-the kernel itself, group adjacent logical pages, coalesce K/V loads within a
-SIMD group, keep online-softmax state in registers, specialize the one-token
-decode case, and batch page-table metadata once per scheduler step. Measure
-aggregate request throughput and memory use as well as kernel latency.
+The page-table loads and irregular access are still real costs. Paged attention
+earns its place by avoiding repeated dense repacks, admitting more concurrent
+requests, and reusing pages over many scheduling steps—not by making every
+isolated kernel faster than MLX. Measure aggregate request throughput and
+memory use as well as kernel latency.
 
 ```bash
 pdm run test --week 3 --day 5

--- a/book/src/week3-05-paged-attention-part2.md
+++ b/book/src/week3-05-paged-attention-part2.md
@@ -130,6 +130,34 @@ The runtime should be able to:
 
 This is the point where decode stops paying the repeated dense-repack cost from Day 1.
 
+## Why the First Paged Kernel Was Slow
+
+The first correct implementation used one scalar FP32 prefill schedule for
+every query length. That combined three expensive choices during decode:
+
+1. It promoted complete BF16 Q/K/V tensors to FP32 and converted the result
+   back, doubling their storage traffic and adding conversion work.
+2. Its threadgroup reserved work for 32 query rows even when decode supplied
+   one row, so almost all of the query-row parallelism was idle.
+3. It walked K/V serially inside that under-filled tile instead of splitting a
+   long context across independent SIMD groups.
+
+Paged addressing was therefore not the main explanation for the end-to-end
+gap. The schedule was mismatched to the decode shape. The optimized design
+preserves BF16 storage, keeps only dot products and online-softmax state in
+FP32, and chooses a different kernel according to query shape.
+
+| Shape | Course-owned dispatch | Work decomposition |
+|---|---|---|
+| `L <= 8`, FP32 or BF16 | Vector paged decode | One threadgroup per query row; 32 SIMD groups stride over the context and merge partial `(max, sum, output)` states. |
+| `L > 8`, BF16, `D == 128` | SIMD-matrix paged prefill | Eight SIMD groups cover a 64-row query block, stage 32 K/V rows at a time through the block table, and use 8×8 matrix fragments. |
+| `L > 8`, FP32 | Scalar paged prefill | A small correctness/reference path with 16 query rows and 32 K/V rows per tile. |
+| CPU FP32 | Scalar reference | A readable oracle used for correctness rather than the performance target. |
+
+The threshold is deliberately part of the extension dispatch rather than a
+Python conversion or dense fallback. Students can benchmark each shape while
+the model-facing `paged_attention` API remains unchanged.
+
 ## How This Maps to `tiny-llm`
 
 ### `src/tiny_llm/attention.py`
@@ -263,9 +291,13 @@ still producing the same result as dense attention.
 Implement two GPU dispatches:
 
 1. For `L <= 8`, partition logical context positions across SIMD groups and
-   merge their partial `(max, sum, output)` states in threadgroup memory.
+   merge their partial `(max, sum, output)` states in threadgroup memory. The
+   reference schedule uses 32 SIMD groups per query so group `g` visits
+   positions `g`, `g + 32`, `g + 64`, and so on.
 2. For BF16 `D == 128` prefill, start from Day 2's SIMD-matrix FlashAttention
-   kernel and resolve each staged K/V row through `block_table`.
+   kernel and resolve each staged K/V row through `block_table`. Use a 64-row
+   query block and 32-row K/V tiles so all eight SIMD groups own useful query
+   rows.
 
 Keep a scalar FP32 path for small correctness fixtures and the CPU reference.
 
@@ -303,6 +335,20 @@ tensors or change cache dtype. Keep this dispatch behind the Week 3 model so
 Week 2 remains independent. The final Week 3 model selects FlashAttention
 prefill automatically for supported `D == 128` models; `--disable-flash-attn`
 exists only for the measured paged-prefill ablation.
+
+This creates the final routing policy:
+
+```plain
+fresh prefill, L > 8, D == 128 -> Day 2 dense FlashAttention on fresh K/V
+long prefill with cached history -> paged BF16 SIMD-matrix attention
+decode or another short chunk    -> paged vector attention
+```
+
+All three paths write or retain the same paged cache. The first path is
+"zero-gather" because it stores fresh K/V in the cache but attends to the
+already-available projection tensors instead of gathering an equivalent dense
+copy back out. `--disable-paged-attention` is a Day 4 dense-gather teaching
+ablation, not the completed Day 5 serving path.
 
 ## Task 4: Connect It to Continuous Batching
 

--- a/book/src/week3-05-paged-attention-part2.md
+++ b/book/src/week3-05-paged-attention-part2.md
@@ -279,9 +279,10 @@ reconstruct dense K/V and express the paged operator as MLX matmul plus
 softmax. MLX SDPA may appear only in tests and benchmarks as an external
 correctness/performance reference.
 
-The optional dense FlashAttention prefill path below gathers K/V only to run
-the course-owned Day 2 kernel. The default paged path still reads the page pool
-directly in the Day 5 Metal kernel.
+Ordinary prefill runs the course-owned Day 2 FlashAttention kernel directly on
+the freshly projected dense K/V, then stores those same tensors in the paged
+cache for decode. It must not gather them back from the cache. Paged prefill
+remains useful when chunked prefill already has history in the page pool.
 
 ## Task 3: Dispatch from the Model
 
@@ -291,14 +292,17 @@ src/tiny_llm/qwen3_week3.py
 
 Update the model so it can route to paged attention when the cache provides paged runtime metadata.
 
-The optional dense FlashAttention prefill and the paged paths must share one
-request cache. When `enable_flash_attn=True` and the current query has more than
-eight tokens, append BF16 K/V to the paged cache, gather its logical dense view,
-and run the Day 2 FlashAttention kernel. Otherwise, pass page metadata to the
-paged BF16 prefill kernel. Subsequent short decode steps always use the
+FlashAttention prefill and the paged paths must share one request cache. For an
+ordinary first prefill with more than eight tokens, append BF16 K/V to the
+paged cache and run the Day 2 FlashAttention kernel directly on the freshly
+projected K/V. Do not gather the tensors back from the cache. If chunked
+prefill already has cached history, pass page metadata to the paged BF16
+prefill kernel instead. Subsequent short decode steps always use the
 vector-oriented paged kernel. Neither path may upcast the complete Q/K/V
 tensors or change cache dtype. Keep this dispatch behind the Week 3 model so
-Week 2 remains independent.
+Week 2 remains independent. The final Week 3 model selects FlashAttention
+prefill automatically for supported `D == 128` models; `--disable-flash-attn`
+exists only for the measured paged-prefill ablation.
 
 ## Task 4: Connect It to Continuous Batching
 

--- a/book/src/week3-05-paged-attention-part2.md
+++ b/book/src/week3-05-paged-attention-part2.md
@@ -269,6 +269,20 @@ Implement two GPU dispatches:
 
 Keep a scalar FP32 path for small correctness fixtures and the CPU reference.
 
+### Course implementation boundary
+
+MLX remains the array runtime for shapes, reshapes, transposes, contiguous
+storage, dtype conversion, allocation, and custom-primitive dispatch. The
+attention implementation itself must remain course-owned: do not call
+`mx.fast.scaled_dot_product_attention`, reuse an MLX attention/Steel kernel, or
+reconstruct dense K/V and express the paged operator as MLX matmul plus
+softmax. MLX SDPA may appear only in tests and benchmarks as an external
+correctness/performance reference.
+
+The optional dense FlashAttention prefill path below gathers K/V only to run
+the course-owned Day 2 kernel. The default paged path still reads the page pool
+directly in the Day 5 Metal kernel.
+
 ## Task 3: Dispatch from the Model
 
 ```

--- a/book/src/week3-overview.md
+++ b/book/src/week3-overview.md
@@ -27,6 +27,11 @@ before paged storage and paged attention on Days 4–5. The paged prefill kernel
 then reuses the same BF16 tiling and online-softmax machinery, leaving page
 translation and decode work partitioning as the new concepts.
 
+The final model runs dense FlashAttention directly on fresh K/V for an
+ordinary first prefill, stores the same K/V in paged cache, and switches to the
+paged vector kernel for decode. Page-walking prefill remains for a chunked
+prefill that already has cached history.
+
 On Apple silicon, FlashAttention and paged attention are not automatic latency
 wins. FlashAttention has the best opportunity at long prefill lengths, where
 avoiding an `L x S` intermediate can save substantial memory traffic. Paged

--- a/book/src/week3-overview.md
+++ b/book/src/week3-overview.md
@@ -22,6 +22,11 @@ left out of the minimal Week 2 checkpoint.
 - Optional prefill, embedding, and scheduling experiments
 - Optional MoE and speculative-decoding extensions
 
+The ordering is intentional: students implement dense FlashAttention on Day 2
+before paged storage and paged attention on Days 4–5. The paged prefill kernel
+then reuses the same BF16 tiling and online-softmax machinery, leaving page
+translation and decode work partitioning as the new concepts.
+
 On Apple silicon, FlashAttention and paged attention are not automatic latency
 wins. FlashAttention has the best opportunity at long prefill lengths, where
 avoiding an `L x S` intermediate can save substantial memory traffic. Paged

--- a/book/src/week3-performance-lab.md
+++ b/book/src/week3-performance-lab.md
@@ -23,6 +23,33 @@ accumulator fragment until the final store. Keeping only the input fragments in
 16-bit precision matters: a 16-bit accumulator passed an isolated loose test
 but accumulated visible error across transformer layers.
 
+### Hoist Quantization Parameters at the Group Boundary
+
+The weights use 4-bit values with one scale and bias for every 128 reduction
+elements. An 8×8 matrix kernel advances through that group in sixteen
+eight-wide tiles. Loading the same scale and bias inside every tile repeats
+parameter-address calculation and device reads sixteen times for each output
+fragment.
+
+Loop over quantization groups first. Each lane loads the scale and bias for
+its two output-fragment elements into registers, then reuses them while it
+unpacks all sixteen matrix tiles in that group:
+
+```plain
+for each 128-value quantization group:
+    load scale and bias for this output fragment
+    for each of its sixteen 8-value reduction tiles:
+        unpack and dequantize weights with the registered parameters
+        matrix-multiply-accumulate into FP32
+```
+
+This changes scheduling, not the quantization equation or model format. In the
+matched Qwen3-0.6B measurement it reduced the synchronized 128-token Q
+projection from about 370 to 328 µs. Experiments that computed two output
+tiles per SIMD group, broadcast packed weights with shuffles, or reduced the
+threadgroup from eight to four SIMD groups all regressed; the optimization
+ledger records those results so they are not rediscovered as assumed wins.
+
 The kernel borrows the scheduling ideas behind MLX Steel without instantiating
 Steel templates or calling MLX operator kernels. An attempted 32×16 tile copied
 shared A/B blocks through threadgroup memory. It reduced global loads but added
@@ -92,12 +119,13 @@ Check full-sequence logits with `logits_to_keep=None`, last-position logits with
 ## Measure the Result
 
 Repeat the matched benchmark from Week 2. The minimal Week 2 path should reach
-at least 70% of MLX decode throughput on the same machine. Week 3 adds a slower
-teaching paged-attention path, so do not reuse that single-request acceptance
-ratio as a serving-engine target. Measure prefill, aggregate request
-throughput, cache capacity, and page reuse separately. The lab may not replace
-a slow operator with the matching MLX implementation; profile and report each
-remaining gap honestly.
+at least 70% of MLX decode throughput on the same machine. Week 3 adds paging,
+allocator, and scheduler work around a paged decode kernel that is now close to
+the dense course attention operator; do not reuse the Week 2 single-request
+acceptance ratio as the serving-engine target. Measure prefill, aggregate
+request throughput, cache capacity, and page reuse separately. The lab may not
+replace a slow operator with the matching MLX implementation; profile and
+report each remaining gap honestly.
 
 ```bash
 pdm run bench --solution tiny_llm_ref --loader week3 \

--- a/book/src/week3-performance-lab.md
+++ b/book/src/week3-performance-lab.md
@@ -131,6 +131,7 @@ independently additive.
 | Eight-column vocabulary matvec | Keep | Best measured layout for the very wide tied output head; smaller projections use two columns to avoid register pressure. |
 | Remove matvec activation barrier | Keep | Roughly 238.6 → 247-252 tok/s; a cache-hot 2 KB vector was cheaper to reread than to copy and synchronize in every threadgroup. |
 | Vanilla → `simdgroup_matrix` prefill | Keep | About 1,005 → 2,052 prefill tok/s; 8×8 matrix fragments replace scalar dot products. |
+| Hoist quantization parameters per group | Keep | Scale and bias are constant across sixteen 8-wide reduction tiles. Keeping them in registers improved the 128-token Q projection from about 370 to 328 µs and the matched lab checkpoint to 2,371 prefill tok/s. |
 | Direct quantized embedding | Keep | Roughly 20% lower isolated latency in a representative run, about 1% end to end; gathers and dequantizes without intermediate arrays. |
 | 256-thread RMSNorm | Keep | Closes most of the gap left by a one-SIMD-group reduction. |
 | Four-head RoPE reuse | Keep | Avoids repeated angle/sine/cosine work; current isolated latency is within roughly 7-14% of MLX. |
@@ -143,6 +144,8 @@ independently additive.
 | Concatenate quantized weights at runtime | Reject | About 235 → 217 tok/s; constructing larger arrays added work and memory traffic. |
 | Preallocate chunked dense KV cache | Reject | About 235 → 229 tok/s; strided logical slices hurt the following operations. Paging belongs in Week 3. |
 | Share 32×16 prefill tiles in threadgroup memory | Reject | About 2,052 → 1,848 prefill tok/s; barriers outweighed reduced global loads at 128 tokens. |
+| Broadcast packed weights within a SIMD group | Reject | About 370 → 699 µs for the 128-token Q projection; coalesced cached loads were cheaper than repeated SIMD shuffles. |
+| Four SIMD groups per prefill threadgroup | Reject | About 370 → 385 µs for the same projection; the smaller scheduling unit added launches without improving occupancy. |
 | Broadcast scale/bias within the wide matvec | Reject | Increased vocabulary-head latency; extra loop structure and broadcasts outweighed parameter-load savings. |
 | Four-output ordinary matvec | Reject | About 249 → 232 tok/s; extra register pressure outweighed activation reuse. |
 | Affine identity in the ordinary matvec | Reject | About 249 → 244.5 tok/s; fewer arithmetic instructions did not improve the executed schedule. |
@@ -168,11 +171,12 @@ measured about 2,042 tok/s versus about 3,318 for the dense Week 1 model. That
 number isolates the lab kernels from Week 3 paging; it is not the output of the
 integrated `--loader week3` command above.
 
-On the completed paged stack, the matched three-process median measured about
-1,118 prefill tok/s and 37.8 decode tok/s without FlashAttention on an M4 Pro.
-The paged-attention teaching kernel dominates decode there. Use the
-performance appendix's progression runner to compare both configurations with
-Week 1 and MLX on the same machine instead of combining their numbers.
+On the completed paged stack after hoisting quantization parameters, a matched
+three-process run measured about 2,371 prefill tok/s and 210 decode tok/s with
+the performance lab, versus 4,416 prefill tok/s and 329 decode tok/s for MLX.
+The lab changes prefill matrix products and should not materially move decode.
+Use the performance appendix's progression runner to compare configurations on
+the same machine instead of combining numbers from separate runs.
 
 One-factor cached-decode ablations give the following attribution. Each row
 uses two models with the same loaded weights, alternates optimized and vanilla

--- a/book/src/week3-performance-lab.md
+++ b/book/src/week3-performance-lab.md
@@ -140,10 +140,12 @@ independently additive.
 | No decode causal-mask graph | Keep | Pass `None` when `L = 1`; every cached position is already valid. |
 | Normalize RoPE offsets once | Keep | Builds one batch offset array per model call rather than once per layer. |
 | Last-token logits | Keep | Avoids vocabulary projection for prompt positions that generation never samples. |
+| Zero-gather FlashAttention prefill | Keep | Runs Day 2 FlashAttention directly on fresh K/V before paged decode. With the SIMD-matrix lab it improved matched prefill about 1.7% at 128 tokens and 2.0% at 512; decode was unchanged. |
 | Fuse Q/K/V and gate/up projections | Reject | About 242 → 227 tok/s; fewer Python calls did not offset a more complex kernel and dispatch map. |
 | Concatenate quantized weights at runtime | Reject | About 235 → 217 tok/s; constructing larger arrays added work and memory traffic. |
 | Preallocate chunked dense KV cache | Reject | About 235 → 229 tok/s; strided logical slices hurt the following operations. Paging belongs in Week 3. |
 | Share 32×16 prefill tiles in threadgroup memory | Reject | About 2,052 → 1,848 prefill tok/s; barriers outweighed reduced global loads at 128 tokens. |
+| Two output tiles per SIMD group | Reject | About 328 → 338 µs for the 128-token Q projection; reusing the activation fragment did not offset the second FP32 accumulator's register pressure. |
 | Broadcast packed weights within a SIMD group | Reject | About 370 → 699 µs for the 128-token Q projection; coalesced cached loads were cheaper than repeated SIMD shuffles. |
 | Four SIMD groups per prefill threadgroup | Reject | About 370 → 385 µs for the same projection; the smaller scheduling unit added launches without improving occupancy. |
 | Broadcast scale/bias within the wide matvec | Reject | Increased vocabulary-head latency; extra loop structure and broadcasts outweighed parameter-load savings. |

--- a/main.py
+++ b/main.py
@@ -21,7 +21,14 @@ parser.add_argument("--sampler-temp", type=float, default=0)
 parser.add_argument("--sampler-top-p", type=float, default=None)
 parser.add_argument("--sampler-top-k", type=int, default=None)
 parser.add_argument("--enable-thinking", action="store_true")
-parser.add_argument("--enable-flash-attn", action="store_true")
+flash_group = parser.add_mutually_exclusive_group()
+flash_group.add_argument(
+    "--enable-flash-attn", dest="enable_flash_attn", action="store_true"
+)
+flash_group.add_argument(
+    "--disable-flash-attn", dest="enable_flash_attn", action="store_false"
+)
+parser.set_defaults(enable_flash_attn=None)
 parser.add_argument("--enable-performance-lab", action="store_true")
 parser.add_argument(
     "--disable-paged-attention",
@@ -46,7 +53,7 @@ args = parser.parse_args()
 if (
     args.solution != "mlx"
     and args.loader == "week3"
-    and args.enable_flash_attn
+    and args.enable_flash_attn is not False
     and args.device != "gpu"
 ):
     parser.error("Week 3 FlashAttention requires --device gpu")

--- a/src/extensions_ref/bindings.cpp
+++ b/src/extensions_ref/bindings.cpp
@@ -72,6 +72,9 @@ NB_MODULE(_ext, m) {
             scale (float): Scaling factor.
             is_causal (bool): Enable causal masking.
 
+        Q, K, V, and output preserve bfloat16 on the optimized GPU paths.
+        Scores and online-softmax accumulation use float32.
+
         Returns:
             array: ``softmax(query @ paged_key.T * scale) @ paged_value``
       )");

--- a/src/extensions_ref/src/paged_attention.cpp
+++ b/src/extensions_ref/src/paged_attention.cpp
@@ -1,8 +1,9 @@
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "mlx/backend/cpu/encoder.h"
@@ -19,8 +20,10 @@ namespace tiny_llm_ext_ref {
 mx::array paged_attention(const mx::array &q, const mx::array &key_pages, const mx::array &value_pages,
                           const mx::array &block_table, const mx::array &context_lens, const float scale,
                           const bool is_causal, const int num_kv_heads, const int num_heads, mx::StreamOrDevice s) {
-    if (q.dtype() != mx::float32 || key_pages.dtype() != mx::float32 || value_pages.dtype() != mx::float32) {
-        throw std::runtime_error("paged_attention: q, key_pages, and value_pages must be float32");
+    if ((q.dtype() != mx::float32 && q.dtype() != mx::bfloat16) || key_pages.dtype() != q.dtype() ||
+        value_pages.dtype() != q.dtype()) {
+        throw std::runtime_error(
+            "paged_attention: q, key_pages, and value_pages must have the same float32 or bfloat16 dtype");
     }
     if (block_table.dtype() != mx::int32 || context_lens.dtype() != mx::int32) {
         throw std::runtime_error("paged_attention: block_table and context_lens must be int32");
@@ -56,7 +59,7 @@ mx::array paged_attention(const mx::array &q, const mx::array &key_pages, const 
         throw std::runtime_error("paged_attention: q batch size must match block_table batch size");
     }
 
-    return mx::array(q.shape(), mx::float32,
+    return mx::array(q.shape(), q.dtype(),
                      std::make_shared<PagedAttention>(to_stream(s), scale, is_causal, num_kv_heads, num_heads),
                      {q, key_pages, value_pages, block_table, context_lens});
 }
@@ -70,7 +73,7 @@ void PagedAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
     auto &out = outputs[0];
 
     if (out.dtype() != mx::float32) {
-        throw std::runtime_error("paged_attention: output dtype must be float32");
+        throw std::runtime_error("paged_attention: the CPU path only supports float32");
     }
     if (!q.flags().row_contiguous || !key_pages.flags().row_contiguous || !value_pages.flags().row_contiguous ||
         !block_table.flags().row_contiguous || !context_lens.flags().row_contiguous) {
@@ -91,8 +94,8 @@ void PagedAttention::eval_cpu(const std::vector<mx::array> &inputs, std::vector<
                       key_pages = mx::array::unsafe_weak_copy(key_pages),
                       value_pages = mx::array::unsafe_weak_copy(value_pages),
                       block_table = mx::array::unsafe_weak_copy(block_table),
-                      context_lens = mx::array::unsafe_weak_copy(context_lens), scale = scale_,
-                      is_causal = is_causal_, num_kv_heads = num_kv_heads_, num_heads = num_heads_]() {
+                      context_lens = mx::array::unsafe_weak_copy(context_lens), scale = scale_, is_causal = is_causal_,
+                      num_kv_heads = num_kv_heads_, num_heads = num_heads_]() {
         const int64_t N = q.shape()[0];
         const int64_t L = q.shape()[1];
         const int64_t D = q.shape()[2];
@@ -236,9 +239,6 @@ void PagedAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     const auto &context_lens = inputs[4];
     auto &out = outputs[0];
 
-    if (out.dtype() != mx::float32) {
-        throw std::runtime_error("paged_attention: output dtype must be float32");
-    }
     if (!q.flags().row_contiguous || !key_pages.flags().row_contiguous || !value_pages.flags().row_contiguous ||
         !block_table.flags().row_contiguous || !context_lens.flags().row_contiguous) {
         throw std::runtime_error("paged_attention: all inputs must be contiguous");
@@ -249,56 +249,82 @@ void PagedAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<
     auto &s = stream();
     auto &d = mx::metal::device(s.device);
     auto library = d.get_library("tiny_llm_ext_ref");
-    auto kernel = d.get_kernel("paged_attention_f32", library);
-
     auto &compute_encoder = d.get_command_encoder(s.index);
-    compute_encoder.set_compute_pipeline_state(kernel);
-    compute_encoder.set_input_array(q, 0);
-    compute_encoder.set_input_array(key_pages, 1);
-    compute_encoder.set_input_array(value_pages, 2);
-    compute_encoder.set_input_array(block_table, 3);
-    compute_encoder.set_input_array(context_lens, 4);
-    compute_encoder.set_output_array(out, 5);
 
     const int N = q.shape()[0];
     const int L = q.shape()[1];
     const int D = q.shape()[2];
     const int page_size = key_pages.shape()[2];
     const int max_pages = block_table.shape()[1];
+    const int is_causal = static_cast<int>(is_causal_);
+    if (D <= 0 || D > 128) {
+        throw std::runtime_error("paged_attention: head dimension must be in the range [1, 128]");
+    }
+
+    auto bind_arrays = [&]() {
+        compute_encoder.set_input_array(q, 0);
+        compute_encoder.set_input_array(key_pages, 1);
+        compute_encoder.set_input_array(value_pages, 2);
+        compute_encoder.set_input_array(block_table, 3);
+        compute_encoder.set_input_array(context_lens, 4);
+        compute_encoder.set_output_array(out, 5);
+    };
+
+    if (L <= 8) {
+        const char *suffix = q.dtype() == mx::bfloat16 ? "bf16" : "f32";
+        auto kernel = d.get_kernel(std::string("paged_attention_decode_") + suffix, library);
+        compute_encoder.set_compute_pipeline_state(kernel);
+        bind_arrays();
+        compute_encoder.set_bytes(N, 6);
+        compute_encoder.set_bytes(L, 7);
+        compute_encoder.set_bytes(D, 8);
+        compute_encoder.set_bytes(page_size, 9);
+        compute_encoder.set_bytes(max_pages, 10);
+        compute_encoder.set_bytes(is_causal, 11);
+        compute_encoder.set_bytes(num_kv_heads_, 12);
+        compute_encoder.set_bytes(num_heads_, 13);
+        compute_encoder.set_bytes(scale_, 14);
+        constexpr int simdgroups_per_query = 32;
+        compute_encoder.set_threadgroup_memory_length(simdgroups_per_query * (D + 3) * sizeof(float), 0);
+        compute_encoder.dispatch_threadgroups(MTL::Size(N * L, 1, 1), MTL::Size(simdgroups_per_query * 32, 1, 1));
+        return;
+    }
+
+    if (q.dtype() == mx::bfloat16) {
+        if (D != 128) {
+            throw std::runtime_error("paged_attention: bfloat16 prefill requires head dimension 128");
+        }
+        auto kernel = d.get_kernel("paged_attention_mma_bf16_d128", library);
+        compute_encoder.set_compute_pipeline_state(kernel);
+        bind_arrays();
+        compute_encoder.set_bytes(N, 6);
+        compute_encoder.set_bytes(L, 7);
+        compute_encoder.set_bytes(page_size, 8);
+        compute_encoder.set_bytes(max_pages, 9);
+        compute_encoder.set_bytes(is_causal, 10);
+        compute_encoder.set_bytes(num_kv_heads_, 11);
+        compute_encoder.set_bytes(num_heads_, 12);
+        compute_encoder.set_bytes(scale_, 13);
+        const int batch_size = N / num_heads_;
+        const int query_blocks = (L + 63) / 64;
+        compute_encoder.dispatch_threadgroups(MTL::Size(query_blocks, num_heads_, batch_size), MTL::Size(32, 8, 1));
+        return;
+    }
+
+    auto kernel = d.get_kernel("paged_attention_scalar_f32", library);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    bind_arrays();
     compute_encoder.set_bytes(N, 6);
     compute_encoder.set_bytes(L, 7);
     compute_encoder.set_bytes(D, 8);
     compute_encoder.set_bytes(page_size, 9);
     compute_encoder.set_bytes(max_pages, 10);
-    compute_encoder.set_bytes(static_cast<int>(is_causal_), 11);
+    compute_encoder.set_bytes(is_causal, 11);
     compute_encoder.set_bytes(num_kv_heads_, 12);
     compute_encoder.set_bytes(num_heads_, 13);
     compute_encoder.set_bytes(scale_, 14);
-
-    size_t tgp_size = kernel->maxTotalThreadsPerThreadgroup();
-    size_t simd_width = kernel->threadExecutionWidth();
-
-    const int Br = 32;
-    const int Bc = 32;
-    if (simd_width * Br > tgp_size) {
-        throw std::runtime_error("paged_attention: simd_width * Br must fit in the threadgroup");
-    }
-    if (Bc > simd_width) {
-        throw std::runtime_error("paged_attention: Bc must be less than or equal to simd_width");
-    }
-    if (D > 128) {
-        throw std::runtime_error("paged_attention: head dimension must be less than or equal to 128");
-    }
-
-    const int Tr = (L + Br - 1) / Br;
-    const int Tc = (max_pages * page_size + Bc - 1) / Bc;
-
-    compute_encoder.set_bytes(Br, 15);
-    compute_encoder.set_bytes(Bc, 16);
-    compute_encoder.set_bytes(Tr, 17);
-    compute_encoder.set_bytes(Tc, 18);
-
-    compute_encoder.dispatch_threadgroups(MTL::Size(N, Tr, 1), MTL::Size(Br, simd_width, 1));
+    const int query_blocks = (L + 15) / 16;
+    compute_encoder.dispatch_threadgroups(MTL::Size(N, query_blocks, 1), MTL::Size(32, 16, 1));
 }
 #else
 void PagedAttention::eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) {

--- a/src/extensions_ref/src/paged_attention.metal
+++ b/src/extensions_ref/src/paged_attention.metal
@@ -1,8 +1,399 @@
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
 #include <metal_stdlib>
+#include "mlx/backend/metal/kernels/utils.h"
 
 using namespace metal;
 
-[[kernel]] void paged_attention_f32(
+namespace {
+
+constant constexpr int HEAD_DIM = 128;
+constant constexpr int MMA_SIZE = 8;
+
+inline ushort2 matrix_coord(ushort lane) {
+    const ushort quad = lane / 4;
+    const ushort row = (quad & 4) + ((lane / 2) % 4);
+    const ushort col = (quad & 2) * 2 + (lane % 2) * 2;
+    return ushort2(col, row);
+}
+
+template <typename T>
+inline void load_matrix(
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& matrix,
+    threadgroup const T* source,
+    int row_stride,
+    ushort lane) {
+    const ushort2 coord = matrix_coord(lane);
+    matrix.thread_elements()[0] = source[coord.y * row_stride + coord.x];
+    matrix.thread_elements()[1] = source[coord.y * row_stride + coord.x + 1];
+}
+
+template <int N>
+inline float row_max(
+    thread const simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>* matrices) {
+    float value = -INFINITY;
+    for (int fragment_idx = 0; fragment_idx < N; fragment_idx++) {
+        const auto values = matrices[fragment_idx].thread_elements();
+        value = max(value, max(values[0], values[1]));
+    }
+    value = max(value, simd_shuffle_xor(value, ushort(1)));
+    value = max(value, simd_shuffle_xor(value, ushort(8)));
+    return value;
+}
+
+template <int N>
+inline float row_sum(
+    thread const simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>* matrices) {
+    float value = 0.0f;
+    for (int fragment_idx = 0; fragment_idx < N; fragment_idx++) {
+        const auto values = matrices[fragment_idx].thread_elements();
+        value += values[0] + values[1];
+    }
+    value += simd_shuffle_xor(value, ushort(1));
+    value += simd_shuffle_xor(value, ushort(8));
+    return value;
+}
+
+inline void clear_matrix(thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& matrix) {
+    matrix.thread_elements()[0] = 0.0f;
+    matrix.thread_elements()[1] = 0.0f;
+}
+
+inline void scale_matrix_rows(
+    thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& matrix,
+    float scale) {
+    matrix.thread_elements()[0] *= scale;
+    matrix.thread_elements()[1] *= scale;
+}
+
+template <typename T>
+inline void matrix_multiply_accumulate(
+    thread simdgroup_matrix<float, MMA_SIZE, MMA_SIZE>& accumulator,
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& left,
+    thread simdgroup_matrix<T, MMA_SIZE, MMA_SIZE>& right) {
+    simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> result;
+    simdgroup_multiply_accumulate(result, left, right, accumulator);
+    accumulator = result;
+}
+
+}  // namespace
+
+template <typename T>
+[[kernel]] void paged_attention_decode(
+    device const T* q [[buffer(0)]],
+    device const T* key_pages [[buffer(1)]],
+    device const T* value_pages [[buffer(2)]],
+    device const int* block_table [[buffer(3)]],
+    device const int* context_lens [[buffer(4)]],
+    device T* out [[buffer(5)]],
+    constant const int& N [[buffer(6)]],
+    constant const int& L [[buffer(7)]],
+    constant const int& D [[buffer(8)]],
+    constant const int& page_size [[buffer(9)]],
+    constant const int& max_pages [[buffer(10)]],
+    constant const int& is_causal [[buffer(11)]],
+    constant const int& num_kv_heads [[buffer(12)]],
+    constant const int& num_heads [[buffer(13)]],
+    constant const float& scale [[buffer(14)]],
+    threadgroup float* scratch [[threadgroup(0)]],
+    uint query_index [[threadgroup_position_in_grid]],
+    uint simdgroup [[simdgroup_index_in_threadgroup]],
+    uint thread_index [[thread_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]) {
+    if (query_index >= N * L) return;
+
+    constexpr int MAX_VALUES_PER_LANE = 4;
+    constexpr int SIMD_GROUPS_PER_QUERY = 32;
+    const int n = query_index / L;
+    const int query_position = query_index - n * L;
+    const int batch = n / num_heads;
+    const int query_head = n - batch * num_heads;
+    const int kv_head = query_head / (num_heads / num_kv_heads);
+    const int context = context_lens[batch];
+    const int values_per_lane = (D + 31) / 32;
+
+    float accumulator[MAX_VALUES_PER_LANE] = {0.0f};
+    float query_values[MAX_VALUES_PER_LANE] = {0.0f};
+    float max_score = -INFINITY;
+    float sum = 0.0f;
+
+    for (int item = 0; item < values_per_lane; item++) {
+        const int dim = lane + item * 32;
+        if (dim < D && item < MAX_VALUES_PER_LANE) {
+            query_values[item] = static_cast<float>(q[query_index * D + dim]) * scale;
+        }
+    }
+
+    for (int position = simdgroup; position < context; position += SIMD_GROUPS_PER_QUERY) {
+        if (is_causal && position > context - L + query_position) continue;
+        const int logical_page = position / page_size;
+        if (logical_page >= max_pages) continue;
+        const int page_id = block_table[batch * max_pages + logical_page];
+        if (page_id < 0) continue;
+        const int slot = position - logical_page * page_size;
+        const int page_offset = ((page_id * num_kv_heads + kv_head) * page_size + slot) * D;
+
+        float partial = 0.0f;
+        for (int item = 0; item < values_per_lane; item++) {
+            const int dim = lane + item * 32;
+            if (dim < D && item < MAX_VALUES_PER_LANE) {
+                partial += query_values[item] * static_cast<float>(key_pages[page_offset + dim]);
+            }
+        }
+        const float score = simd_sum(partial);
+        const float new_max = max(max_score, score);
+        const float old_factor = max_score == -INFINITY ? 0.0f : fast::exp(max_score - new_max);
+        const float score_factor = fast::exp(score - new_max);
+        sum = sum * old_factor + score_factor;
+        for (int item = 0; item < values_per_lane; item++) {
+            const int dim = lane + item * 32;
+            if (dim < D && item < MAX_VALUES_PER_LANE) {
+                accumulator[item] = accumulator[item] * old_factor +
+                    score_factor * static_cast<float>(value_pages[page_offset + dim]);
+            }
+        }
+        max_score = new_max;
+    }
+
+    threadgroup float* partial_accumulators = scratch;
+    threadgroup float* partial_maxima = partial_accumulators + SIMD_GROUPS_PER_QUERY * D;
+    threadgroup float* partial_sums = partial_maxima + SIMD_GROUPS_PER_QUERY;
+    threadgroup float* partial_factors = partial_sums + SIMD_GROUPS_PER_QUERY;
+    if (lane == 0) {
+        partial_maxima[simdgroup] = max_score;
+        partial_sums[simdgroup] = sum;
+    }
+    for (int item = 0; item < values_per_lane; item++) {
+        const int dim = lane + item * 32;
+        if (dim < D && item < MAX_VALUES_PER_LANE) {
+            partial_accumulators[simdgroup * D + dim] = accumulator[item];
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float global_max = -INFINITY;
+    if (simdgroup == 0) {
+        for (int group = 0; group < SIMD_GROUPS_PER_QUERY; group++) {
+            global_max = max(global_max, partial_maxima[group]);
+        }
+        if (lane < SIMD_GROUPS_PER_QUERY) {
+            partial_factors[lane] = global_max == -INFINITY
+                ? 0.0f
+                : fast::exp(partial_maxima[lane] - global_max);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (thread_index == 0) {
+        float global_sum = 0.0f;
+        for (int group = 0; group < SIMD_GROUPS_PER_QUERY; group++) {
+            global_sum += partial_sums[group] * partial_factors[group];
+        }
+        partial_sums[0] = global_sum;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (thread_index < D) {
+        float value_sum = 0.0f;
+        for (int group = 0; group < SIMD_GROUPS_PER_QUERY; group++) {
+            value_sum += partial_accumulators[group * D + thread_index] * partial_factors[group];
+        }
+        out[query_index * D + thread_index] = partial_sums[0] == 0.0f
+            ? static_cast<T>(0.0f)
+            : static_cast<T>(value_sum / partial_sums[0]);
+    }
+}
+
+instantiate_kernel("paged_attention_decode_f32", paged_attention_decode, float);
+instantiate_kernel("paged_attention_decode_bf16", paged_attention_decode, bfloat16_t);
+
+[[kernel, max_total_threads_per_threadgroup(256)]] void paged_attention_mma_bf16_d128(
+    device const bfloat* q [[buffer(0)]],
+    device const bfloat* key_pages [[buffer(1)]],
+    device const bfloat* value_pages [[buffer(2)]],
+    device const int* block_table [[buffer(3)]],
+    device const int* context_lens [[buffer(4)]],
+    device bfloat* out [[buffer(5)]],
+    constant const int& N [[buffer(6)]],
+    constant const int& L [[buffer(7)]],
+    constant const int& page_size [[buffer(8)]],
+    constant const int& max_pages [[buffer(9)]],
+    constant const int& is_causal [[buffer(10)]],
+    constant const int& num_kv_heads [[buffer(11)]],
+    constant const int& num_heads [[buffer(12)]],
+    constant const float& scale [[buffer(13)]],
+    uint3 group_id [[threadgroup_position_in_grid]],
+    ushort simd_gid [[simdgroup_index_in_threadgroup]],
+    ushort lane [[thread_index_in_simdgroup]]) {
+    constexpr int BQ = 64;
+    constexpr int BK = 32;
+    constexpr int SIMD_GROUPS = 8;
+    constexpr int THREADS = SIMD_GROUPS * 32;
+    constexpr int LDQ = HEAD_DIM + 2;
+    constexpr int LDK = BK + 2;
+    constexpr int LDV = HEAD_DIM + 2;
+    constexpr int KV_STORAGE = HEAD_DIM * LDK;
+    constexpr int OUTPUT_FRAGMENTS = HEAD_DIM / MMA_SIZE;
+    constexpr int SCORE_FRAGMENTS = BK / MMA_SIZE;
+
+    const int query_block = group_id.x;
+    const int query_head = group_id.y;
+    const int batch = group_id.z;
+    const int n = batch * num_heads + query_head;
+    const int kv_head = query_head / (num_heads / num_kv_heads);
+    const int context = context_lens[batch];
+    const int thread_idx = simd_gid * 32 + lane;
+    const ushort2 coord = matrix_coord(lane);
+    const int query_row_in_block = simd_gid * MMA_SIZE + coord.y;
+    const int query_row = query_block * BQ + query_row_in_block;
+    const bool query_valid = n < N && query_row < L;
+
+    device const bfloat* q_head = q + n * L * HEAD_DIM;
+    threadgroup bfloat q_tile[BQ * LDQ];
+    threadgroup bfloat kv_tile[KV_STORAGE];
+    threadgroup int physical_pages[BK];
+
+    for (int idx = thread_idx; idx < BQ * HEAD_DIM; idx += THREADS) {
+        const int row = idx / HEAD_DIM;
+        const int dim = idx - row * HEAD_DIM;
+        const int global_row = query_block * BQ + row;
+        q_tile[row * LDQ + dim] = global_row < L ? q_head[global_row * HEAD_DIM + dim] : bfloat(0.0f);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> output[OUTPUT_FRAGMENTS];
+    for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+        clear_matrix(output[output_fragment]);
+    }
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    const int total_kv_tiles = (context + BK - 1) / BK;
+    int kv_tile_limit = total_kv_tiles;
+    if (is_causal) {
+        const int last_query = min((query_block + 1) * BQ, L) - 1;
+        const int last_visible_key = last_query + (context - L);
+        kv_tile_limit = clamp((last_visible_key + 1 + BK - 1) / BK, 0, total_kv_tiles);
+    }
+
+    for (int tile_idx = 0; tile_idx < kv_tile_limit; tile_idx++) {
+        if (thread_idx < BK) {
+            const int key = tile_idx * BK + thread_idx;
+            const int logical_page = key / page_size;
+            physical_pages[thread_idx] = key < context && logical_page < max_pages
+                ? block_table[batch * max_pages + logical_page]
+                : -1;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int idx = thread_idx; idx < BK * HEAD_DIM; idx += THREADS) {
+            const int key = idx / HEAD_DIM;
+            const int dim = idx - key * HEAD_DIM;
+            const int global_key = tile_idx * BK + key;
+            const int logical_page = global_key / page_size;
+            const int slot = global_key - logical_page * page_size;
+            const int page_id = physical_pages[key];
+            const int page_offset = ((page_id * num_kv_heads + kv_head) * page_size + slot) * HEAD_DIM;
+            kv_tile[dim * LDK + key] = page_id >= 0
+                ? key_pages[page_offset + dim]
+                : bfloat(0.0f);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        simdgroup_matrix<float, MMA_SIZE, MMA_SIZE> scores[SCORE_FRAGMENTS];
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            clear_matrix(scores[key_fragment]);
+        }
+        for (int dim = 0; dim < HEAD_DIM; dim += MMA_SIZE) {
+            simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> q_fragment;
+            load_matrix(q_fragment, q_tile + simd_gid * MMA_SIZE * LDQ + dim, LDQ, lane);
+            for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+                simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> k_fragment;
+                load_matrix(k_fragment, kv_tile + dim * LDK + key_fragment * MMA_SIZE, LDK, lane);
+                matrix_multiply_accumulate(scores[key_fragment], q_fragment, k_fragment);
+            }
+        }
+
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            thread auto& score_values = scores[key_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                const int tile_key = key_fragment * MMA_SIZE + coord.x + element;
+                const int key = tile_idx * BK + tile_key;
+                bool valid = query_valid && key < context && physical_pages[tile_key] >= 0;
+                if (is_causal) valid = valid && key <= query_row + (context - L);
+                score_values[element] = valid ? score_values[element] * scale : -INFINITY;
+            }
+        }
+
+        const float tile_max = row_max<SCORE_FRAGMENTS>(scores);
+        const float new_max = max(running_max, tile_max);
+        const bool finite_row = query_valid && new_max != -INFINITY;
+        const float previous_scale = running_max == -INFINITY || !finite_row
+            ? 0.0f
+            : fast::exp(running_max - new_max);
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            thread auto& score_values = scores[key_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                score_values[element] = score_values[element] == -INFINITY || !finite_row
+                    ? 0.0f
+                    : fast::exp(score_values[element] - new_max);
+            }
+        }
+        const float tile_sum = row_sum<SCORE_FRAGMENTS>(scores);
+        running_max = new_max;
+        running_sum = previous_scale * running_sum + tile_sum;
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            scale_matrix_rows(output[output_fragment], previous_scale);
+        }
+
+        simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> probabilities[SCORE_FRAGMENTS];
+        for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+            const auto score_values = scores[key_fragment].thread_elements();
+            probabilities[key_fragment].thread_elements()[0] = bfloat(score_values[0]);
+            probabilities[key_fragment].thread_elements()[1] = bfloat(score_values[1]);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BK * HEAD_DIM; idx += THREADS) {
+            const int key = idx / HEAD_DIM;
+            const int dim = idx - key * HEAD_DIM;
+            const int global_key = tile_idx * BK + key;
+            const int logical_page = global_key / page_size;
+            const int slot = global_key - logical_page * page_size;
+            const int page_id = physical_pages[key];
+            const int page_offset = ((page_id * num_kv_heads + kv_head) * page_size + slot) * HEAD_DIM;
+            kv_tile[key * LDV + dim] = page_id >= 0
+                ? value_pages[page_offset + dim]
+                : bfloat(0.0f);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            for (int key_fragment = 0; key_fragment < SCORE_FRAGMENTS; key_fragment++) {
+                simdgroup_matrix<bfloat, MMA_SIZE, MMA_SIZE> v_fragment;
+                load_matrix(
+                    v_fragment,
+                    kv_tile + key_fragment * MMA_SIZE * LDV + output_fragment * MMA_SIZE,
+                    LDV,
+                    lane);
+                matrix_multiply_accumulate(output[output_fragment], probabilities[key_fragment], v_fragment);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (query_valid) {
+        for (int output_fragment = 0; output_fragment < OUTPUT_FRAGMENTS; output_fragment++) {
+            const auto output_values = output[output_fragment].thread_elements();
+            for (int element = 0; element < 2; element++) {
+                const int dim = output_fragment * MMA_SIZE + coord.x + element;
+                out[n * L * HEAD_DIM + query_row * HEAD_DIM + dim] = running_sum == 0.0f
+                    ? bfloat(0.0f)
+                    : bfloat(output_values[element] / running_sum);
+            }
+        }
+    }
+}
+
+[[kernel]] void paged_attention_scalar_f32(
     device const float* q [[buffer(0)]],
     device const float* key_pages [[buffer(1)]],
     device const float* value_pages [[buffer(2)]],
@@ -18,109 +409,132 @@ using namespace metal;
     constant const int& num_kv_heads [[buffer(12)]],
     constant const int& num_heads [[buffer(13)]],
     constant const float& scale [[buffer(14)]],
-    constant const int& Br [[buffer(15)]],
-    constant const int& Bc [[buffer(16)]],
-    [[maybe_unused]] constant const int& Tr [[buffer(17)]],
-    constant const int& Tc [[buffer(18)]],
     uint2 group_id [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
-    uint simd_lid [[thread_index_in_simdgroup]]) {
-  const int n = group_id.x;
-  const int i = group_id.y;
-  const int a = simd_gid;
-  const int b = simd_lid;
-  const int row = i * Br + a;
-  const bool is_i_in_range = n < N && row < L && a < Br;
+    uint lane [[thread_index_in_simdgroup]]) {
+    constexpr int BQ = 16;
+    constexpr int BK = 32;
+    constexpr int MAX_D = 128;
+    constexpr int OUTPUTS_PER_LANE = MAX_D / BK;
+    constexpr int THREADS = BQ * BK;
 
-  const int batch = n / num_heads;
-  const int q_head = n % num_heads;
-  const int q_kv_ratio = num_heads / num_kv_heads;
-  const int kv_head = q_head / q_kv_ratio;
-  const int context_len = context_lens[batch];
-  const int causal_offset = context_len - L;
+    const int n = group_id.x;
+    const int query_block = group_id.y;
+    const int query_row_in_block = simd_gid;
+    const int query_row = query_block * BQ + query_row_in_block;
+    const int thread_idx = query_row_in_block * BK + lane;
+    const bool query_valid = n < N && query_row < L;
+    const int batch = n / num_heads;
+    const int query_head = n - batch * num_heads;
+    const int kv_head = query_head / (num_heads / num_kv_heads);
+    const int context = context_lens[batch];
 
-  threadgroup float q_local[32][128];
-  threadgroup float o_i[32 * 128];
+    threadgroup float q_tile[BQ * MAX_D];
+    threadgroup float kv_tile[BK * MAX_D];
+    threadgroup float probabilities[BQ * BK];
+    threadgroup int physical_pages[BK];
 
-  if (simd_lid == 0) {
-    for (int c = 0; c < D; c++) {
-      q_local[a][c] = is_i_in_range ? q[n * L * D + row * D + c] : 0.0f;
-      o_i[a * D + c] = 0.0f;
+    for (int idx = thread_idx; idx < BQ * MAX_D; idx += THREADS) {
+        const int row = idx / MAX_D;
+        const int dim = idx - row * MAX_D;
+        const int global_row = query_block * BQ + row;
+        q_tile[idx] = global_row < L && dim < D ? q[n * L * D + global_row * D + dim] : 0.0f;
     }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  float m_i = -INFINITY;
-  float l_i = 0.0f;
-
-  for (int j = 0; j < Tc; j++) {
-    const int col = j * Bc + b;
-    if (j * Bc >= context_len) {
-      continue;
-    }
+    float output_fragment[OUTPUTS_PER_LANE] = {0.0f};
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    const int total_kv_tiles = (context + BK - 1) / BK;
+    int kv_tile_limit = total_kv_tiles;
     if (is_causal) {
-      const int row_max = min((i + 1) * Br - 1, L - 1);
-      if (j * Bc > row_max + causal_offset) {
-        continue;
-      }
+        const int last_query = min((query_block + 1) * BQ, L) - 1;
+        const int last_visible_key = last_query + (context - L);
+        kv_tile_limit = clamp((last_visible_key + 1 + BK - 1) / BK, 0, total_kv_tiles);
     }
 
-    const int page_idx = col / page_size;
-    const int slot = col - page_idx * page_size;
-    int page_id = -1;
-    bool is_j_in_range = col < context_len && b < Bc && page_idx < max_pages;
-    if (is_j_in_range) {
-      page_id = block_table[batch * max_pages + page_idx];
-      is_j_in_range = page_id >= 0;
+    for (int tile_idx = 0; tile_idx < kv_tile_limit; tile_idx++) {
+        if (thread_idx < BK) {
+            const int key = tile_idx * BK + thread_idx;
+            const int logical_page = key / page_size;
+            physical_pages[thread_idx] = key < context && logical_page < max_pages
+                ? block_table[batch * max_pages + logical_page]
+                : -1;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BK * MAX_D; idx += THREADS) {
+            const int key = idx / MAX_D;
+            const int dim = idx - key * MAX_D;
+            const int global_key = tile_idx * BK + key;
+            const int logical_page = global_key / page_size;
+            const int slot = global_key - logical_page * page_size;
+            const int page_id = physical_pages[key];
+            const int page_offset = ((page_id * num_kv_heads + kv_head) * page_size + slot) * D;
+            kv_tile[idx] = page_id >= 0 && dim < D ? key_pages[page_offset + dim] : 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const int tile_key = lane;
+        const int key = tile_idx * BK + tile_key;
+        bool valid = query_valid && key < context && physical_pages[tile_key] >= 0;
+        if (is_causal) valid = valid && key <= query_row + (context - L);
+        float score = -INFINITY;
+        if (valid) {
+            score = 0.0f;
+            for (int dim = 0; dim < D; dim++) {
+                score += q_tile[query_row_in_block * MAX_D + dim] * kv_tile[tile_key * MAX_D + dim];
+            }
+            score *= scale;
+        }
+
+        const float tile_max = simd_max(score);
+        const float new_max = max(running_max, tile_max);
+        const bool finite_row = new_max != -INFINITY;
+        const float previous_scale = running_max == -INFINITY || !finite_row
+            ? 0.0f
+            : fast::exp(running_max - new_max);
+        const float probability = score == -INFINITY || !finite_row ? 0.0f : fast::exp(score - new_max);
+        running_max = new_max;
+        running_sum = previous_scale * running_sum + simd_sum(probability);
+        probabilities[query_row_in_block * BK + lane] = probability;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int idx = thread_idx; idx < BK * MAX_D; idx += THREADS) {
+            const int value_key = idx / MAX_D;
+            const int dim = idx - value_key * MAX_D;
+            const int global_key = tile_idx * BK + value_key;
+            const int logical_page = global_key / page_size;
+            const int slot = global_key - logical_page * page_size;
+            const int page_id = physical_pages[value_key];
+            const int page_offset = ((page_id * num_kv_heads + kv_head) * page_size + slot) * D;
+            kv_tile[idx] = page_id >= 0 && dim < D ? value_pages[page_offset + dim] : 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (query_valid) {
+            for (int output_idx = 0; output_idx < OUTPUTS_PER_LANE; output_idx++) {
+                const int dim = lane + output_idx * BK;
+                if (dim < D) {
+                    float partial = 0.0f;
+                    for (int value_key = 0; value_key < BK; value_key++) {
+                        partial += probabilities[query_row_in_block * BK + value_key] *
+                            kv_tile[value_key * MAX_D + dim];
+                    }
+                    output_fragment[output_idx] = previous_scale * output_fragment[output_idx] + partial;
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
-    bool visible = is_i_in_range && is_j_in_range;
-    if (visible && is_causal) {
-      visible = col <= row + causal_offset;
+    if (query_valid) {
+        for (int output_idx = 0; output_idx < OUTPUTS_PER_LANE; output_idx++) {
+            const int dim = lane + output_idx * BK;
+            if (dim < D) {
+                out[n * L * D + query_row * D + dim] = running_sum == 0.0f
+                    ? 0.0f
+                    : output_fragment[output_idx] / running_sum;
+            }
+        }
     }
-
-    float s_a_b = -INFINITY;
-    if (visible) {
-      float score = 0.0f;
-      for (int c = 0; c < D; c++) {
-        const int k_idx =
-            ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
-        score += q_local[a][c] * key_pages[k_idx];
-      }
-      s_a_b = score * scale;
-    }
-
-    const float rowmax = simd_max(s_a_b);
-    const float new_max = max(m_i, rowmax);
-    const float old_scale = exp(m_i - new_max);
-    m_i = new_max;
-
-    const float p_a_b = visible ? exp(s_a_b - m_i) : 0.0f;
-    const float rowsum = simd_sum(p_a_b);
-    l_i = old_scale * l_i + rowsum;
-
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (int c = 0; c < D; c++) {
-      float partial = 0.0f;
-      if (visible) {
-        const int v_idx =
-            ((page_id * num_kv_heads + kv_head) * page_size + slot) * D + c;
-        partial = p_a_b * value_pages[v_idx];
-      }
-      const float res = simd_sum(partial);
-      if (simd_lid == 0 && is_i_in_range) {
-        o_i[a * D + c] = old_scale * o_i[a * D + c] + res;
-      }
-    }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-  }
-
-  if (simd_lid == 0) {
-    for (int c = 0; c < D; c++) {
-      if (is_i_in_range) {
-        out[n * L * D + row * D + c] =
-            l_i > 0.0f ? o_i[a * D + c] / l_i : 0.0f;
-      }
-    }
-  }
 }

--- a/src/extensions_ref/src/quantized_matmul.metal
+++ b/src/extensions_ref/src/quantized_matmul.metal
@@ -137,44 +137,67 @@ template <typename T>
 
     const int packed_cols = N / packs_per_item;
     const int groups_per_row = N / group_size;
-    for (int reduction_base = 0; reduction_base < N; reduction_base += tile_size) {
-        simdgroup_matrix<T, tile_size, tile_size> activation_fragment;
-        simdgroup_matrix<T, tile_size, tile_size> weight_fragment;
-        simdgroup_matrix<float, tile_size, tile_size> next_accumulator;
-
+    for (int group_base = 0; group_base < N; group_base += group_size) {
+        float weight_scales[2];
+        float weight_biases[2];
         #pragma clang loop unroll(full)
         for (int element = 0; element < 2; ++element) {
-            const int activation_row = row_base + fragment_row;
-            const int reduction_column = reduction_base + fragment_column + element;
-            activation_fragment.thread_elements()[element] =
-                activation_row < M ? a[activation_row * N + reduction_column] : T(0);
-
-            // The matrix fragment is N x K, while the packed weights are
-            // stored as K x N. Transpose while unpacking and dequantizing.
-            const int reduction_row = reduction_base + fragment_row;
             const int output_column = column_base + fragment_column + element;
             if (output_column < K) {
-                const int quant_group = reduction_row / group_size;
-                const int packed_column = reduction_row / packs_per_item;
-                const int shift = (reduction_row % packs_per_item) * bits;
-                const uint32_t packed = b[output_column * packed_cols + packed_column];
-                const float quantized = static_cast<float>((packed >> shift) & mask);
-                const float scale = static_cast<float>(
-                    scales[output_column * groups_per_row + quant_group]);
-                const float bias = static_cast<float>(
-                    biases[output_column * groups_per_row + quant_group]);
-                weight_fragment.thread_elements()[element] =
-                    static_cast<T>(quantized * scale + bias);
+                const int parameter =
+                    output_column * groups_per_row + group_base / group_size;
+                weight_scales[element] = static_cast<float>(scales[parameter]);
+                weight_biases[element] = static_cast<float>(biases[parameter]);
             } else {
-                weight_fragment.thread_elements()[element] = T(0);
+                weight_scales[element] = 0.0f;
+                weight_biases[element] = 0.0f;
             }
         }
-        simdgroup_multiply_accumulate(
-            next_accumulator,
-            activation_fragment,
-            weight_fragment,
-            accumulator);
-        accumulator = next_accumulator;
+
+        for (int reduction_base = group_base;
+             reduction_base < group_base + group_size;
+             reduction_base += tile_size) {
+            simdgroup_matrix<T, tile_size, tile_size> activation_fragment;
+            simdgroup_matrix<T, tile_size, tile_size> weight_fragment;
+            simdgroup_matrix<float, tile_size, tile_size> next_accumulator;
+
+            #pragma clang loop unroll(full)
+            for (int element = 0; element < 2; ++element) {
+                const int activation_row = row_base + fragment_row;
+                const int reduction_column =
+                    reduction_base + fragment_column + element;
+                activation_fragment.thread_elements()[element] =
+                    activation_row < M
+                        ? a[activation_row * N + reduction_column]
+                        : T(0);
+
+                // The matrix fragment is N x K, while the packed weights are
+                // stored as K x N. Transpose while unpacking and dequantizing.
+                const int reduction_row = reduction_base + fragment_row;
+                const int output_column =
+                    column_base + fragment_column + element;
+                if (output_column < K) {
+                    const int packed_column = reduction_row / packs_per_item;
+                    const int shift =
+                        (reduction_row % packs_per_item) * bits;
+                    const uint32_t packed =
+                        b[output_column * packed_cols + packed_column];
+                    const float quantized =
+                        static_cast<float>((packed >> shift) & mask);
+                    weight_fragment.thread_elements()[element] = static_cast<T>(
+                        quantized * weight_scales[element] +
+                        weight_biases[element]);
+                } else {
+                    weight_fragment.thread_elements()[element] = T(0);
+                }
+            }
+            simdgroup_multiply_accumulate(
+                next_accumulator,
+                activation_fragment,
+                weight_fragment,
+                accumulator);
+            accumulator = next_accumulator;
+        }
     }
 
     #pragma clang loop unroll(full)

--- a/src/tiny_llm/qwen3_week3.py
+++ b/src/tiny_llm/qwen3_week3.py
@@ -94,7 +94,7 @@ class Qwen3ModelWeek3:
         self,
         mlx_model: Any,
         page_size: int = 128,
-        enable_flash_attn: bool = False,
+        enable_flash_attn: bool | None = None,
         enable_performance_lab: bool = False,
         enable_paged_attention: bool = True,
     ):

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -89,12 +89,21 @@ def paged_attention(
 
     factor = mx.rsqrt(query.shape[-1]) if scale is None else mx.array(scale)
     B, H_q, L, D = query.shape
-    _, H, _, _ = key_pages.shape
+    _, H, stored_page_size, _ = key_pages.shape
     assert H_q % H == 0
+    if stored_page_size != page_size:
+        raise ValueError(
+            f"page_size={page_size} does not match page storage {stored_page_size}"
+        )
 
-    query = mx.contiguous(query.astype(mx.float32).reshape(B * H_q, L, D))
-    key_pages = mx.contiguous(key_pages.astype(mx.float32))
-    value_pages = mx.contiguous(value_pages.astype(mx.float32))
+    if query.dtype != key_pages.dtype or query.dtype != value_pages.dtype:
+        raise ValueError("query, key pages, and value pages must have the same dtype")
+    if query.dtype not in (mx.float32, mx.bfloat16):
+        raise ValueError("paged attention supports float32 or bfloat16 inputs")
+
+    query = mx.contiguous(query.reshape(B * H_q, L, D))
+    key_pages = mx.contiguous(key_pages)
+    value_pages = mx.contiguous(value_pages)
     block_table = mx.contiguous(block_table.astype(mx.int32))
     context_lens = mx.contiguous(context_lens.astype(mx.int32))
     is_causal = mask == "causal"

--- a/src/tiny_llm_ref/paged_kv_cache.py
+++ b/src/tiny_llm_ref/paged_kv_cache.py
@@ -17,21 +17,39 @@ class PagedKvMetadata:
 
 
 class TinyKvPagedPool:
-    """Model-local physical storage for paged KV.
+    """Layer-local physical storage for paged KV.
 
-    The model owns one pool and passes it to every layer cache. The pool gives
-    out physical page ids from one free list. Because every live page id is
-    unique, the page id alone is enough to find the physical K/V page.
+    The model owns one pool per transformer layer. Request caches for the same
+    layer share that pool, so a physical page id only needs to be unique within
+    its layer.
     """
 
     def __init__(self, page_size: int = 128):
         assert page_size > 0
         self.page_size = page_size
-        self.key_pages: mx.array | None = None
-        self.value_pages: mx.array | None = None
+        self._key_pages: mx.array | None = None
+        self._value_pages: mx.array | None = None
         self.free_page_ids: list[int] = []
         self.used_page_ids: set[int] = set()
         self.num_allocated_pages = 0
+
+    @property
+    def key_pages(self) -> mx.array | None:
+        if self._key_pages is None:
+            return None
+        return self._key_pages[: self.num_pages]
+
+    @property
+    def value_pages(self) -> mx.array | None:
+        if self._value_pages is None:
+            return None
+        return self._value_pages[: self.num_pages]
+
+    @property
+    def capacity(self) -> int:
+        if self._key_pages is None:
+            return 0
+        return self._key_pages.shape[0]
 
     @property
     def num_pages(self) -> int:
@@ -57,39 +75,38 @@ class TinyKvPagedPool:
         return page_id
 
     def read_page(self, page_id: int) -> tuple[mx.array, mx.array]:
-        if self.key_pages is None or self.value_pages is None:
+        if self._key_pages is None or self._value_pages is None:
             raise ValueError(f"Page {page_id} has no storage")
         if page_id >= self.num_pages:
             raise ValueError(f"Page {page_id} is out of range")
         return (
-            self.key_pages[page_id : page_id + 1],
-            self.value_pages[page_id : page_id + 1],
+            self._key_pages[page_id : page_id + 1],
+            self._value_pages[page_id : page_id + 1],
         )
 
     def _ensure_page_storage(self, key: mx.array, value: mx.array) -> None:
         B, H, _, D = key.shape
         assert B == 1
 
-        if self.key_pages is not None and self.value_pages is not None:
-            assert self.key_pages.shape[1:] == (H, self.page_size, D)
-            assert self.value_pages.shape == self.key_pages.shape
-            assert self.key_pages.dtype == key.dtype
-            assert self.value_pages.dtype == value.dtype
-            if self.key_pages.shape[0] >= self.num_pages:
+        if self._key_pages is not None and self._value_pages is not None:
+            assert self._key_pages.shape[1:] == (H, self.page_size, D)
+            assert self._value_pages.shape == self._key_pages.shape
+            assert self._key_pages.dtype == key.dtype
+            assert self._value_pages.dtype == value.dtype
+            if self.capacity >= self.num_pages:
                 return
 
-        new_key_pages = mx.zeros(
-            (self.num_pages, H, self.page_size, D), dtype=key.dtype
-        )
+        new_capacity = max(4, self.num_pages, self.capacity * 2)
+        new_key_pages = mx.zeros((new_capacity, H, self.page_size, D), dtype=key.dtype)
         new_value_pages = mx.zeros(
-            (self.num_pages, H, self.page_size, D), dtype=value.dtype
+            (new_capacity, H, self.page_size, D), dtype=value.dtype
         )
-        if self.key_pages is not None and self.value_pages is not None:
-            old_pages = self.key_pages.shape[0]
-            new_key_pages[:old_pages, :, :, :] = self.key_pages
-            new_value_pages[:old_pages, :, :, :] = self.value_pages
-        self.key_pages = new_key_pages
-        self.value_pages = new_value_pages
+        if self._key_pages is not None and self._value_pages is not None:
+            old_pages = self.num_pages - 1
+            new_key_pages[:old_pages, :, :, :] = self._key_pages[:old_pages]
+            new_value_pages[:old_pages, :, :, :] = self._value_pages[:old_pages]
+        self._key_pages = new_key_pages
+        self._value_pages = new_value_pages
 
     def write_page_slice(
         self,
@@ -103,10 +120,10 @@ class TinyKvPagedPool:
         if page_id not in self.used_page_ids:
             raise ValueError(f"Page {page_id} is free")
         self._ensure_page_storage(key, value)
-        assert self.key_pages is not None
-        assert self.value_pages is not None
-        H, capacity, D = self.key_pages.shape[1:]
-        assert self.value_pages.shape == self.key_pages.shape
+        assert self._key_pages is not None
+        assert self._value_pages is not None
+        H, capacity, D = self._key_pages.shape[1:]
+        assert self._value_pages.shape == self._key_pages.shape
         assert capacity == self.page_size
         assert key.shape[:2] == (1, H)
         assert key.shape[3] == D
@@ -114,8 +131,8 @@ class TinyKvPagedPool:
         assert 0 <= start <= capacity
         assert end <= self.page_size
 
-        self.key_pages[page_id, :, start:end, :] = key[0]
-        self.value_pages[page_id, :, start:end, :] = value[0]
+        self._key_pages[page_id, :, start:end, :] = key[0]
+        self._value_pages[page_id, :, start:end, :] = value[0]
 
     def free_page(self, page_id: int) -> None:
         if page_id not in self.used_page_ids:
@@ -127,11 +144,10 @@ class TinyKvPagedPool:
 
 
 class TinyKvPagedCache(TinyKvCache):
-    """Layer-local K/V cache backed by a model-owned page pool.
+    """Request-and-layer-local K/V cache backed by a layer page pool.
 
-    Each transformer layer gets its own TinyKvPagedCache and therefore its own
-    `page_ids`, `page_lens`, and `offset`. The shared part is only the pool,
-    which lets pages be recycled across requests and layers.
+    Each request gets one cache handle per transformer layer. Cache handles for
+    the same layer share a pool so pages can be recycled across requests.
     """
 
     def __init__(self, pool: TinyKvPagedPool):

--- a/src/tiny_llm_ref/qwen3_week3.py
+++ b/src/tiny_llm_ref/qwen3_week3.py
@@ -79,8 +79,8 @@ class Qwen3MultiHeadAttention:
         projection_k = projection_k.transpose(0, 2, 1, 3)
         projection_v = projection_v.transpose(0, 2, 1, 3)
 
-        if self.use_flash_attention and L > 8:
-            key, value, _, mask = cache.update_and_fetch(
+        if self.use_flash_attention and L > 8 and cache.offset == 0:
+            metadata = cache.update_and_fetch_paged(
                 projection_k,
                 projection_v,
                 mask_length=L,
@@ -88,10 +88,10 @@ class Qwen3MultiHeadAttention:
             )
             x = flash_attention(
                 projection_q,
-                key,
-                value,
+                projection_k,
+                projection_v,
                 scale=self.scale,
-                mask=mask,
+                mask=metadata.mask,
             )
         elif self.use_paged_attention:
             metadata = cache.update_and_fetch_paged(
@@ -238,11 +238,13 @@ class Qwen3ModelWeek3:
         self,
         mlx_model: Any,
         page_size: int = 128,
-        enable_flash_attn: bool = False,
+        enable_flash_attn: bool | None = None,
         enable_performance_lab: bool = False,
         enable_paged_attention: bool = True,
     ):
-        if enable_flash_attn and mlx_model.args.head_dim != 128:
+        if enable_flash_attn is None:
+            enable_flash_attn = mlx_model.args.head_dim == 128
+        elif enable_flash_attn and mlx_model.args.head_dim != 128:
             raise ValueError("Week 3 FlashAttention requires head_dim=128")
         self.num_hidden_layers = mlx_model.args.num_hidden_layers
         self.hidden_size = mlx_model.args.hidden_size

--- a/src/tiny_llm_ref/qwen3_week3.py
+++ b/src/tiny_llm_ref/qwen3_week3.py
@@ -101,7 +101,7 @@ class Qwen3MultiHeadAttention:
                 mask=mask,
             )
             x = paged_attention(
-                projection_q.astype(mx.float32),
+                projection_q,
                 metadata.key_pages,
                 metadata.value_pages,
                 metadata.block_table,
@@ -109,7 +109,7 @@ class Qwen3MultiHeadAttention:
                 metadata.page_size,
                 scale=self.scale,
                 mask=metadata.mask,
-            ).astype(x.dtype)
+            )
         else:
             key, value, _, mask = cache.update_and_fetch(
                 projection_k,
@@ -248,9 +248,12 @@ class Qwen3ModelWeek3:
         self.hidden_size = mlx_model.args.hidden_size
         self.vocab_size = mlx_model.args.vocab_size
         self.page_size = page_size
-        # One model-level pool is shared by all layer caches. Each layer cache
-        # still owns its own page table and allocates its own physical pages.
-        self.page_pool = TinyKvPagedPool(page_size=self.page_size)
+        # Each layer owns physical storage shared by all request caches for that
+        # layer. Page ids are therefore layer-local, as they are in the kernel.
+        self.page_pools = [
+            TinyKvPagedPool(page_size=self.page_size)
+            for _ in range(self.num_hidden_layers)
+        ]
         precision = mx.bfloat16
         self.precision = precision
 
@@ -331,11 +334,9 @@ class Qwen3ModelWeek3:
         self.mlx_model = mlx_model
 
     def create_kv_cache(self) -> list[TinyKvCache]:
-        # One request gets one cache handle per layer. The handles share the
-        # model-level pool, but their page_ids/page_lens/offset are independent.
-        return [
-            TinyKvPagedCache(pool=self.page_pool) for _ in range(self.num_hidden_layers)
-        ]
+        # One request gets one cache handle per layer. Requests share storage
+        # within a layer, while every handle keeps independent logical metadata.
+        return [TinyKvPagedCache(pool=pool) for pool in self.page_pools]
 
     def __call__(
         self,

--- a/tests_refsol/test_week_3_day_4.py
+++ b/tests_refsol/test_week_3_day_4.py
@@ -154,6 +154,19 @@ def test_task_1_paged_pool_reuses_freed_pages():
     assert_allclose(gathered_value, second_value, precision=mx.float32)
 
 
+def test_task_1_paged_pool_grows_storage_geometrically():
+    pool = TinyKvPagedPool(page_size=4)
+    cache = TinyKvPagedCache(pool=pool)
+    key, value = _random_chunk(17)
+
+    cache.update_and_fetch_paged(key, value)
+
+    assert pool.num_pages == 5
+    assert pool.capacity == 8
+    assert pool.key_pages.shape[0] == pool.num_pages
+    assert pool.value_pages.shape[0] == pool.num_pages
+
+
 def test_task_1_paged_cache_rewind():
     page_size = 4
     pool = TinyKvPagedPool(page_size=page_size)
@@ -184,7 +197,7 @@ def test_task_1_paged_cache_rewind():
     assert_allclose(paged_value, full_value, precision=mx.float32)
 
 
-def test_task_1_model_kv_caches_share_layer_pools():
+def test_task_1_model_kv_caches_share_storage_within_each_layer():
     mlx_model = _fake_qwen3_mlx_model()
     week3_model = Qwen3ModelWeek3(mlx_model, page_size=4, enable_paged_attention=False)
     first_request_cache = week3_model.create_kv_cache()
@@ -192,12 +205,12 @@ def test_task_1_model_kv_caches_share_layer_pools():
 
     assert len(first_request_cache) == week3_model.num_hidden_layers
     for layer in range(week3_model.num_hidden_layers):
-        assert first_request_cache[layer].pool is week3_model.page_pool
-        assert second_request_cache[layer].pool is week3_model.page_pool
+        assert first_request_cache[layer].pool is week3_model.page_pools[layer]
+        assert second_request_cache[layer].pool is week3_model.page_pools[layer]
 
     assert first_request_cache[0].page_ids is not first_request_cache[1].page_ids
     assert first_request_cache[0].page_lens is not first_request_cache[1].page_lens
-    assert first_request_cache[0].pool is first_request_cache[1].pool
+    assert first_request_cache[0].pool is not first_request_cache[1].pool
 
 
 def test_task_1_model_layer_caches_keep_independent_page_metadata():
@@ -210,13 +223,11 @@ def test_task_1_model_layer_caches_keep_independent_page_metadata():
 
     assert cache[0].page_ids == [0, 1]
     assert cache[0].page_lens == [4, 1]
-    owned_page_ids = set(cache[0].page_ids)
     for layer in range(1, week3_model.num_hidden_layers):
         assert cache[layer].page_lens == cache[0].page_lens
-        assert owned_page_ids.isdisjoint(cache[layer].page_ids)
-        owned_page_ids.update(cache[layer].page_ids)
+        assert cache[layer].page_ids == cache[0].page_ids
         for page_id in cache[layer].page_ids:
-            key_page, value_page = week3_model.page_pool.read_page(page_id)
+            key_page, value_page = week3_model.page_pools[layer].read_page(page_id)
             assert key_page.shape[2] == week3_model.page_size
             assert value_page.shape[2] == week3_model.page_size
 

--- a/tests_refsol/test_week_3_day_5.py
+++ b/tests_refsol/test_week_3_day_5.py
@@ -191,6 +191,48 @@ def test_task_2_batched_paged_attention_matches_dense_attention():
     assert_allclose(paged_output[2:3], second_output, precision=mx.float32)
 
 
+@pytest.mark.parametrize("query_length", [1, 65])
+def test_paged_attention_preserves_bfloat16_for_decode_and_prefill(query_length):
+    page_size = 32
+    pool = TinyKvPagedPool(page_size=page_size)
+    cache = TinyKvPagedCache(pool=pool)
+    blocker = TinyKvPagedCache(pool=pool)
+    first_key, first_value = _random_chunk(64, head_dim=128)
+    first_key = first_key.astype(mx.bfloat16)
+    first_value = first_value.astype(mx.bfloat16)
+    cache.update_and_fetch(first_key, first_value)
+
+    blocker_key, blocker_value = _random_chunk(page_size, head_dim=128)
+    blocker.update_and_fetch(
+        blocker_key.astype(mx.bfloat16),
+        blocker_value.astype(mx.bfloat16),
+    )
+    next_key, next_value = _random_chunk(query_length, head_dim=128)
+    metadata = cache.update_and_fetch_paged(
+        next_key.astype(mx.bfloat16),
+        next_value.astype(mx.bfloat16),
+        mask="causal",
+    )
+    query = mx.random.normal(shape=(1, 4, query_length, 128)).astype(mx.bfloat16)
+
+    dense_key, dense_value = cache.gather_dense()
+    expected = flash_attention(query, dense_key, dense_value, mask="causal")
+    output = paged_attention(
+        query,
+        metadata.key_pages,
+        metadata.value_pages,
+        metadata.block_table,
+        metadata.context_lens,
+        metadata.page_size,
+        mask=metadata.mask,
+    )
+
+    assert cache.page_ids[:2] == [0, 1]
+    assert cache.page_ids[2] == 3
+    assert output.dtype == mx.bfloat16
+    assert_allclose(output, expected, precision=mx.bfloat16, rtol=0.02, atol=0.02)
+
+
 def test_task_3_incremental_decode_matches_week2_with_paged_attention():
     mlx_model = _fake_qwen3_mlx_model()
     week2_model = Qwen3ModelWeek2(mlx_model)

--- a/tests_refsol/test_week_3_day_5.py
+++ b/tests_refsol/test_week_3_day_5.py
@@ -266,15 +266,22 @@ def test_task_3_incremental_decode_matches_week2_with_paged_attention():
         )
 
 
-def test_week3_flash_prefill_matches_paged_prefill():
+def test_week3_flash_prefill_matches_paged_prefill(monkeypatch):
     mlx_model = _fake_qwen3_mlx_model(head_dim=128)
-    paged_model = Qwen3ModelWeek3(mlx_model, page_size=4)
-    flash_model = Qwen3ModelWeek3(mlx_model, page_size=4, enable_flash_attn=True)
+    paged_model = Qwen3ModelWeek3(
+        mlx_model, page_size=4, enable_flash_attn=False
+    )
+    flash_model = Qwen3ModelWeek3(mlx_model, page_size=4)
     inputs = mx.array([[1, 5, 7, 3, 9, 11, 4, 2, 8]], dtype=mx.int32)
     paged_cache = paged_model.create_kv_cache()
     flash_cache = flash_model.create_kv_cache()
 
     paged_out = paged_model(inputs, 0, paged_cache)
+    monkeypatch.setattr(
+        TinyKvPagedCache,
+        "gather_dense",
+        lambda self: pytest.fail("ordinary FlashAttention prefill must not gather K/V"),
+    )
     flash_out = flash_model(inputs, 0, flash_cache)
     paged_out = paged_out - mx.logsumexp(paged_out, axis=-1, keepdims=True)
     flash_out = flash_out - mx.logsumexp(flash_out, axis=-1, keepdims=True)

--- a/tests_refsol/test_week_3_day_5.py
+++ b/tests_refsol/test_week_3_day_5.py
@@ -1,5 +1,6 @@
 """Week 3 Day 5 paged-attention runtime tests."""
 
+import inspect
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -16,6 +17,15 @@ from .tiny_llm_base import (
     scaled_dot_product_attention_grouped,
 )
 from .utils import assert_allclose
+
+
+def test_paged_attention_is_course_owned():
+    source = inspect.getsource(paged_attention)
+
+    assert "mx.fast" not in source
+    assert "scaled_dot_product_attention" not in source
+    assert "gather_dense" not in source
+    assert ".paged_attention(" in source
 
 
 def _random_chunk(


### PR DESCRIPTION
## Summary

Paged attention used a scalar FP32 tile sized for 32 query rows even during one-token decode, while a model-wide page pool grew by copying one page at a time. Together these made the Week 3 teaching path much slower than dense decode and caused quadratic allocator-copy work.

This change preserves BF16, adds a dedicated vector paged-decode path and a FlashAttention-derived paged-prefill fallback, and uses geometrically growing per-layer page pools. Supported Week 3 models now run course-owned FlashAttention directly on fresh K/V for ordinary prefill, store those same tensors in the paged cache without gathering them back, and automatically switch to paged attention for decode. Paged prefill remains for chunked prefill with cached history; the disable flag is retained for measured ablations.

The prefill performance lab also keeps quantization scale and bias in registers across each 128-value group. This improves the synchronized 128-token Q projection from about 370 to 328 microseconds and raises the matched lab checkpoint to roughly 2,371 prefill tok/s versus 4,416 for MLX. Zero-gather Flash prefill adds about 1.7% at 128 tokens and 2.0% at 512 tokens once the optimized matmul is enabled. Rejected load-broadcast, smaller-threadgroup, and wider-register-tile experiments are recorded in the course ledger.

The implementation boundary is documented and tested: learned operators dispatch to course-owned extensions rather than MLX fast implementations. The complete Week 3 reference suite passes (69 passed, 4 model-dependent skips), and the book and lint checks pass.

_AI-assisted: Codex._