### PR TITLE
Document retained optimization inventory

### DIFF
--- a/book/src/appendix-performance.md
+++ b/book/src/appendix-performance.md
@@ -56,6 +56,33 @@ pdm run bench --solution tiny_llm_ref --loader week3 --batch-decode \
 Always record the model, MLX version, hardware, prompt/output lengths, warmup,
 repeat count, and whether the number is a median or one representative run.
 
+## Retained Optimization Inventory
+
+This table is the implementation checklist for the optimized course path. Every
+retained optimization in the repository has a teaching location; rejected
+experiments and their measurements are recorded in the Week 3 performance lab.
+
+| Retained change | Shipped implementation boundary | Where it is explained |
+|---|---|---|
+| Synchronized, matched measurement | `bench.py` evaluates timed work, computes full prompt logits for matched prefill, releases caches, and separates prefill from decode. `bench_course_progression.py` uses fresh processes, alternating order, medians, and optional pauses between runs. | Week 2 Day 2 and this appendix |
+| KV cache before decode tuning | `TinyKvFullCache`, `create_kv_cache`, and cached generation prefill once and then pass one new token. | Week 2 Day 1 |
+| Packed 4-bit weights | `QuantizedWeights` preserves weight, scale, bias, group size, and bit width instead of materializing dense 16-bit matrices. | Week 2 Day 3 |
+| Shape-dispatched SIMD matvec | `quantized_matvec_x2` handles ordinary projections and `quantized_matvec_x8` handles `K >= 8192`; eight SIMD groups share activation loads and reduce with `simd_sum`. | Week 2 Day 3 |
+| Matvec scheduling cleanup | The retained kernel rereads the cache-hot activation vector instead of copying it to threadgroup memory and waiting at a barrier. | Week 2 Day 3 scheduling ablations |
+| Online decode attention | `decode_attention_custom` keeps the query in registers, uses 32 SIMD groups, FP32 online softmax, and a parallel final reduction for `L <= 8` and context at most 256. | Week 2 Day 4 |
+| Fused RMSNorm | One 256-thread group performs a two-level reduction, normalization, and learned scaling with FP32 accumulation. | Week 2 Day 5 |
+| Fused RoPE | One thread computes an angle once for a pair and reuses it across four heads; batch offsets are normalized once per model call. | Week 2 Day 5 |
+| Fused SwiGLU | One Metal dispatch computes SiLU and multiplies the up branch without graph intermediates. | Week 2 Day 5 |
+| Decode graph cleanup | Generation requests `logits_to_keep=1`, single-token decode omits the causal-mask graph, and Week 1 remains unchanged. | Week 3 performance lab and Week 2 overview |
+| SIMD-matrix quantized prefill | The optional `quantized_matmul_simdgroup` path uses 8-by-8 matrix fragments, unpacking weights directly and accumulating in FP32. | Week 3 performance lab |
+| Direct quantized embedding | The optional embedding kernel fuses row gather, int4 unpacking, scale, and bias for both signed and unsigned token IDs. | Week 3 performance lab |
+| FlashAttention prefill | The BF16 SIMD-matrix kernel streams Q/K/V tiles, uses FP32 online softmax, bounds causal work, and avoids the quadratic score tensor. | Week 3 Day 2 |
+| Serving and cache scheduling | Continuous batching reuses active slots, chunked prefill bounds scheduler stalls, and paged attention separates logical context from reusable physical pages. | Week 3 Days 1 and 3-5 |
+
+The model-loading boundary is not an optimization shortcut. MLX still supplies
+model files, arrays, streams, allocation, and extension dispatch; the retained
+Week 2 learned operators above execute course-owned Python, C++, or Metal code.
+
 ## End-to-End Checkpoints and Reverse Ablations
 
 The following post-restructure snapshot used Qwen3-0.6B on an Apple M4 Pro

--- a/book/src/week2-03-quantized-matvec.md
+++ b/book/src/week2-03-quantized-matvec.md
@@ -383,6 +383,20 @@ retained schedule looks this way; they are not Day 3's cumulative course
 result. The end of this chapter reports the matched Day 2 to Day 3 checkpoint
 change.
 
+The final host dispatcher makes that schedule explicit. Flatten all leading
+activation dimensions into `M`, then use the custom matvec when `M <= 8`.
+Within that path, use two output columns per SIMD group for ordinary
+projections and switch to eight when `K >= 8192`, which selects the wide
+vocabulary head. These are measured dispatch thresholds, not mathematical
+requirements; keep them visible so a later profile can replace them.
+
+At the Python-to-extension boundary, make scales, biases, activations, and
+packed weights row-contiguous once with `mx.contiguous`. The C++ primitive
+validates that contract before encoding the kernel. A Metal kernel receives
+raw buffers and strides are not implicit, so silently accepting a noncontiguous
+view would produce either wrong addressing or a slower hidden copy in a less
+explicit layer.
+
 Likewise, raising the ordinary projection tile from two to four output columns
 increased register pressure enough to reduce decode to about 232 tok/s. The
 best measured split is two columns for normal projections and eight only for
@@ -444,7 +458,8 @@ pattern:
 4. Select the matrix-vector layout for `M <= 8`; otherwise select the vanilla
    matrix layout. Keep both paths explicit for direct comparisons.
    Calculate a SIMD-aligned thread-group configuration and tile output columns
-   so packed input values and activations can be reused.
+   so packed input values and activations can be reused. Use the two-column
+   kernel below `K = 8192` and the eight-column kernel at or above it.
 5. Dispatch with `dispatchThreadgroups`.
 
 You can test your implementation by running:

--- a/book/src/week2-04-decode-attention.md
+++ b/book/src/week2-04-decode-attention.md
@@ -112,6 +112,12 @@ should not be forced onto 2,048 tokens. Retain the readable composition for
 tests and ablations, and retain tiled prefill FlashAttention in Week 3; prefill
 is a different workload where both query and context lengths are large.
 
+The retained reference guard is deliberately concrete: use the course kernel
+only when query length is at most eight and cached context length is at most
+256. Otherwise use the readable grouped-attention path. Keeping this condition
+at the model call site makes the benchmarked operating range reviewable instead
+of burying a performance policy inside the Metal kernel.
+
 Keep arbitrary dense, per-request masks on the readable compatibility path.
 They appear in the first continuous-batching exercise, while the normal Week 2
 decode path uses no explicit mask. Week 3 replaces dense batch masks with paged

--- a/book/src/week2-05-fast-kernels.md
+++ b/book/src/week2-05-fast-kernels.md
@@ -155,6 +155,13 @@ Compare against the readable equations with tolerances rather than bit-for-bit
 equality. Test RoPE with scalar and per-batch offsets. Always call `mx.eval`
 inside a timed iteration when measuring these lazy operations.
 
+The operator benchmark must also compare the same logical RoPE layout. The
+course kernel accepts the model-native `B, L, H, D` tensor. `mx.fast.rope`
+expects `B, H, L, D`, so transpose into that layout before the MLX call and
+transpose its result back afterward. Without those transposes, a one-token
+benchmark accidentally treats the head axis as sequence positions and the
+timing no longer measures an equivalent operation.
+
 ## Expected Performance Contribution
 
 **Measured operator improvement: about 34-39% over the readable Week 1


### PR DESCRIPTION
## Why

The merged course restructure explains the optimization work across several chapters, but a reviewer or student should be able to verify that every retained implementation has a teaching location without reconstructing the mapping from source files.

## What changed

- adds a code-to-chapter inventory covering measurement controls, KV caching, quantized matvec scheduling, fused operators, decode and prefill attention, graph cleanup, embedding, batching, chunking, and paging;
- documents the exact x2/x8 matvec thresholds and contiguous extension boundary;
- records the decode-attention crossover guard and the layout transpose required for a fair MLX RoPE comparison;
- keeps the existing top-of-page WIP warnings on every substantially revised chapter and appendix.

_AI-assisted: Codex._