### PR TITLE
fix: preserve Week 2 Metal capture ordering

### DIFF
--- a/benches/capture_week2_shader.py
+++ b/benches/capture_week2_shader.py
@@ -288,6 +288,9 @@ def main() -> None:
     args.output.parent.mkdir(parents=True, exist_ok=True)
     mx.metal.start_capture(str(args.output.resolve()))
     try:
+        # Retire the command buffer created before capture started so measured
+        # work is encoded into command buffers created inside the capture.
+        mx.synchronize()
         for _ in range(args.iterations):
             mx.eval(*capture())
         mx.synchronize()

--- a/benches/test_capture_week2_shader.py
+++ b/benches/test_capture_week2_shader.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from benches import capture_week2_shader as capture_module
+
+
+def test_capture_retires_pre_capture_buffer_before_measured_evals(
+    monkeypatch, tmp_path
+):
+    events = []
+    output = tmp_path / "week2.gputrace"
+    args = SimpleNamespace(output=output, iterations=2)
+
+    def build(name):
+        events.append(f"build:{name}")
+        return [name]
+
+    fake_metal = SimpleNamespace(
+        start_capture=lambda path: events.append("start"),
+        stop_capture=lambda: events.append("stop"),
+    )
+    fake_mx = SimpleNamespace(
+        metal=fake_metal,
+        eval=lambda value: events.append(f"eval:{value}"),
+        synchronize=lambda: events.append("sync"),
+    )
+
+    monkeypatch.setattr(capture_module, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        capture_module,
+        "prepare_workload",
+        lambda parsed: (
+            "test workload",
+            lambda: build("warmup"),
+            lambda: build("capture"),
+        ),
+    )
+    monkeypatch.setattr(capture_module, "mx", fake_mx)
+
+    capture_module.main()
+
+    assert events == [
+        "build:warmup",
+        "eval:warmup",
+        "build:capture",
+        "eval:capture",
+        "start",
+        "sync",
+        "build:capture",
+        "eval:capture",
+        "build:capture",
+        "eval:capture",
+        "sync",
+        "stop",
+    ]


### PR DESCRIPTION
The Week 2 Metal capture harness can leave a command buffer created before capture pending across the capture boundary. That makes the trace depend on work encoded outside the intended measured window.

This keeps the rebuilt #166 harness unchanged and applies only the reviewed ordering repair: start capture, synchronize pre-capture work, run the measured evaluations, synchronize them, then stop capture. A focused regression locks that order; workload selection, schedules, performance policy, and benchmark evidence remain unchanged.

This is the top of native stack #198, based exactly on rebuilt #166 head `9d9dc18e2c528159a92a4da909370a7072aa4363`. Its two-file delta is tree-equivalent to the previously reviewed #187 repair at `485f73f3441d9d1dab4ac4a0909aef639646f2c0`.

_AI-assisted: Codex._
