### PR TITLE
fix: durably reconcile interrupted Week 4 undo

### DIFF
--- a/src/tiny_llm_ref/agent/recovery.py
+++ b/src/tiny_llm_ref/agent/recovery.py
@@ -960,6 +960,8 @@ class MutationJournal:
                     ),
                 )
                 result_matches = self._undo_result_matches(change)
+                if result_matches:
+                    self._fsync_reconciled_undo_result(change)
             except AgentError:
                 self.session.append(
                     "undo_change_recovered",
@@ -1039,6 +1041,49 @@ class MutationJournal:
             self._undo_result_sha256(change),
             result_mode,
         )
+
+    def _fsync_reconciled_undo_result(self, change: PlannedRestore) -> None:
+        """Make an observed crash-reconciled namespace result durable."""
+
+        expected_parent = (
+            change.expected_parent_dev,
+            change.expected_parent_ino,
+        )
+        _relative, parent, name = self._open_parent_dir(
+            change.path,
+            expected_parent=expected_parent,
+        )
+        expected_result = (
+            self._undo_result_sha256(change),
+            None if change.remove else change.restore_mode,
+        )
+
+        def result_fingerprint() -> tuple[str | None, int | None]:
+            current = self._read_regular_at(
+                parent,
+                name,
+                allow_missing=change.remove,
+            )
+            if current is None:
+                return None, None
+            content, status = current
+            return self._digest(content), stat.S_IMODE(status.st_mode)
+
+        try:
+            if result_fingerprint() != expected_result:
+                raise AgentError("undo result changed during crash reconciliation")
+            os.fsync(parent)
+            parent_status = os.fstat(parent)
+            if (parent_status.st_dev, parent_status.st_ino) != expected_parent:
+                raise AgentError("mutation parent directory was replaced")
+            if result_fingerprint() != expected_result:
+                raise AgentError("undo result changed during crash reconciliation")
+        except OSError as error:
+            raise AgentError(
+                "could not make crash-reconciled undo result durable"
+            ) from error
+        finally:
+            os.close(parent)
 
     def _current_mode(self, raw: str) -> int | None:
         return self._current_fingerprint(raw)[1]

--- a/tests_refsol/test_week_4_day_6.py
+++ b/tests_refsol/test_week_4_day_6.py
@@ -1734,6 +1734,131 @@ def test_task_6_interrupted_undo_reconciles_completed_change_before_retry(
     )
 
 
+def _record_pending_undo_change(session, journal, plan, change, change_id):
+    operation = "remove" if change.remove else "restore"
+    retained_recovery_path = journal._retained_recovery_path(change, change_id)
+    session.append(
+        "undo_change_started",
+        undo_change_id=change_id,
+        checkpoint_id=plan.checkpoint.id,
+        plan_fingerprint=journal._undo_plan_fingerprint(plan),
+        intent_id=change.intent_id,
+        covered_intent_ids=list(change.covered_intent_ids),
+        path=change.path,
+        operation=operation,
+        retained_recovery_path=retained_recovery_path,
+        expected_parent_dev=change.expected_parent_dev,
+        expected_parent_ino=change.expected_parent_ino,
+        expected_sha256=change.expected_sha256,
+        expected_mode=change.expected_mode,
+        result_sha256=journal._undo_result_sha256(change),
+        result_mode=change.restore_mode,
+        branch_id=plan.checkpoint.branch_id,
+    )
+
+
+def _pending_applied_undo(tmp_path, operation):
+    target = tmp_path / "value.txt"
+    session = memory_session(tmp_path, "test-model")
+    journal = MutationJournal(session, tmp_path)
+    if operation == "restore":
+        target.write_text("old", encoding="utf-8")
+        target.chmod(0o640)
+        checkpoint = journal.create_checkpoint("before edit")
+        _journaled_write(journal, target, "new")
+    else:
+        checkpoint = journal.create_checkpoint("before create")
+        _journaled_write(journal, target, "created")
+    plan = journal.plan_undo(checkpoint)
+    change = plan.changes[0]
+    _record_pending_undo_change(session, journal, plan, change, "a" * 32)
+    if operation == "restore":
+        assert change.restore_content is not None
+        assert change.restore_mode is not None
+        target.write_text(change.restore_content, encoding="utf-8")
+        target.chmod(change.restore_mode)
+    else:
+        target.unlink()
+    return target, session, journal, plan
+
+
+@pytest.mark.parametrize("operation", ["restore", "remove"])
+def test_task_6_reconciled_hard_crash_fsyncs_parent_before_finish(
+    tmp_path, monkeypatch, operation
+):
+    target, session, journal, plan = _pending_applied_undo(tmp_path, operation)
+    recovery_module = importlib.import_module(MutationJournal.__module__)
+    real_fsync = recovery_module.os.fsync
+    original_append = session.append
+    order = []
+
+    def record_parent_fsync(descriptor):
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            order.append("parent_fsync")
+        return real_fsync(descriptor)
+
+    def record_finish(event_type, **data):
+        if event_type == "undo_change_finished":
+            order.append("finish")
+        return original_append(event_type, **data)
+
+    monkeypatch.setattr(recovery_module.os, "fsync", record_parent_fsync)
+    monkeypatch.setattr(session, "append", record_finish)
+
+    resumed = journal.apply_undo(
+        plan,
+        confirm=lambda _plan: pytest.fail("reconciled undo prompted again"),
+    )
+
+    assert resumed.conflicts == ()
+    if operation == "restore":
+        assert resumed.restored == ("value.txt",)
+        assert target.read_text(encoding="utf-8") == "old"
+    else:
+        assert resumed.removed == ("value.txt",)
+        assert not target.exists()
+    assert order.count("finish") == 1
+    assert "parent_fsync" in order
+    assert order.index("parent_fsync") < order.index("finish")
+
+
+@pytest.mark.parametrize("operation", ["restore", "remove"])
+def test_task_6_reconciled_hard_crash_fsync_failure_stays_conflicted(
+    tmp_path, monkeypatch, operation
+):
+    _target, session, journal, plan = _pending_applied_undo(tmp_path, operation)
+    recovery_module = importlib.import_module(MutationJournal.__module__)
+    real_fsync = recovery_module.os.fsync
+
+    def fail_parent_fsync(descriptor):
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            raise OSError("injected reconciliation fsync failure")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(recovery_module.os, "fsync", fail_parent_fsync)
+
+    resumed = journal.apply_undo(
+        plan,
+        confirm=lambda _plan: pytest.fail("conflicted undo prompted again"),
+    )
+
+    assert resumed.restored == ()
+    assert resumed.removed == ()
+    assert resumed.conflicts == ("value.txt",)
+    assert not any(
+        event.type == "undo_change_finished"
+        for event in session.events
+        if event.data.get("undo_change_id") == "a" * 32
+    )
+    recovery = next(
+        event
+        for event in session.events
+        if event.type == "undo_change_recovered"
+        and event.data.get("undo_change_id") == "a" * 32
+    )
+    assert recovery.data["status"] == "conflict"
+
+
 def test_task_6_interrupted_after_durable_undo_finish_resumes_remaining_change(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Restacks the original PR #171 delta onto repaired PR #170 head `5bbe6b8863e830b1643fa168c06307083f03d335`, retaining and deduplicating #171's stronger atomic-write mode handling.

Crash reconciliation now reopens the expected parent by its recorded identity, verifies the observed restore/removal through the anchored directory descriptor, fsyncs that parent, rechecks the result, and only then appends `undo_change_finished`. Parent fsync failures produce a conflict and never a finished record.

Added deterministic hard-crash reconciliation regressions for both restored and removed paths, including parent-fsync-before-finish ordering and fsync-failure behavior.

## Exact head and validation

Head: `1202b6bd821103fd24ea6b3c0be63d7d9bef93ed`

- cumulative Week 4 reference suite: 235 passed
- focused restore/remove reconciliation and fsync-failure regressions: passed
- focused mode-safety regressions: passed
- scoped Ruff check/format check: passed
- `git diff --check`: passed

This branch does not change or force-push the original `skyzh/week4-day6-control-recovery` branch.
