### PR TITLE
docs: repair Week 2 renamed sitemap URLs

### DIFF
--- a/book/src/sitemap.txt
+++ b/book/src/sitemap.txt
@@ -14,8 +14,8 @@ https://skyzh.github.io/tiny-llm/week1-overview
 https://skyzh.github.io/tiny-llm/week2-01-kv-cache
 https://skyzh.github.io/tiny-llm/week2-02-benchmarking
 https://skyzh.github.io/tiny-llm/week2-03-quantized-matvec
-https://skyzh.github.io/tiny-llm/week2-04-decode-attention
-https://skyzh.github.io/tiny-llm/week2-05-fast-kernels
+https://skyzh.github.io/tiny-llm/week2-04-fused-model-kernels
+https://skyzh.github.io/tiny-llm/week2-05-decode-attention
 https://skyzh.github.io/tiny-llm/week2-06-simd-matrix-prefill
 https://skyzh.github.io/tiny-llm/week2-07-split-k-prefill
 https://skyzh.github.io/tiny-llm/week2-overview

--- a/book/src/sitemap.xml
+++ b/book/src/sitemap.xml
@@ -49,10 +49,10 @@
         <loc>https://skyzh.github.io/tiny-llm/week2-03-quantized-matvec</loc>
     </url>
     <url>
-        <loc>https://skyzh.github.io/tiny-llm/week2-04-decode-attention</loc>
+        <loc>https://skyzh.github.io/tiny-llm/week2-04-fused-model-kernels</loc>
     </url>
     <url>
-        <loc>https://skyzh.github.io/tiny-llm/week2-05-fast-kernels</loc>
+        <loc>https://skyzh.github.io/tiny-llm/week2-05-decode-attention</loc>
     </url>
     <url>
         <loc>https://skyzh.github.io/tiny-llm/week2-06-simd-matrix-prefill</loc>


### PR DESCRIPTION
## Summary

Repairs the renamed Week 2 Day 4/5 sitemap URLs on top of the exact original PR #157 head `03d76bce5d7e88758cd91add75d9253c4021f512`.

This changes only:
- `book/src/sitemap.txt`
- `book/src/sitemap.xml`

The stale `week2-04-decode-attention` and `week2-05-fast-kernels` entries are replaced with `week2-04-fused-model-kernels` and `week2-05-decode-attention`.

## Validation

At exact head `ba585514392ed5b1762e22421a7157b516111ad9`:
- `pdm install -v`
- `pdm run check-installation`
- `pdm run build-ext`
- `pdm run build-ext-test`
- `pdm run build-ext-ref`
- `pdm run test-refsol` — 267 passed, 8 skipped
- `book/sitemap.sh --check`
- clean worktree and `git diff --check`

This is an isolated repair branch. The original `skyzh/xcode-matvec-profile` branch was not changed or force-pushed.
