### PR TITLE
Fix: empty Week 2 Metal GPU captures

### DIFF
--- a/benches/capture_week2_shader.py
+++ b/benches/capture_week2_shader.py
@@ -77,8 +77,9 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     mx.metal.start_capture(str(args.output.resolve()))
     try:
-        mx.eval(quantized_linear(capture_x, weights))
+        # close the old command buffer created before `start_capture`
         mx.synchronize()
+        mx.eval(quantized_linear(capture_x, weights))
     finally:
         mx.metal.stop_capture()
 


### PR DESCRIPTION
## Summary

Move `mx.synchronize()` before evaluating the captured Week 2 projection
workload.

This retires the Metal command buffer created before `start_capture()` and
ensures that the target quantized matvec dispatch is encoded into a command
buffer created during the capture window.

## Test environment

- Machine: Mac mini
- Chip: Apple M4
- Memory: 16 GB
- macOS: 26.6 (`25G72`)
- Xcode: 26.6 (`17F113`)
- Python: 3.12.12
- MLX: 0.32.0
- mlx-lm: 0.31.3

## Problem

Apple Metal Capture only records commands from command buffers that are:

1. created after capture starts; and
2. committed before capture stops.

MLX creates the next command buffer immediately after committing the current
one. As a result, the warmup evaluation leaves a command buffer that was
created before `start_capture()`.

Previously, the target dispatch was encoded into that pre-capture command
buffer and omitted from the GPU trace. The following synchronization then
committed a newly created but empty command buffer, producing a trace with zero
compute dispatches.

<img width="367" height="163" alt="empty" src="https://github.com/user-attachments/assets/9208d358-7487-4f8a-ad8c-704c9a24da08" />

## Fix

Synchronize immediately after starting the capture:

```python
mx.metal.start_capture(str(args.output.resolve()))
try:
    mx.synchronize()
    mx.eval(quantized_linear(capture_x, weights))
finally:
    mx.metal.stop_capture()
```

This commits the pre-capture command buffer first. MLX then creates a
replacement command buffer inside the capture window, which receives the
target dispatch.

## Reference

Apple documents that programmatic Metal capture only records commands in
command buffers created after capture starts and committed before capture
stops:

https://developer.apple.com/documentation/xcode/capturing-a-metal-workload-programmatically
