### PR TITLE
Align Week 2 profiler with decode dispatch

### DIFF
--- a/benches/profile_week2_kernels.py
+++ b/benches/profile_week2_kernels.py
@@ -59,6 +59,8 @@ class KernelImplementation:
     quantized_linear: Callable[..., mx.array]
     decode_attention: Callable[..., mx.array]
     swiglu: Callable[[mx.array, mx.array], mx.array]
+    decode_attention_max_query: int
+    decode_attention_max_context: int
 
 
 def load_implementation(name: str) -> KernelImplementation:
@@ -78,6 +80,8 @@ def load_implementation(name: str) -> KernelImplementation:
         quantized_linear=quantize.quantized_linear,
         decode_attention=kernels.decode_attention_custom,
         swiglu=kernels.swiglu,
+        decode_attention_max_query=getattr(model, "DECODE_ATTENTION_MAX_QUERY", 0),
+        decode_attention_max_context=getattr(model, "DECODE_ATTENTION_MAX_CONTEXT", 0),
     )
 
 
@@ -156,6 +160,21 @@ def project(implementation: KernelImplementation, x: mx.array, weight: Any) -> m
     if isinstance(weight, implementation.quantized_weights_type):
         return implementation.quantized_linear(x, weight)
     return implementation.linear(x, weight)
+
+
+def should_use_decode_attention(
+    implementation: KernelImplementation,
+    enabled: bool,
+    query_length: int,
+    context_length: int,
+    mask: mx.array | str | None,
+) -> bool:
+    return (
+        enabled
+        and query_length <= implementation.decode_attention_max_query
+        and context_length <= implementation.decode_attention_max_context
+        and not isinstance(mask, mx.array)
+    )
 
 
 class KernelReplay:
@@ -247,10 +266,12 @@ class KernelReplay:
         mask = "causal" if self.phase == "prefill" else None
         for layer in self.model.layers_inner:
             attention = layer.self_attn
-            if (
-                attention.use_decode_attention
-                and self.rows <= 8
-                and self.context <= 128
+            if should_use_decode_attention(
+                self.implementation,
+                attention.use_decode_attention,
+                self.rows,
+                self.context,
+                mask,
             ):
                 output = self.implementation.decode_attention(
                     self.query,

--- a/benches/test_profile_week2_kernels.py
+++ b/benches/test_profile_week2_kernels.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import mlx.core as mx
+import pytest
 
 from benches import profile_week2_kernels as profile
 
@@ -65,6 +66,59 @@ def test_profile_reuses_the_model_decode_attention_boundaries():
             )
             is expected
         )
+
+
+@pytest.mark.parametrize(
+    ("phase", "tokens", "enabled", "expected_path", "expected_mask"),
+    (
+        ("decode", 128, True, "custom", None),
+        ("decode", 256, True, "custom", None),
+        ("decode", 257, True, "readable", None),
+        ("prefill", 2, True, "custom", "causal"),
+        ("prefill", 3, True, "readable", "causal"),
+        ("decode", 128, False, "readable", None),
+    ),
+)
+def test_kernel_replay_routes_attention_with_production_guard(
+    phase,
+    tokens,
+    enabled,
+    expected_path,
+    expected_mask,
+):
+    calls = []
+
+    def record(path):
+        def attention(query, _key, _value, *, scale, mask):
+            calls.append((path, scale, mask))
+            return query
+
+        return attention
+
+    implementation = SimpleNamespace(
+        decode_attention=record("custom"),
+        grouped_attention=record("readable"),
+        decode_attention_max_query=2,
+        decode_attention_max_context=256,
+    )
+    attention = SimpleNamespace(
+        num_kv_heads=1,
+        head_dim=4,
+        scale=0.5,
+        use_decode_attention=enabled,
+    )
+    layer = SimpleNamespace(
+        hidden_size=4,
+        num_attention_heads=1,
+        self_attn=attention,
+        mlp=SimpleNamespace(hidden_dim=8),
+    )
+    model = SimpleNamespace(layers_inner=[layer], precision=mx.float32)
+
+    replay = profile.KernelReplay(implementation, model, phase, tokens)
+    replay.attention()
+
+    assert calls == [(expected_path, 0.5, expected_mask)]
 
 
 def test_student_and_reference_profiles_share_the_production_guard():

--- a/benches/test_profile_week2_kernels.py
+++ b/benches/test_profile_week2_kernels.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from benches import profile_week2_kernels as profile
+
+
+def test_kernel_group_profile_rotates_every_group_through_each_position():
+    calls = []
+
+    def build(name):
+        def run():
+            calls.append(name)
+            return []
+
+        return run
+
+    builders = tuple((name, build(name)) for name in ("a", "b", "c", "d"))
+
+    profile.benchmark_groups(builders, warmup=0, iterations=4)
+
+    assert calls == [
+        "a",
+        "b",
+        "c",
+        "d",
+        "b",
+        "c",
+        "d",
+        "a",
+        "c",
+        "d",
+        "a",
+        "b",
+        "d",
+        "a",
+        "b",
+        "c",
+    ]
+
+
+def test_profile_reuses_the_model_decode_attention_boundaries():
+    implementation = SimpleNamespace(
+        decode_attention_max_query=2,
+        decode_attention_max_context=256,
+    )
+    explicit_mask = mx.zeros((1, 1, 1, 1), dtype=mx.float32)
+
+    cases = (
+        (True, 1, 1, None, True),
+        (True, 2, 256, "causal", True),
+        (True, 3, 256, None, False),
+        (True, 2, 257, None, False),
+        (True, 1, 1, explicit_mask, False),
+        (False, 1, 1, None, False),
+    )
+    for enabled, query_length, context_length, mask, expected in cases:
+        assert (
+            profile.should_use_decode_attention(
+                implementation,
+                enabled,
+                query_length,
+                context_length,
+                mask,
+            )
+            is expected
+        )
+
+
+def test_student_and_reference_profiles_share_the_production_guard():
+    for name in ("tiny_llm", "tiny_llm_ref"):
+        implementation = profile.load_implementation(name)
+        assert implementation.decode_attention_max_query == 2
+        assert implementation.decode_attention_max_context == 256

--- a/src/tiny_llm/qwen3_week2.py
+++ b/src/tiny_llm/qwen3_week2.py
@@ -23,6 +23,9 @@ WEEK2_CHECKPOINTS = (
     "split-k",
 )
 
+DECODE_ATTENTION_MAX_CONTEXT = 256
+DECODE_ATTENTION_MAX_QUERY = 2
+
 
 class Qwen3MultiHeadAttention:
     def __init__(


### PR DESCRIPTION
## Why

The Week 2 kernel profiler copied decode-attention limits that had drifted from the production model, so custom profile cases could attribute work to the wrong path.

## What changed

Load the dispatch boundaries from the selected Week 2 model contract, use the same mask and boundary decision as production, and cover that decision, its real `KernelReplay.attention()` routing, and the profiler's order rotation with focused tests.

## Review note

The stale inline guard now fails both distinguishing replay cases while the restored head passes 9 profiler tests, 30 benchmark tests, and the unchanged 561-test reference suite.

AI-Assisted: GPT-5.6 Sol + Tuner
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
