### PR TITLE
Refresh course performance metrics and Week 4 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ can build the model serving infrastructure from scratch and dig into the optimiz
 
 The goal is to learn the techniques behind efficiently serving a large language model (e.g., Qwen3 models).
 
-In week 1, you will implement the necessary components in Python (only Python!) to use the Qwen3 model to generate responses (e.g., attention, RoPE, etc). In week 2, **A Step Closer to vLLM**, you will add a KV cache first, then integrate and measure course-owned Metal decode and SIMD-matrix prefill kernels until the model reaches about 70% of MLX's decode performance. In week 3, **Build a Mini vLLM**, you will turn that fast model into a serving engine with continuous batching, chunked prefill, paged attention, and FlashAttention over paged KV. In week 4, you will use the engine to build applications such as coding agents and RAG.
+In week 1, you will implement the necessary components in Python (only Python!) to use the Qwen3 model to generate responses (e.g., attention, RoPE, etc). In week 2, **A Step Closer to vLLM**, you will add a KV cache first, then integrate and measure course-owned Metal decode and SIMD-matrix prefill kernels until the model reaches about 75% of MLX's decode performance. In week 3, **Build a Mini vLLM**, you will turn that fast model into a serving engine with continuous batching, chunked prefill, paged attention, and FlashAttention over paged KV. The seven-day Week 4 draft then builds a coding agent through an agent loop, bounded tools, safety checks, sessions, context compaction, control and recovery, and held-out evaluation.
 
 Why MLX: nowadays it's easier to get a macOS-based local development environment than setting up an NVIDIA GPU.
 
@@ -44,17 +44,22 @@ existing status, and all Week 4 application material remains work in progress.
 | 2.3            | Quantized Matvec                                             | ✅    | ✅   | 🚧  |
 | 2.4            | Decode Attention                                             | 🚧    | 🚧   | 🚧  |
 | 2.5            | Fast Model Kernels                                           | 🚧    | 🚧   | 🚧  |
+| 2.6            | SIMD-Matrix Prefill                                          | ✅    | ✅   | 🚧  |
 | 3.1            | Continuous Batching                                           | ✅    | ✅   | 🚧  |
-| 3.2            | Flash Attention for Prefill                                  | ✅    | ✅   | 🚧  |
-| 3.3            | Chunked Prefill                                               | ✅    | ✅   | 🚧  |
-| 3.4            | Paged KV Cache                                                | ✅    | ✅   | 🚧  |
-| 3.5            | Paged Attention                                               | ✅    | ✅   | 🚧  |
+| 3.2            | Chunked Prefill                                               | ✅    | ✅   | 🚧  |
+| 3.3            | Paged KV Cache                                                | ✅    | ✅   | 🚧  |
+| 3.4            | Direct Paged Attention                                        | ✅    | ✅   | 🚧  |
+| 3.5            | Paged FlashAttention                                          | ✅    | ✅   | 🚧  |
 | 3.6 (optional) | MoE (Mixture of Experts)                                     | ✅    | ✅   | ✅  |
-| 3.7 (optional) | Performance Lab                                               | 🚧    | 🚧   | 🚧  |
-| 3.8 (optional) | Speculative Decoding                                         | 🚧    | 🚧   | 🚧  |
-| 4.1            | CLI Coding Agent                                              | 🚧    | 🚧   | 🚧  |
-| 4.2            | RAG Pipeline                                                  | 🚧    | 🚧   | 🚧  |
-| 4.3            | Tool Calling and Agent Serving                               | 🚧    | 🚧   | 🚧  |
+| 3.7 (optional) | Serving Performance Lab                                       | 🚧    | 🚧   | 🚧  |
+| 3.x (optional) | Speculative Decoding                                          | 🚧    | 🚧   | 🚧  |
+| 4.1            | Agent Loop                                                    | 🚧    | 🚧   | 🚧  |
+| 4.2            | Tools                                                         | 🚧    | 🚧   | 🚧  |
+| 4.3            | Safety and Validation                                         | 🚧    | 🚧   | 🚧  |
+| 4.4            | Sessions                                                      | 🚧    | 🚧   | 🚧  |
+| 4.5            | Context Compaction                                            | 🚧    | 🚧   | 🚧  |
+| 4.6            | Control and Recovery                                          | 🚧    | 🚧   | 🚧  |
+| 4.7            | Evaluation                                                    | 🚧    | 🚧   | 🚧  |
 
 Other topics not covered: quantized/compressed KV cache, prefix/prompt cache, fine-tuning, and long-context techniques.
 

--- a/book/src/appendix-performance.md
+++ b/book/src/appendix-performance.md
@@ -50,7 +50,10 @@ For operator attribution and serving throughput, also use:
 pdm run bench-week2-operators --model qwen3-0.6b --context 128
 
 pdm run bench --solution tiny_llm_ref --loader week3 --batch-decode \
-  --num-seqs 16 --batch-size 4 --model qwen3-0.6b
+  --num-seqs 16 --batch-size 4 --prefill-step 128 \
+  --min-input-len 128 --max-input-len 128 \
+  --min-output-len 65 --max-output-len 65 --warmup 1 \
+  --model qwen3-0.6b
 ```
 
 Always record the model, MLX version, hardware, prompt/output lengths, warmup,
@@ -88,36 +91,33 @@ learned operators above execute course-owned Python, C++, or Metal code.
 
 Use the following Qwen3-0.6B snapshot as a reasonableness check after running
 the commands above. It was measured on an Apple M4 Pro with a 20-core GPU and
-64 GB of memory, using a 128-token prompt, 65 generated tokens, two complete
-warmups, and a three-process median. Some rows come from separate historical
-campaigns and are labeled accordingly; rerun the current progression command
-for a matched comparison on your machine.
+64 GB of memory, MLX 0.29.1, and Python 3.12.13. Every row uses a 128-token
+prompt, 65 generated tokens, two complete warmups, and the median of three
+fresh processes. The runner alternated checkpoint order across repeats.
 
 | Checkpoint | Prefill tok/s | Versus Week 1 | Gap to MLX | Decode tok/s | Versus Week 1 | Gap to MLX |
 |---|---:|---:|---:|---:|---:|---:|
-| Week 1 readable model | 3,342.45 | baseline | 24.1% slower | 19.49 | baseline | 93.4% slower |
-| Week 2 through Day 5 | 1,012.27 | 69.7% slower | 77.0% slower | 240.17 | 12.32x | 18.5% slower |
-| Week 2 completed SIMD-matrix model (historical dense run) | 2,042 | 38.9% slower | 53.6% slower | 246 | 12.62x | 16.5% slower |
-| Week 3 completed paged FlashAttention model | 1,956.79 | 41.5% slower | 55.6% slower | 204.80 | 10.51x | 30.5% slower |
-| MLX | 4,402.94 | 1.32x | baseline | 294.75 | 15.12x | baseline |
+| Week 1 readable model | 3,310.10 | baseline | 24.5% slower | 19.44 | baseline | 93.9% slower |
+| Week 2 completed SIMD-matrix model | 1,928.49 | 41.7% slower | 56.0% slower | 244.87 | 12.60x | 23.5% slower |
+| Week 3 completed paged FlashAttention model | 1,859.97 | 43.8% slower | 57.6% slower | 207.40 | 10.67x | 35.2% slower |
+| MLX | 4,383.47 | 1.32x | baseline | 320.06 | 16.46x | baseline |
 
 Week 1 prefill is fast because it materializes dense 16-bit weights and uses
 efficient dense matrix multiplication. Week 2 deliberately optimizes the
-memory-bound one-token decode shape first; its readable scalar quantized
-prefill path therefore regresses. Week 2 Day 6 recovers part of that prefill
-gap before serving work begins. The paged vector decode kernel stays close to the
-dense course kernel, while page-cache and serving-runtime overhead leave the
-single-request checkpoint about 13.8% behind Week 2 decode. The runner releases
-every request cache, including warmups, so paged checkpoints reuse allocator
-capacity rather than timing pool growth left by an earlier run.
+memory-bound one-token decode shape first; its scalar quantized prefill path
+therefore regresses until Week 2 Day 6 introduces SIMD-matrix fragments. Week
+3's page-table and serving-runtime work is not free: the single-request
+checkpoint is 15.3% slower than Week 2 for decode and 3.6% slower for prefill at
+this short shape. The serving measurement below shows the separate benefit
+when four requests share the decode batch.
 
-## Historical Week 2 Chapter Ladder
+## Matched Week 2 Chapter Ladder
 
-The next two tables preserve a separate three-process M4 Pro Week 2 progression
-run with a 128-token prompt, 65 generated tokens, and two warmups. Its Week 1
-decode baseline was 19.51 tok/s and its matched MLX denominator was 327.84
-tok/s. Use this campaign to attribute the cumulative Week 2 steps; do not mix
-its denominators with the newer full-course snapshot above.
+This separate three-process campaign uses the same model, prompt/output shape,
+warmups, hardware, and alternating order. Its matched denominators are Week 1
+at 3,313.05 prefill and 19.34 decode tok/s, and MLX at 4,373.56 prefill and
+316.35 decode tok/s. End-to-end rows are cumulative; percentages are changes
+from the preceding executable checkpoint unless stated otherwise.
 
 ### Week 1: Establish the Readable Baseline
 
@@ -127,93 +127,94 @@ its denominators with the newer full-course snapshot above.
 | 1.2 RoPE | Builds positions, sine, and cosine with array operations. | No isolated checkpoint gain; Week 2 later fuses this work. |
 | 1.3 GQA | Shares K/V heads, reducing KV storage versus full multi-head attention. | The Qwen3 architecture already fixes the head ratio, so the course has no MHA-to-GQA timing ablation. |
 | 1.4 RMSNorm and MLP | Uses readable array expressions and exposes intermediate tensors. | No speed claim; Week 2 measures fused replacements against these equations. |
-| 1.5 Qwen3 Model | Produces the first complete model and the baseline prefill graph. | The completed Week 1 checkpoint measured about 3,350 prefill tok/s, 24.1% below MLX. |
-| 1.6 Generation | Recomputes the growing prefix for every output token. | About 19.51 decode tok/s at context 128, roughly 94.0% below MLX. |
+| 1.5 Qwen3 Model | Produces the first complete model and the baseline prefill graph. | The completed Week 1 checkpoint measured 3,313.05 prefill tok/s, 24.2% below MLX. |
+| 1.6 Generation | Recomputes the growing prefix for every output token. | The matched checkpoint reached 19.34 decode tok/s at context 128, 93.9% below MLX. |
 | 1.7 Sampling | Adds temperature/top-p/top-k policy after logits. | Not a model-throughput optimization; deterministic argmax is used by the course benchmark. |
 
 ### Week 2: Build the Fast Decode Checkpoint
 
-Unless a row identifies an isolated or M1 Pro measurement, the estimates come
-from this historical Week 2 progression campaign. End-to-end rows are
-cumulative and include all earlier rows; do not add the percentages together.
-
 | Chapter | Change | Measured estimate | How to interpret it |
 |---|---|---|---|
-| 2.1 KV Cache | Prefill once, retain K/V, and process one new query per decode step while preserving the readable Week 1 operators. | 19.51 → 101.80 decode tok/s: 5.22x Week 1 and 68.9% below MLX. | This is an algorithmic gain, not a faster operator. Its size depends strongly on context and output length and grows as full-prefix recomputation becomes more expensive. |
+| 2.1 KV Cache | Prefill once, retain K/V, and process one new query per decode step while preserving the readable Week 1 operators. | Prefill 3,296.76; decode 98.47 tok/s, or 5.09x Week 1 and 68.9% below MLX. | This is an algorithmic gain, not a faster operator. Its size depends strongly on context and output length and grows as full-prefix recomputation becomes more expensive. |
 | 2.2 Benchmark | Synchronize lazy work, separate prefill from decode, and establish the cached and MLX baselines. | 0% direct speedup. | Measurement prevents changes in inputs, synchronization, or machine state from being mistaken for optimization. |
-| 2.3 Quantized Matvec | Keep weights packed and use the course SIMD matvec for every decode projection. | End to end: 101.80 → 134.24 tok/s (+31.9%), 6.88x Week 1 and 59.1% below MLX. Isolated versus the scalar quantized kernel: Q/K/V/O were 1.39–1.65x, gate/up/down were 1.86–1.89x, and the 151,936-row tied output head was about 10.5x. | Operator and end-to-end gains answer different questions. On the earlier M1 Pro path, the first two-column SIMD matvec added about 5.7%, and removing its activation barrier added another 3–4%; those historical deltas are not part of the M4 Pro ladder. |
-| 2.4 Decode Attention | Replace the readable float32 score/softmax/value composition with a course-owned online-softmax kernel in its measured short-context range. | 134.24 → 143.42 tok/s (+6.8%) at context 128: 7.35x Week 1 and 56.3% below MLX. | An isolated comparison against a different readable bfloat16 composition was about 7% faster at context 128 but became slower at longer contexts; it is not the cumulative course comparison. Quantized weight reads still dominate short decode, and the fixed 32-group schedule does not scale monotonically. Report dtype, context, schedule, and end-to-end throughput rather than treating avoided intermediates as a speedup by themselves. |
-| 2.5a RMSNorm | Fuse square, reduction, normalization, and scaling in a course Metal kernel. | Isolated: about 1.36x the readable equation. Cumulative: 143.42 → 193.18 tok/s (+34.7%). | The cumulative delta includes every preceding chapter, while the isolated number compares only the operator at decode shapes. |
-| 2.5b RoPE | Rotate pairs directly and reuse each angle across four heads. | Cumulative: 193.18 → 222.51 tok/s (+15.2%). | This row starts from the RMSNorm checkpoint, so it is not additive with the RMSNorm percentage. The prior isolated RoPE number used a mismatched MLX layout and is intentionally omitted until rerun with the corrected transpose. |
-| 2.5c SwiGLU | Fuse SiLU and multiplication into one element-by-element kernel. | Isolated: about 1.39x the readable equation. Cumulative: 222.51 → 242.67 tok/s (+9.1%). | This row starts from the RoPE checkpoint. The verified isolated RMSNorm and SwiGLU gains were about 36% and 39% over their readable equations. |
-| 2.6 SIMD-Matrix Prefill | Add the tiled quantized prefill schedule, direct quantized embedding, and last-token projection. | A separate dense ablation reached about 2,042 prefill tok/s and 246 decode tok/s. | This is not denominator-compatible with the preceding progression rows; rerun the current ladder for a matched result. |
-| Week 2 checkpoint | Combine the dense KV cache, SIMD matvec, decode attention, fused element-wise kernels, and SIMD-matrix prefill. | The through-Day-5 campaign reached 242.67 decode tok/s versus 327.84 for matched MLX; the later Day 6 dense ablation reached about 246 tok/s. | Compare rows only within one campaign; use the current commands above for the latest integrated checkpoint. |
+| 2.3 Quantized Matvec | Keep weights packed and use the course SIMD matvec for every decode projection. | Prefill 747.08; decode 130.19 tok/s, +32.2% from Day 1 and 58.8% below MLX. | Packed weights reduce decode memory traffic but make the still-scalar prefill path much slower. The isolated table below separates kernel latency from this end-to-end result. |
+| 2.4 Decode Attention | Replace the readable score/softmax/value composition with a course-owned online-softmax kernel in its measured short-context range. | Prefill 732.02; decode 137.71 tok/s, +5.8%. | Quantized weight reads still dominate short decode. Report dtype, context, schedule, and end-to-end throughput rather than treating avoided intermediates as a speedup by themselves. |
+| 2.5a RMSNorm | Fuse square, reduction, normalization, and scaling in a course Metal kernel. | Prefill 731.85; decode 185.55 tok/s, +34.7%. | The cumulative delta includes all prior chapters; the isolated kernel is 1.31x faster than the readable equation. |
+| 2.5b RoPE | Rotate pairs directly and reuse each angle across four heads. | Prefill 766.62; decode 214.61 tok/s, +15.7%. | The corrected-layout isolated comparison is 1.52x faster than readable RoPE. |
+| 2.5c SwiGLU | Fuse SiLU and multiplication into one element-by-element kernel. | Prefill 777.80; decode 234.78 tok/s, +9.4%. | The isolated fused kernel is 1.38x faster than the readable expression. |
+| 2.6 SIMD-Matrix Prefill | Add the tiled quantized prefill schedule, direct quantized embedding, and last-token projection. | Prefill 1,932.94 tok/s, +148.5%; decode 240.98 tok/s, +2.6%. | This is the workload-shape handoff: matrix fragments repair prefill while leaving the one-token SIMD matvec path intact. |
+| Week 2 checkpoint | Combine the dense KV cache, SIMD matvec, decode attention, fused element-wise kernels, and SIMD-matrix prefill. | 12.46x Week 1 decode; 23.8% below MLX decode and 55.8% below MLX prefill. | All figures now come from one matched campaign. |
 
 ## Week 3: Improve Serving Structure
 
 | Chapter | What improves | Performance reality |
 |---|---|---|
-| 3.1 Continuous Batching | Reuses decode slots as requests finish and keeps multiple requests active. | Improves aggregate utilization, not single-request latency. In one four-request snapshot, dense batching reached 305.3 aggregate decode tok/s versus 240.2 for one Week 2 request; do not treat different batch sizes as a kernel speedup. |
+| 3.1 Continuous Batching | Reuses decode slots as requests finish and keeps multiple requests active. | Improves aggregate utilization, not single-request latency. The fixed serving snapshot below reports both wall-clock output and timed decode throughput. |
 | 3.2 Chunked Prefill | Bounds how long a prompt can delay active decoders. | Primarily improves fairness and time-to-next-token. Smaller chunks add launches and may reduce aggregate throughput; report both latency and throughput. |
 | 3.3 Paged Attention, Part 1 | Allocates a paged KV cache with fixed-size reusable pages and separates logical context from physical storage. | Per-layer pools grow geometrically and share storage across requests in that layer. This improves capacity, reuse, removal, and fragmentation without serializing every layer through one backing tensor. |
-| 3.4 Paged Attention, Part 2 | Reads K/V through page tables without rebuilding dense per-request K/V. | The decode operator is approximately matched with the dense course kernel across the documented batch/context cases. The single-request paged checkpoint reached 206.96 decode tok/s, 29.8% below MLX; the matched four-request serving run reached 348.75 aggregate decode tok/s. |
-| 3.5 Paged FlashAttention | Tiles the direct Day 4 page walk with Week 2 SIMD-matrix fragments and online softmax. | Its opportunity is long prefill; decode retains the Day 4 vector schedule. The completed historical snapshot reached about 1,957 prefill tok/s at the short course shape. |
+| 3.4 Paged Attention, Part 2 | Reads K/V through page tables without rebuilding dense per-request K/V. | The completed single-request Week 3 checkpoint reached 207.40 decode tok/s. With four active slots, the paged serving path reached a 327.62 tok/s median during timed decode sections. |
+| 3.5 Paged FlashAttention | Tiles the direct Day 4 page walk with Week 2 SIMD-matrix fragments and online softmax. | Its opportunity is long prefill; decode retains the Day 4 vector schedule. The completed checkpoint reached 1,859.97 prefill tok/s at the short course shape. |
 | 3.6 Optional MoE | Routes tokens through selected experts and supports sparse Qwen3 variants. | Expands model coverage and can reduce active parameter work, but the course has no controlled dense-versus-MoE speed claim. |
 | 3.7 Optional Serving Lab | Varies chunk size, batch size, page size, request mix, and dense-versus-paged policy without adding a model kernel. | Report latency, throughput, memory, fairness, and allocator behavior together. |
 | Optional Speculative Decoding | Drafts several tokens and verifies them with the target model. | Work in progress. Speed depends on acceptance rate and cache-rewind cost; no result should be claimed yet. |
 
-### Moved Week 2 Kernel Attribution
+### Current Isolated Operator Snapshot
 
-These measurements motivated the kernels that now live in Week 2 Day 6. They
-are reference evidence, not results to copy. Reproduce the comparison with the
-progression and operator commands at the start of this appendix.
+The operator runner uses synchronized median latency over 50 iterations after
+10 warmups at the Qwen3-0.6B shapes. Lower latency is better. The speedup column
+compares the course kernel with its readable or vanilla course implementation,
+not with MLX.
 
-Last-token logits made the output projection about 40x faster and the complete
-Qwen3-0.6B model about 1.29x faster in one M4 Pro measurement. Normalizing RoPE
-offsets once saved about 2% per isolated call, while omitting the single-token
-causal flag was below the measurable noise floor.
+| Operator | Readable/vanilla µs | Course µs | MLX µs | Course speedup |
+|---|---:|---:|---:|---:|
+| Quantized embedding | 150.7 | 177.4 | 137.6 | 0.85x |
+| Q projection | 190.8 | 135.1 | 106.8 | 1.41x |
+| K projection | 154.3 | 109.7 | 106.5 | 1.41x |
+| V projection | 156.5 | 112.9 | 109.7 | 1.39x |
+| O projection | 195.8 | 123.9 | 109.6 | 1.58x |
+| Gate projection | 229.2 | 124.1 | 113.8 | 1.85x |
+| Up projection | 230.1 | 123.7 | 114.6 | 1.86x |
+| Down projection | 235.3 | 126.1 | 120.6 | 1.87x |
+| Tied LM head | 4,547.7 | 439.2 | 427.7 | 10.35x |
+| Prefill Q matmul | 729.6 | 355.7 | 232.7 | 2.05x |
+| RMSNorm | 167.9 | 128.2 | 126.3 | 1.31x |
+| RoPE | 168.9 | 111.5 | 108.6 | 1.52x |
+| SwiGLU | 147.5 | 106.6 | 108.1 | 1.38x |
+| Decode attention | 138.8 | 126.6 | 107.6 | 1.10x |
 
-An earlier dense Week 2-based ablation reached about 2,042 prefill tok/s and
-246 decode tok/s, compared with about 3,318 prefill tok/s and 19.4 decode tok/s
-for Week 1. This isolates the lab kernels from paging and is not the result of
-the integrated Week 3 loader.
+The direct embedding kernel loses this isolated one-token comparison, so it
+should not be described as a standalone speedup. Day 6's end-to-end prefill
+gain comes from the SIMD-matrix products and last-token output boundary. The
+tied output head remains the largest isolated matvec win because it reads the
+widest packed matrix.
 
-On the completed paged stack after hoisting quantization parameters, a matched
-three-process run reached about 2,371 prefill tok/s and 210 decode tok/s, versus
-4,416 prefill tok/s and 329 decode tok/s for MLX. The lab changes prefill matrix
-products and should not materially move decode.
+### Current Four-Slot Serving Snapshot
 
-The following cached-decode rows are reverse ablations from the finished model.
-Each comparison loads the same weights, alternates optimized and readable runs,
-and changes only the named component:
+This serving comparison fixes all 16 requests at 128 prompt and 65 output
+tokens, uses a chunk size of 128, warms up once, alternates paged and
+dense-gather processes, and reports the median of three runs per path.
 
-| Replacement | Readable tok/s | Optimized tok/s | Throughput gain |
-|---|---:|---:|---:|
-| Quantized embedding gather | 243.87 | 245.75 | +0.8% |
-| RMSNorm Metal kernel | 185.28 | 246.16 | +32.9% |
-| RoPE Metal kernel | 193.38 | 245.92 | +27.2% |
-| Fused SwiGLU | 219.14 | 245.29 | +11.9% |
-| Online decode attention | 245.17 | 245.73 | +0.2% |
+| Week 3 path | Output tok/s | Total tok/s | Prefill tok/s | Decode tok/s |
+|---|---:|---:|---:|---:|
+| Day 4 dense-gather ablation | 175.02 | 519.66 | 2,423.55 | 207.64 |
+| Completed paged path | 248.50 | 737.87 | 2,315.78 | 327.62 |
 
-These gains are not additive. As a diagnostic only, replacing the course QMV
-with MLX improved throughput by 14.5%, replacing attention improved it by 9.8%,
-and replacing both reached about 309.7 tok/s. Those MLX substitutions are not
-part of the course solution; they identify the two course-owned kernels with
-the largest remaining optimization ceiling.
-
-In one matched four-request snapshot, the dense path reached 305.31 aggregate
-decode tok/s while the Week 3 paged path reached 348.75 tok/s. This is not a
-universal paged-kernel speedup: it is an end-to-end serving result that includes
-avoided repacking and cache reuse. The isolated operator remains close to the
-dense course kernel and behind MLX.
+Paging is 4.4% slower during prefill in this workload, but removes enough
+repacking during decode to raise timed decode throughput by 57.8% and
+wall-clock output throughput by 42.0%. This is a serving-system result, not a
+claim that indirect page reads beat contiguous reads in every isolated kernel.
 
 ## Week 4: Measure Application Quality Separately
 
 | Chapter | Appropriate metric |
 |---|---|
-| 4.1 Coding Agent | Task-completion rate, steps, generated tokens, tool errors, and wall-clock latency. The agent loop adds work; it does not improve model tok/s. |
-| 4.2 RAG | Retrieval recall/precision, grounded-answer quality, added prompt tokens, and time to first token. Better evidence can improve answers while reducing throughput. |
-| 4.3 Tool Calling and Agent Serving | Valid-action rate, recovery rate, concurrent sessions, cache reuse, and end-to-end task latency. Keep these separate from kernel throughput. |
+| 4.1 Agent Loop | Valid-action rate, steps, generated tokens, and wall-clock latency. The loop adds work; it does not improve model tok/s. |
+| 4.2 Tools | Successful bounded reads, exact-edit success, command failures, and observation size. |
+| 4.3 Safety and Validation | Rejected unsafe actions, false rejections, mutation scope, and post-edit test results. |
+| 4.4 Sessions | Resume fidelity, serialized state size, and time to restore useful context. |
+| 4.5 Compaction | Token reduction, retained-task-state accuracy, and task completion before and after compaction. |
+| 4.6 Control and Recovery | Steering latency, interrupt latency, and successful checkpoint/undo recovery. |
+| 4.7 Evaluation | Held-out task-completion rate, test pass rate, steps, tokens, and end-to-end latency. |
 
 The Week 4 chapters remain works in progress. Their success criterion is useful,
 safe application behavior on top of the Week 2/3 inference interfaces, not a


### PR DESCRIPTION
## Why

The performance appendix mixed historical campaigns after the BF16 and chapter restructuring. The README roadmap also stopped at a three-part Week 4 outline instead of the current seven-day draft.

## What changed

- Replace the course and Week 2 tables with fresh three-process medians from the completed curriculum.
- Add current isolated operator latencies and a three-run, four-slot paged-versus-dense serving comparison.
- Explain the measured tradeoffs, including the isolated quantized-embedding regression and the source of the Day 6 prefill gain.
- Align the README roadmap with Week 2 Day 6, the reordered Week 3 chapters, and all seven draft Week 4 days.

## Measurement context

Measured Qwen3-0.6B on an Apple M4 Pro with a 20-core GPU and 64 GB memory, using MLX 0.29.1. The course progression used 128 prompt tokens, 65 output tokens, two warmups, three fresh processes, and alternating checkpoint order.

## Validation

- CSpell: 32 files checked, 0 issues.
- mdBook build completed and all local Markdown links resolve.
- Benchmark percentages were recalculated from the recorded medians.

_AI-assisted: Codex._
