### PR TITLE
fix: propagate test command exit status

### DIFF
--- a/scripts/dev-tools.py
+++ b/scripts/dev-tools.py
@@ -1,8 +1,9 @@
 import argparse
-import shutil
 import os
-import pytest
+import shutil
 from pathlib import Path
+
+import pytest
 
 
 def copy_test(args, skip_if_exists=False, force=False):
@@ -17,40 +18,39 @@ def copy_test(args, skip_if_exists=False, force=False):
             print(
                 f"You can run `pdm run copy-test --week {args.week} --day {args.day} --force` to update it"
             )
-        return
+        return 0
     print(f"copying {source_file} to {target_file}")
     shutil.copyfile(source_file, target_file)
+    return 0
 
 
 def test(args):
     if args.week and args.day:
         copy_test(args, skip_if_exists=True)
-        pytest.main(
+        return pytest.main(
             ["-v", f"tests/test_week_{args.week}_day_{args.day}.py"] + args.remainders
         )
     elif args.week or args.day:
         print("Please provide both week and day")
-        exit(1)
-    else:
-        pytest.main(["-v", "tests"] + args.remainders)
+        return 1
+    return pytest.main(["-v", "tests"] + args.remainders)
 
 
 def test_refsol(args):
     if args.week and args.day:
-        pytest.main(
+        return pytest.main(
             ["-v", f"tests_refsol/test_week_{args.week}_day_{args.day}.py"]
             + args.remainders
         )
     elif args.week or args.day:
         print("Please provide both week and day")
-        exit(1)
-    else:
-        pytest.main(["-v", "tests_refsol"] + args.remainders)
+        return 1
+    return pytest.main(["-v", "tests_refsol"] + args.remainders)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(required=True)
     copy_test_parser = subparsers.add_parser("copy-test")
     copy_test_parser.add_argument("--week", type=int, required=True)
     copy_test_parser.add_argument("--day", type=int, required=True)
@@ -68,12 +68,13 @@ def main():
     test_refsol_parser.set_defaults(test_refsol_parser=True)
     args = parser.parse_args()
     if hasattr(args, "copy_test_parser"):
-        copy_test(args, force=args.force)
+        return copy_test(args, force=args.force)
     if hasattr(args, "test_parser"):
-        test(args)
+        return test(args)
     if hasattr(args, "test_refsol_parser"):
-        test_refsol(args)
+        return test_refsol(args)
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/dev-tools.py
+++ b/scripts/dev-tools.py
@@ -6,7 +6,21 @@ from pathlib import Path
 import pytest
 
 
+def validate_week_day(args, required=False):
+    week_provided = args.week is not None
+    day_provided = args.day is not None
+    if week_provided != day_provided or (required and not week_provided):
+        print("Please provide both week and day")
+        return False
+    if week_provided and (args.week <= 0 or args.day <= 0):
+        print("Week and day must be positive integers")
+        return False
+    return True
+
+
 def copy_test(args, skip_if_exists=False, force=False):
+    if not validate_week_day(args, required=True):
+        return 1
     source_file = f"tests_refsol/test_week_{args.week}_day_{args.day}.py"
     target_file = f"tests/test_week_{args.week}_day_{args.day}.py"
     if skip_if_exists and os.path.exists(target_file) and not force:
@@ -25,26 +39,24 @@ def copy_test(args, skip_if_exists=False, force=False):
 
 
 def test(args):
-    if args.week and args.day:
+    if not validate_week_day(args):
+        return 1
+    if args.week is not None:
         copy_test(args, skip_if_exists=True)
         return pytest.main(
             ["-v", f"tests/test_week_{args.week}_day_{args.day}.py"] + args.remainders
         )
-    elif args.week or args.day:
-        print("Please provide both week and day")
-        return 1
     return pytest.main(["-v", "tests"] + args.remainders)
 
 
 def test_refsol(args):
-    if args.week and args.day:
+    if not validate_week_day(args):
+        return 1
+    if args.week is not None:
         return pytest.main(
             ["-v", f"tests_refsol/test_week_{args.week}_day_{args.day}.py"]
             + args.remainders
         )
-    elif args.week or args.day:
-        print("Please provide both week and day")
-        return 1
     return pytest.main(["-v", "tests_refsol"] + args.remainders)
 
 

--- a/tests_refsol/test_dev_tools.py
+++ b/tests_refsol/test_dev_tools.py
@@ -60,6 +60,32 @@ def test_partial_week_day_selection_fails_closed(tmp_path, command):
     assert "Please provide both week and day" in result.stdout
 
 
+@pytest.mark.parametrize("command", ["test", "test-refsol"])
+@pytest.mark.parametrize(
+    "selectors",
+    [
+        ("--week", "0"),
+        ("--day", "0"),
+        ("--week", "0", "--day", "0"),
+        ("--week", "-1", "--day", "1"),
+        ("--week", "1", "--day", "-1"),
+    ],
+)
+def test_non_positive_week_day_selection_fails_closed(tmp_path, command, selectors):
+    result = subprocess.run(
+        [sys.executable, str(DEV_TOOLS), command, *selectors],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    if len(selectors) == 2:
+        assert "Please provide both week and day" in result.stdout
+    else:
+        assert "Week and day must be positive integers" in result.stdout
+
+
 def test_copy_test_missing_source_fails_closed(tmp_path):
     result = subprocess.run(
         [
@@ -78,6 +104,26 @@ def test_copy_test_missing_source_fails_closed(tmp_path):
     )
     assert result.returncode != 0
     assert "tests_refsol/test_week_99_day_99.py" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "selectors",
+    [
+        ("--week", "0", "--day", "1"),
+        ("--week", "1", "--day", "0"),
+        ("--week", "-1", "--day", "1"),
+    ],
+)
+def test_copy_test_non_positive_selection_fails_closed(tmp_path, selectors):
+    result = subprocess.run(
+        [sys.executable, str(DEV_TOOLS), "copy-test", *selectors],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "Week and day must be positive integers" in result.stdout
 
 
 def test_missing_command_fails_closed(tmp_path):

--- a/tests_refsol/test_dev_tools.py
+++ b/tests_refsol/test_dev_tools.py
@@ -1,0 +1,92 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+DEV_TOOLS = Path(__file__).parents[1] / "scripts" / "dev-tools.py"
+
+
+def run_test_command(tmp_path, command, test_directory, test_source):
+    tests = tmp_path / test_directory
+    tests.mkdir(exist_ok=True)
+    (tests / "test_sample.py").write_text(test_source)
+    return subprocess.run(
+        [sys.executable, str(DEV_TOOLS), command, "--", "-q", "-s"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "test_directory"),
+    [("test", "tests"), ("test-refsol", "tests_refsol")],
+)
+def test_pytest_status_and_output_are_propagated(tmp_path, command, test_directory):
+    passing = run_test_command(
+        tmp_path,
+        command,
+        test_directory,
+        'def test_pass():\n    print("PASS-MARKER")\n',
+    )
+    assert passing.returncode == 0
+    assert "PASS-MARKER" in passing.stdout
+    assert "1 passed" in passing.stdout
+
+    failing = run_test_command(
+        tmp_path,
+        command,
+        test_directory,
+        'def test_fail():\n    print("FAIL-MARKER")\n    assert False\n',
+    )
+    assert failing.returncode == 1
+    assert "FAIL-MARKER" in failing.stdout
+    assert "1 failed" in failing.stdout
+
+
+@pytest.mark.parametrize("command", ["test", "test-refsol"])
+def test_partial_week_day_selection_fails_closed(tmp_path, command):
+    result = subprocess.run(
+        [sys.executable, str(DEV_TOOLS), command, "--week", "3"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "Please provide both week and day" in result.stdout
+
+
+def test_copy_test_missing_source_fails_closed(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_TOOLS),
+            "copy-test",
+            "--week",
+            "99",
+            "--day",
+            "99",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "tests_refsol/test_week_99_day_99.py" in result.stderr
+
+
+def test_missing_command_fails_closed(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(DEV_TOOLS)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "the following arguments are required" in result.stderr


### PR DESCRIPTION
## Summary

- return `pytest.main(...)` status from both developer test wrappers
- exit the CLI process with the selected command's status
- make partial selectors, missing copy sources, and missing subcommands fail closed
- reject zero and negative week/day selectors before any full-suite fallback
- add subprocess regressions for successful and failing learner/reference runs while asserting pytest output remains visible

## Root cause

`test()` and `test_refsol()` invoked `pytest.main(...)` without returning its status, and `__main__` ignored `main()`'s result. Python therefore exited 0 even when pytest reported failures or no collected tests.

## Impact

Documented `pdm run test` and `pdm run test-refsol` commands now preserve pytest's normal output and process exit code. Successful suites still exit 0; test failures exit 1; empty or fully deselected runs preserve pytest exit 5. Selector presence is checked against `None`, and non-positive week/day values are rejected rather than being mistaken for an omitted selector and running the full suite. Invalid command selection and missing copy sources also remain nonzero.

## Validation

- `pdm run pytest tests_refsol/test_dev_tools.py -q` — 19 passed
- `pdm run test --week 0 --day 0` — rejected, exit 1
- `pdm run test-refsol --day 0` — rejected as partial selection, exit 1
- `pdm run copy-test --week 0 --day 1` — rejected, exit 1
- before/after reproduction: clean learner no-tests and fully deselected reference runs changed from incorrect exit 0 to pytest exit 5 with unchanged summaries
- `pdm run test-refsol --week 3 --day 1 -- -q` — 5 passed, 1 skipped, exit 0
- `pdm run test --week 3 --day 1 -- -q -k task_1` — expected unimplemented-starter failures remained visible, exit 1
- `pdm run test-refsol -- -- -q` — 285 passed, 8 skipped
- `pdm install -v`
- `pdm run check-installation`
- `pdm run build-ext`
- `pdm run build-ext-test`
- `pdm run build-ext-ref`
- `pdm run ruff check scripts/dev-tools.py tests_refsol/test_dev_tools.py`
- `pdm run ruff format --check scripts/dev-tools.py tests_refsol/test_dev_tools.py`
- `book/sitemap.sh --check`
- cached `git diff --check`

This draft is based directly on exact `main` commit `41b75677847d2480b1aac5c0d6038dc58d440178`.
