### PR TITLE
docs: align Week 4 checkpoint status

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,20 @@ appendix. The detailed chapter order and current status live in the
 
 ## Roadmap
 
-The status columns track whether each chapter's code, tests, and documentation
-are ready. Week 4 remains unpublished and is not yet part of the rendered daily
-course. Its executable checkpoints now cover structured actions, bounded
+The status columns track whether each chapter's complete learner checkpoint,
+focused tests, and rendered documentation are ready. Week 4 remains unpublished
+and is not yet part of the rendered daily course, so every Week 4 documentation
+cell remains 🚧 even when an executable draft exists. Rows 4.1–4.3 also remain
+🚧 for code and tests because their current focused checks cover narrower
+starter slices while the draft chapters describe larger cumulative exercises.
+
+The executable Week 4 checkpoints now cover structured actions, bounded
 workspace tools, exact command allowlisting, durable sessions, reusable
 generation caches, structured token compaction, cooperative cancellation,
 durable steering, write-ahead file-mutation recovery, checkpoints, undo, and
-session branches. Day 7 adds sealed inert task packages, frozen candidate
-snapshots, deterministic static held-out checks, forbidden-path grading, and
-evaluation metrics without importing or executing candidate code.
+session branches. The Day 7 checkpoint adds sealed inert task packages, frozen
+candidate snapshots, deterministic static held-out checks, forbidden-path
+grading, and evaluation metrics without importing or executing candidate code.
 
 The Week 4 CLI's workspace tools are read-only by default; persistent runs still
 write a sensitive transcript under `.tiny-llm/sessions`. Enabling writes or an
@@ -129,10 +134,10 @@ or approving a mutation.
 | 4.1 | Agent Loop | 🚧 | 🚧 | 🚧 |
 | 4.2 | Tools | 🚧 | 🚧 | 🚧 |
 | 4.3 | Safety and Validation | 🚧 | 🚧 | 🚧 |
-| 4.4 | Interactive Sessions | ✅ | ✅ | ✅ |
-| 4.5 | Context Compaction | ✅ | ✅ | ✅ |
-| 4.6 | Control and Recovery | ✅ | ✅ | ✅ |
-| 4.7 | Evaluation | ✅ | ✅ | ✅ |
+| 4.4 | Interactive Sessions | ✅ | ✅ | 🚧 |
+| 4.5 | Context Compaction | ✅ | ✅ | 🚧 |
+| 4.6 | Control and Recovery | ✅ | ✅ | 🚧 |
+| 4.7 | Evaluation | ✅ | ✅ | 🚧 |
 
 Other topics not covered include quantized or compressed KV caches,
 cross-request prefix caching, fine-tuning, and long-context techniques.

--- a/book/src/week4-02-tools.md.draft
+++ b/book/src/week4-02-tools.md.draft
@@ -106,9 +106,11 @@ The timeout belongs to `ToolPolicy`, not the model action. It attempts to
 terminate the command's same-process-group descendants and reaps the foreground
 child. A descendant that creates another session can escape this cleanup, so a
 disposable workspace and stronger OS process isolation are still required for
-hostile commands. The runner handles `KeyboardInterrupt` while a command is
-active; unified loop, decoder, and steering cancellation is a planned Day 6
-extension.
+hostile commands. At the Day 2 checkpoint, the runner handles
+`KeyboardInterrupt` while a command is active. The cumulative reference
+implementation adds one cooperative cancellation signal across the loop,
+course-model decoder, command polling, and steering in Day 6; that behavior is
+not part of the Day 2 focused check.
 
 Exact allowlisting is necessary but not sufficient. Every eligible
 model-dispatched `run_command` action that passes preflight also asks `y/N` and

--- a/book/src/week4-03-safe-editing.md.draft
+++ b/book/src/week4-03-safe-editing.md.draft
@@ -8,9 +8,10 @@ mutations should require review, and successful work should be validated.
 > protected roots and paths, rejection of detected symlinks, and writes disabled
 > by default.
 > Atomic writes, exact edits, and exact command allowlisting are checked on Day
-> 5. A mutation journal, automatic diff capture, validation-aware completion,
-> checkpoint undo, and process isolation are not implemented in the current
-> baseline.
+> 5. Durable mutation intents, recovery, and default-No checkpoint undo belong
+> to the cumulative Day 6 implementation, not this focused checkpoint.
+> Automatic diff capture, validation-aware completion, and process isolation
+> remain deferred.
 
 ## Current Checkpoint
 
@@ -77,7 +78,7 @@ can still read or modify any host path allowed to the process, spawn children,
 or use the network. Strong confinement requires a container, virtual machine, or
 equivalent sandbox.
 
-## Planned Mutation Journal
+## From a Stale-Write Guard to the Day 6 Mutation Journal
 
 The recovery target performs these steps around an approved write or edit:
 
@@ -88,7 +89,7 @@ The recovery target performs these steps around an approved write or edit:
 5. produce a diff for the trace or confirmation policy; and
 6. replace the file atomically.
 
-The current baseline records an in-memory content digest when it reads a file,
+The Day 3 checkpoint records an in-memory content digest when it reads a file,
 rejects byte changes detected during mutation preflight, rechecks the digest
 after human approval, performs an atomic replace, and tracks paths changed by
 file tools. It also retains an outcome-uncertain path if interruption or an
@@ -96,9 +97,13 @@ exception occurs between starting the commit and recording its completion, so
 the CLI tells the operator to inspect that file. This catches ordinary changes
 during the approval pause, but there is still a check-to-replace race against a
 hostile concurrent filesystem actor. The digest is a stale-write guard, not a
-durable journal: the baseline does not retain before-images or diffs. Do not
-claim that checkpoint undo works until those artifacts and their conflict checks
-are implemented and tested.
+durable journal, and checkpoint undo is not a Day 3 capability.
+
+The cumulative reference implementation adds bounded before-images,
+write-ahead mutation intents, restart classification, conflict checks, and
+default-No checkpoint undo in Day 6. That later journal does not add automatic
+diff capture or process isolation; follow the Day 6 chapter before claiming its
+recovery and undo guarantees.
 
 Do not automatically use `git reset`, `git checkout`, or a temporary commit as
 the mutation journal. A learner may run the agent in a repository that already

--- a/book/src/week4-04-sessions.md.draft
+++ b/book/src/week4-04-sessions.md.draft
@@ -5,8 +5,9 @@ process exits. This chapter makes the event stream durable and adds a reusable
 generation cache without making either representation depend on the other.
 
 > **Implementation status:** The reference implementation, learner API surface,
-> and focused tests in this chapter are executable. The Week 4 chapters remain
-> unpublished while the later daily checkpoints are completed.
+> and focused tests in this chapter are executable. Like every Week 4 daily
+> chapter, this file remains unrendered pending course review; executable does
+> not mean published.
 
 ## Check the Chapter
 

--- a/book/src/week4-05-compaction.md.draft
+++ b/book/src/week4-05-compaction.md.draft
@@ -5,8 +5,9 @@ Day 5 derives a bounded model-visible working set without deleting or rewriting
 the durable trace from Day 4.
 
 > **Implementation status:** The reference implementation, learner API surface,
-> and focused tests are executable. Week 4 remains unpublished while the later
-> recovery and evaluation checkpoints are completed.
+> and focused tests in this chapter are executable. Like every Week 4 daily
+> chapter, this file remains unrendered pending course review; executable does
+> not mean published.
 
 ## Check the Chapter
 

--- a/book/src/week4-06-control-recovery.md.draft
+++ b/book/src/week4-06-control-recovery.md.draft
@@ -8,8 +8,9 @@ response as a safety boundary.
 > **Implementation status:** The reference implementation, learner API surface,
 > and focused tests are executable. Ctrl-C interruption is integrated with the
 > CLI. Checkpoint, undo, branch, and steering operations are programmatic APIs;
-> the CLI does not yet expose commands for them. Week 4 remains unpublished
-> while held-out evaluation is completed.
+> the CLI does not yet expose commands for them. Like every Week 4 daily
+> chapter, this file remains unrendered pending course review; executable does
+> not mean published.
 
 ## Check the Chapter
 

--- a/book/src/week4-07-evaluation.md.draft
+++ b/book/src/week4-07-evaluation.md.draft
@@ -8,8 +8,10 @@ executes candidate code.
 
 > **Implementation status:** The reference implementation, learner API surface,
 > inert task packages, and focused tests implement the static evaluation boundary
-> described here. Executable Python tests and general coding-task grading remain
-> deferred until the candidate can run inside a container or virtual machine.
+> described here. Like every Week 4 daily chapter, this file remains unrendered
+> pending course review; executable does not mean published. Executable Python
+> tests and general coding-task grading remain deferred until the candidate can
+> run inside a container or virtual machine.
 
 ## Check the Chapter
 

--- a/book/src/week4-overview.md
+++ b/book/src/week4-overview.md
@@ -240,7 +240,8 @@ pdm run evaluate-agent grade evals/week4/localized-constant
 
 The grade command uses a fresh temporary stage and frozen snapshot. It keeps
 commands disabled, supplies no automatic write approval, and never runs code
-from the package.
+from the package. The shipped unchanged fixture is intentionally incorrect:
+`inspect` exits zero, while `grade` prints a normal failed report and exits one.
 
 The default Qwen3 4B model follows the structured action protocol more reliably.
 Use `--model qwen3-0.6b` on memory-constrained machines and expect to spend more


### PR DESCRIPTION
Week 4’s final Day 7 stack made earlier draft status text stale: Day 2/3 still described Day 6 features as planned or unimplemented, while Day 4–6 implied later checkpoints were unfinished.

- make early chapters checkpoint-relative while pointing to cumulative Day 6 behavior
- use one stable executable-but-unrendered status across Days 4–7
- clarify roadmap status semantics and the expected exit 1 for the unchanged evaluation fixture

Validation: Week 4 reference tests passed (287 passed); mdBook, sitemap, link, and diff checks are green.

_AI-assisted: Codex._