### PR TITLE
Fix: avoid BF16 precision issue in SiLU

### DIFF
--- a/book/src/week1-04-rmsnorm-and-mlp.md
+++ b/book/src/week1-04-rmsnorm-and-mlp.md
@@ -119,8 +119,9 @@ else:
 ```
 
 The negative branch is algebraically equivalent to the direct sigmoid formula, but it prevents `exp(-x)` from becoming
-`exp(large positive)` when `x` is a large negative value. In vector code, compute the direct branch with `abs(x)`, then
-use `1 - y` for negative inputs. This approach closely matches MLX's low-precision GPU path.
+`exp(large positive)` when `x` is a large negative value. In vector code, first compute `z = exp(-abs(x))`. Use
+`z / (1 + z)` for negative inputs and `1 / (1 + z)` otherwise. Do not rewrite the negative branch as
+`1 - 1 / (1 + z)`: in low precision, the fraction can round to `1`, and the subtraction then incorrectly produces zero.
 
 Then implement `Qwen3MLP`. Qwen3's MLP contains:
 

--- a/src/tiny_llm_ref/basics.py
+++ b/src/tiny_llm_ref/basics.py
@@ -20,7 +20,7 @@ def linear(
 
 def silu(x: mx.array) -> mx.array:
     # Use abs(x) to avoid exp(large positive) when x is a large negative value.
-    # For x < 0, 1 - 1 / (1 + exp(x)) = exp(x) / (1 + exp(x)).
-    sigmoid = 1 / (1 + mx.exp(-mx.abs(x)))
-    sigmoid = mx.where(x < 0, 1 - sigmoid, sigmoid)
+    # For x < 0, 1 / (1 + exp(-x)) = exp(x) / (1 + exp(x)).
+    z = mx.exp(-mx.abs(x))
+    sigmoid = mx.where(x < 0, z / (1 + z), 1 / (1 + z))
     return x * sigmoid

--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -45,13 +45,22 @@ def test_task_1_rms_norm_cast_to_float32(stream: mx.Stream):
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
-@pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
+@pytest.mark.parametrize(
+    "precision",
+    [*PRECISIONS, mx.bfloat16],
+    ids=[*PRECISION_IDS, "bf16"],
+)
 def test_task_2_silu(stream: mx.Stream, precision: mx.Dtype):
     with mx.stream(stream):
         BATCH_SIZE = 10
         DIM = 10
         for _ in range(100):
-            x = mx.random.uniform(shape=(BATCH_SIZE, DIM), dtype=precision)
+            x = mx.random.uniform(
+                low=-20,
+                high=20,
+                shape=(BATCH_SIZE, DIM),
+                dtype=precision,
+            )
             user_output = silu(x)
             reference_output = nn.silu(x)
             assert_allclose(user_output, reference_output, precision=precision)


### PR DESCRIPTION
Fixes [#161](https://github.com/skyzh/tiny-llm/issues/161).

## Problem

The Week 1 SiLU implementation computes the negative branch using `1 - sigmoid(-x)`. In BF16, the sigmoid value may round to `1`, causing small negative SiLU outputs to become `0`. This error accumulates across Qwen3 layers and causes the model comparison to fail after upgrading to MLX 0.32.0 / mlx-lm 0.31.3.

## Change

Compute the negative branch directly using `z = exp(-abs(x))` and `z / (1 + z)`, avoiding BF16 cancellation. The existing SiLU test now covers BF16 and negative inputs, and the lesson documentation is updated accordingly.

Validation on MLX 0.32.0 / mlx-lm 0.31.3:

| Model | Mismatches | Max difference |
| --- | ---: | ---: |
| Qwen3-0.6B | 0 / 7,596,800 | 1.25 |
| Qwen3-1.7B | 0 / 4,558,080 | 2.75 |
| Qwen3-4B | 0 / 1,519,360 | 0.5 |