### PR TITLE
Publish Week 4 chapters for early review

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ implementation, test, and publication readiness is tracked below.
 ## Roadmap
 
 The table distinguishes complete learner checkpoints (`Code`), focused tests
-(`Test`), and rendered chapters (`Doc`). Week 4 has tested reference checkpoints
-through Day 7, but its daily chapters are not yet published and Days 1–3 remain
-incomplete learner checkpoints.
+(`Test`), and rendered chapters (`Doc`). Week 4's daily chapters are public for
+early review, but Days 1–3 remain incomplete learner checkpoints.
 
 Persistent Week 4 runs can store sensitive transcripts under
 `.tiny-llm/sessions`, and model-directed file or command tools are not sandboxed.
@@ -103,13 +102,13 @@ Use a disposable workspace and read the
 | 3.5 | Paged FlashAttention | ✅ | ✅ | 🚧 |
 | 3.6 (optional) | Speculative Decoding | 🚧 | 🚧 | 🚧 |
 | 3.x (optional) | MoE (Mixture of Experts) | ✅ | ✅ | ✅ |
-| 4.1 | Agent Loop | 🚧 | 🚧 | 🚧 |
-| 4.2 | Tools | 🚧 | 🚧 | 🚧 |
-| 4.3 | Safety and Validation | 🚧 | 🚧 | 🚧 |
-| 4.4 | Interactive Sessions | ✅ | ✅ | 🚧 |
-| 4.5 | Context Compaction | ✅ | ✅ | 🚧 |
-| 4.6 | Control and Recovery | ✅ | ✅ | 🚧 |
-| 4.7 | Evaluation | ✅ | ✅ | 🚧 |
+| 4.1 | Agent Loop | 🚧 | 🚧 | ✅ |
+| 4.2 | Tools | 🚧 | 🚧 | ✅ |
+| 4.3 | Safety and Validation | 🚧 | 🚧 | ✅ |
+| 4.4 | Interactive Sessions | ✅ | ✅ | ✅ |
+| 4.5 | Context Compaction | ✅ | ✅ | ✅ |
+| 4.6 | Control and Recovery | ✅ | ✅ | ✅ |
+| 4.7 | Evaluation | ✅ | ✅ | ✅ |
 
 Other topics not covered include quantized or compressed KV caches,
 cross-request prefix caching, fine-tuning, and long-context techniques.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,13 @@
     - [🚧 Optional: Speculative Decoding](./week3-optional-speculative-decoding.md)
     - [Optional: Mixture of Experts](./week3-optional-moe.md)
 - [🚧 Week 4: Build a Coding Agent](./week4-overview.md)
+    - [🚧 Agent Loop](./week4-01-agent-loop.md)
+    - [🚧 Tools](./week4-02-tools.md)
+    - [🚧 Safety and Validation](./week4-03-safe-editing.md)
+    - [🚧 Interactive Sessions](./week4-04-sessions.md)
+    - [🚧 Context Compaction](./week4-05-compaction.md)
+    - [🚧 Control and Recovery](./week4-06-control-recovery.md)
+    - [🚧 Evaluation](./week4-07-evaluation.md)
 - [🚧 Appendix: Performance Evidence Ledger](./appendix-performance.md)
 
 ---

--- a/book/src/sitemap.txt
+++ b/book/src/sitemap.txt
@@ -28,4 +28,11 @@ https://skyzh.github.io/tiny-llm/week3-05-flash-attention
 https://skyzh.github.io/tiny-llm/week3-optional-moe
 https://skyzh.github.io/tiny-llm/week3-optional-speculative-decoding
 https://skyzh.github.io/tiny-llm/week3-overview
+https://skyzh.github.io/tiny-llm/week4-01-agent-loop
+https://skyzh.github.io/tiny-llm/week4-02-tools
+https://skyzh.github.io/tiny-llm/week4-03-safe-editing
+https://skyzh.github.io/tiny-llm/week4-04-sessions
+https://skyzh.github.io/tiny-llm/week4-05-compaction
+https://skyzh.github.io/tiny-llm/week4-06-control-recovery
+https://skyzh.github.io/tiny-llm/week4-07-evaluation
 https://skyzh.github.io/tiny-llm/week4-overview

--- a/book/src/sitemap.xml
+++ b/book/src/sitemap.xml
@@ -91,6 +91,27 @@
         <loc>https://skyzh.github.io/tiny-llm/week3-overview</loc>
     </url>
     <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-01-agent-loop</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-02-tools</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-03-safe-editing</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-04-sessions</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-05-compaction</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-06-control-recovery</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-07-evaluation</loc>
+    </url>
+    <url>
         <loc>https://skyzh.github.io/tiny-llm/week4-overview</loc>
     </url>
 </urlset>

--- a/book/src/week4-01-agent-loop.md
+++ b/book/src/week4-01-agent-loop.md
@@ -1,5 +1,9 @@
 # Day 1: From Generation to an Agent Loop
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 The decoder from Week 1 produces text once and exits. An agent repeatedly turns
 text into an action, executes that action, and gives the result back to the
 model. Today you will make that control flow explicit.

--- a/book/src/week4-02-tools.md
+++ b/book/src/week4-02-tools.md
@@ -1,5 +1,9 @@
 # Day 2: Tools and Structured Actions
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 The agent loop becomes useful when actions can inspect and change a repository.
 The course protocol uses five actions: `list_files`, `read_file`, `edit_file`,
 `write_file`, and `run_command`.

--- a/book/src/week4-03-safe-editing.md
+++ b/book/src/week4-03-safe-editing.md
@@ -1,5 +1,9 @@
 # Day 3: Safe Editing and Validation
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 Tools connect probabilistic model output to real side effects. Today you will
 make that boundary explicit. File tools should remain inside one workspace,
 mutations should require review, and successful work should be validated.

--- a/book/src/week4-04-sessions.md
+++ b/book/src/week4-04-sessions.md
@@ -1,13 +1,16 @@
 # Day 4: Interactive Sessions and Resume
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 The stateless loop from the first three days loses its conversation whenever the
 process exits. This chapter makes the event stream durable and adds a reusable
 generation cache without making either representation depend on the other.
 
 > **Implementation status:** The reference implementation, learner API surface,
-> and focused tests in this chapter are executable. Like every Week 4 daily
-> chapter, this file remains unrendered pending course review; executable does
-> not mean published.
+> and focused tests in this chapter are executable. The chapter remains WIP even
+> though the checkpoint is executable.
 
 ## Check the Chapter
 

--- a/book/src/week4-05-compaction.md
+++ b/book/src/week4-05-compaction.md
@@ -1,13 +1,16 @@
 # Day 5: Token-Aware Context Compaction
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 An append-only session grows forever, but the model has a finite context window.
 Day 5 derives a bounded model-visible working set without deleting or rewriting
 the durable trace from Day 4.
 
 > **Implementation status:** The reference implementation, learner API surface,
-> and focused tests in this chapter are executable. Like every Week 4 daily
-> chapter, this file remains unrendered pending course review; executable does
-> not mean published.
+> and focused tests in this chapter are executable. The chapter remains WIP even
+> though the checkpoint is executable.
 
 ## Check the Chapter
 

--- a/book/src/week4-06-control-recovery.md
+++ b/book/src/week4-06-control-recovery.md
@@ -1,5 +1,9 @@
 # Day 6: Control and Recovery
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 Long-running agents need a way to stop, accept a correction, and recover from a
 file mutation that was interrupted at an awkward moment. Day 6 adds those
 controls without treating a working directory, a process group, or a model
@@ -8,9 +12,8 @@ response as a safety boundary.
 > **Implementation status:** The reference implementation, learner API surface,
 > and focused tests are executable. Ctrl-C interruption is integrated with the
 > CLI. Checkpoint, undo, branch, and steering operations are programmatic APIs;
-> the CLI does not yet expose commands for them. Like every Week 4 daily
-> chapter, this file remains unrendered pending course review; executable does
-> not mean published.
+> the CLI does not yet expose commands for them. The chapter remains WIP even
+> though the checkpoint is executable.
 
 ## Check the Chapter
 

--- a/book/src/week4-07-evaluation.md
+++ b/book/src/week4-07-evaluation.md
@@ -1,5 +1,9 @@
 # Day 7: Safe Deterministic Evaluation
 
+> 🚧 **Early-review WIP:** This chapter is public for early review and may
+> change. Use a disposable workspace when running the agent or enabling writes
+> or commands.
+
 An agent saying that it finished is not evidence that its change is correct.
 Day 7 adds a small, deterministic evaluation harness that grades the resulting
 files independently of the model's final message. The checkpoint is deliberately
@@ -8,10 +12,9 @@ executes candidate code.
 
 > **Implementation status:** The reference implementation, learner API surface,
 > inert task packages, and focused tests implement the static evaluation boundary
-> described here. Like every Week 4 daily chapter, this file remains unrendered
-> pending course review; executable does not mean published. Executable Python
-> tests and general coding-task grading remain deferred until the candidate can
-> run inside a container or virtual machine.
+> described here. The chapter remains WIP even though the checkpoint is
+> executable. Executable Python tests and general coding-task grading remain
+> deferred until the candidate can run inside a container or virtual machine.
 
 ## Check the Chapter
 

--- a/book/src/week4-overview.md
+++ b/book/src/week4-overview.md
@@ -1,10 +1,10 @@
 # 🚧 Week 4: Build a Coding Agent
 
-> 🚧 **Course status:** The daily chapters are drafts and are not included in
-> the rendered book yet. The repository contains tested checkpoints through
-> Day 7, including safe static held-out evaluation. Executing model-authored code
-> or held-out pytest remains deferred until an isolated container or virtual
-> machine backend exists.
+> 🚧 **Course status:** The daily chapters are public for early review and may
+> change. The repository contains tested checkpoints through Day 7, including
+> safe static held-out evaluation. Executing model-authored code or held-out
+> pytest remains deferred until an isolated container or virtual machine backend
+> exists.
 
 Weeks 1 through 3 turned tokens into text, made decoding efficient, and
 introduced serving techniques. Week 4 adds the next layer: an agent loop that
@@ -189,7 +189,7 @@ provide a focused inference-framework exercise without changing model kernels.
 | 6 | Control and recovery | Cooperative cancellation, durable interrupt and steering events, mutation reconciliation, checkpoints, conflict-safe undo, branches, and command cancellation with a fake process are validated. |
 | 7 | Evaluation | Sealed inert packages, frozen snapshots, static held-out checks, forbidden-path grading, and metrics are validated without executing candidate code. |
 
-Each draft chapter names the focused learner command for its current checkpoint.
+Each daily chapter names the focused learner command for its current checkpoint.
 For example:
 
 ```bash


### PR DESCRIPTION
Why

Week 4’s seven daily chapters exist only as draft files even though they are now authorized for public early review.

Change

Publish the seven pages in book order, place the same prominent WIP and disposable-workspace warning at each chapter start, regenerate the sitemap, and mark only the Week 4 documentation cells green.

Review note

The repository’s existing `mdbook test` command fails on both main and this branch because it Rust-doctests Python and shell fences; the normal book build, link, and sitemap gates are green.

AI-Assisted: GPT-5.6 Sol + Sentinel
Reviewed-by: GPT-5.6 Sol + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (safety)
Reviewed-by: GPT-5.6 Sol + Scholar (learner)