### PR TITLE
Repair Week 3 speculative decoding

### DIFF
--- a/book/src/week3-optional-speculative-decoding.md
+++ b/book/src/week3-optional-speculative-decoding.md
@@ -27,7 +27,8 @@ By the end of this chapter, you should be able to:
 - Complete Week 2 cached generation for both the draft and target models.
 - Complete the Week 3 paged cache and page-aware attention path.
 - Use compatible tokenizers for the two models. A shared token id must represent
-  the same text in both vocabularies.
+  the same text in both vocabularies. Validate that contract before either model
+  runs; mismatched prompt encodings, EOS ids, or vocabularies must fail closed.
 
 This extension comes after paged attention for two concrete reasons. Rejected
 draft tokens must release pages and repair the valid tail length, and verifying
@@ -56,12 +57,28 @@ tokens and the draft-cache offset. Stop early at EOS.
 
 Keep the proposal length configurable. A longer proposal reduces target calls
 only when the acceptance rate remains high enough to repay the extra draft work.
+Use a default of four and treat zero as an explicit target-only fallback:
+
+```python
+speculative_generate(
+    draft_model,
+    model,
+    draft_tokenizer,
+    tokenizer,
+    prompt,
+    proposal_length=4,
+)
+```
 
 ## Task 3: Verify in One Target Call
 
 Pass the last accepted token followed by the draft proposal to the target model
 in one call. Request logits for every supplied position, then compare the target
 greedy tokens with the aligned draft sequence.
+
+Keep prompt, proposal, and verification token arrays in a supported 32-bit
+integer dtype. Mixing unsigned and signed 32-bit token arrays can promote a
+concatenation to 64-bit indices, which quantized embeddings reject.
 
 The first supplied token is already accepted. Starting at the next position,
 find the longest matching prefix. If every draft token matches, keep the target
@@ -81,6 +98,10 @@ Treat cache offsets as a correctness invariant:
 Exercise mismatch at the first, middle, and final proposed token. Also test a
 fully accepted proposal and EOS inside a proposal. Compare the complete output
 with ordinary greedy generation from the target model.
+
+```bash
+pdm run test --week 3 --day 7
+```
 
 Run the integrated path with a small draft model and a larger target model:
 

--- a/src/tiny_llm/generate.py
+++ b/src/tiny_llm/generate.py
@@ -5,6 +5,13 @@ from .qwen3_week2 import Qwen3ModelWeek2
 from typing import Callable
 
 
+def _release_kv_cache(kv_cache):
+    if kv_cache is None:
+        return
+    for layer in kv_cache:
+        layer.release()
+
+
 def simple_generate(
     model: Qwen3ModelWeek1,
     tokenizer: TokenizerWrapper,
@@ -28,5 +35,236 @@ def speculative_generate(
     draft_tokenizer: TokenizerWrapper,
     tokenizer: TokenizerWrapper,
     prompt: str,
+    proposal_length: int = 4,
 ) -> str:
-    pass
+    if (
+        not isinstance(proposal_length, int)
+        or isinstance(proposal_length, bool)
+        or proposal_length < 0
+    ):
+        raise ValueError("proposal_length must be a non-negative integer")
+
+    def _encode(tokenizer):
+        return [
+            int(token) for token in tokenizer.encode(prompt, add_special_tokens=False)
+        ]
+
+    def _eos_ids(tokenizer):
+        eos_ids = getattr(tokenizer, "eos_token_ids", None)
+        if eos_ids is None:
+            eos_ids = {tokenizer.eos_token_id}
+        return {int(token) for token in eos_ids}
+
+    target_prompt_tokens = _encode(tokenizer)
+    draft_prompt_tokens = _encode(draft_tokenizer)
+    if not target_prompt_tokens:
+        raise ValueError("prompt must encode to at least one token")
+    if target_prompt_tokens != draft_prompt_tokens:
+        raise ValueError("draft and target tokenizers encode the prompt differently")
+    if _eos_ids(tokenizer) != _eos_ids(draft_tokenizer):
+        raise ValueError("draft and target tokenizers use different EOS token ids")
+
+    target_get_vocab = getattr(tokenizer, "get_vocab", None)
+    draft_get_vocab = getattr(draft_tokenizer, "get_vocab", None)
+    if not callable(target_get_vocab) or not callable(draft_get_vocab):
+        raise ValueError(
+            "draft and target tokenizers must expose comparable vocabularies"
+        )
+    if target_get_vocab() != draft_get_vocab():
+        raise ValueError("draft and target tokenizers use different token ids")
+
+    target_eos_ids = _eos_ids(tokenizer)
+    draft_eos_ids = _eos_ids(draft_tokenizer)
+    detokenizer = tokenizer.detokenizer
+    detokenizer.reset()
+
+    kv_cache = model.create_kv_cache()
+    draft_kv_cache = None
+
+    def _step(model, y, offset, kv_cache, n_tokens=1):
+        logits = model(y[None], offset, kv_cache, logits_to_keep=n_tokens)
+        if n_tokens > 1:
+            logits = logits[:, -n_tokens:, :]
+        else:
+            logits = logits[:, -1, :]
+        logprobs = logits - mx.logsumexp(logits, keepdims=True)
+        y = mx.argmax(logprobs, axis=-1).astype(mx.int32)
+        return y, logprobs.squeeze(0)
+
+    def _token_array(tokens):
+        return mx.array(tokens, dtype=mx.int32)
+
+    def _token_id(token):
+        return int(token.item())
+
+    def _prefill(model, prefill_tokens, kv_cache):
+        token, _ = _step(model, _token_array(prefill_tokens), 0, kv_cache)
+        mx.eval(token)
+        return _token_id(token), len(prefill_tokens)
+
+    def _rewind_cache(kv_cache, revert_len):
+        if revert_len == 0:
+            return
+        for layer in kv_cache:
+            layer.rewind(revert_len)
+
+    def _assert_cache_offset(kv_cache, expected):
+        for layer in kv_cache:
+            if hasattr(layer, "offset"):
+                assert layer.offset == expected
+
+    def _print_text(text, progress):
+        newline = "\n"
+        print(f"+{progress} {text.replace(newline, ' ')[-80:]}")
+
+    def _emit(token_ids):
+        for token_id in token_ids:
+            detokenizer.add_token(token_id)
+        if token_ids:
+            _print_text(detokenizer.text, len(token_ids))
+
+    def _finish():
+        finalize = getattr(detokenizer, "finalize", None)
+        if callable(finalize):
+            finalize()
+        text = detokenizer.text
+        print(text)
+        return text
+
+    def _target_only(token_id, offset):
+        while True:
+            if token_id in target_eos_ids:
+                return _finish()
+            _emit([token_id])
+            token, _ = _step(
+                model,
+                _token_array([token_id]),
+                offset,
+                kv_cache,
+            )
+            mx.eval(token)
+            offset += 1
+            _assert_cache_offset(kv_cache, offset)
+            token_id = _token_id(token)
+
+    try:
+        token_id, offset = _prefill(model, target_prompt_tokens, kv_cache)
+        _assert_cache_offset(kv_cache, offset)
+        if token_id in target_eos_ids:
+            return _finish()
+        if proposal_length == 0:
+            return _target_only(token_id, offset)
+
+        draft_kv_cache = draft_model.create_kv_cache()
+        draft_token_id, draft_offset = _prefill(
+            draft_model,
+            draft_prompt_tokens,
+            draft_kv_cache,
+        )
+        _assert_cache_offset(draft_kv_cache, draft_offset)
+        assert offset == draft_offset
+        if draft_token_id in draft_eos_ids:
+            return _target_only(token_id, offset)
+
+        def _draft_generate(last_token_id, offset, max_tokens):
+            tokens: list[int] = []
+            current_offset = offset
+            for _ in range(max_tokens):
+                token, _ = _step(
+                    draft_model,
+                    _token_array([last_token_id]),
+                    current_offset,
+                    draft_kv_cache,
+                )
+                mx.eval(token)
+                last_token_id = _token_id(token)
+                tokens.append(last_token_id)
+                current_offset += 1
+                if last_token_id in draft_eos_ids:
+                    break
+            return tokens, current_offset
+
+        while True:
+            draft_tokens, draft_offset = _draft_generate(
+                token_id,
+                draft_offset,
+                proposal_length,
+            )
+            _assert_cache_offset(draft_kv_cache, draft_offset)
+
+            verification_ids = [token_id, *draft_tokens]
+            new_tokens, _ = _step(
+                model,
+                _token_array(verification_ids),
+                offset,
+                kv_cache,
+                len(verification_ids),
+            )
+            mx.eval(new_tokens)
+            target_predictions = [
+                int(value) for value in new_tokens.reshape(-1).tolist()
+            ]
+            assert len(target_predictions) == len(verification_ids)
+            offset += len(verification_ids)
+            _assert_cache_offset(kv_cache, offset)
+
+            aligned_target = [token_id, *target_predictions[:-1]]
+            mismatch_index = None
+            terminal_index = None
+            for i, (target_id, draft_id) in enumerate(
+                zip(aligned_target, verification_ids, strict=True)
+            ):
+                if target_id != draft_id:
+                    mismatch_index = i
+                    break
+                if target_id in target_eos_ids:
+                    terminal_index = i
+                    break
+
+            if terminal_index is not None:
+                _emit(aligned_target[:terminal_index])
+                target_rewind = len(verification_ids) - terminal_index
+                draft_rewind = len(draft_tokens) - terminal_index
+                _rewind_cache(kv_cache, target_rewind)
+                _rewind_cache(draft_kv_cache, draft_rewind)
+                offset -= target_rewind
+                draft_offset -= draft_rewind
+                assert offset == draft_offset
+                _assert_cache_offset(kv_cache, offset)
+                _assert_cache_offset(draft_kv_cache, draft_offset)
+                return _finish()
+
+            if mismatch_index is not None:
+                assert mismatch_index >= 1
+                _emit(aligned_target[:mismatch_index])
+                target_rewind = len(verification_ids) - mismatch_index
+                draft_rewind = len(draft_tokens) - mismatch_index
+                _rewind_cache(kv_cache, target_rewind)
+                _rewind_cache(draft_kv_cache, draft_rewind)
+                offset -= target_rewind
+                draft_offset -= draft_rewind
+                assert offset == draft_offset
+                _assert_cache_offset(kv_cache, offset)
+                _assert_cache_offset(draft_kv_cache, draft_offset)
+                token_id = aligned_target[mismatch_index]
+                if token_id in target_eos_ids:
+                    return _finish()
+                continue
+
+            _emit(aligned_target)
+            bonus_token_id = target_predictions[-1]
+            if bonus_token_id in target_eos_ids:
+                return _finish()
+
+            _, draft_offset = _draft_generate(
+                verification_ids[-1],
+                draft_offset,
+                1,
+            )
+            token_id = bonus_token_id
+            assert offset == draft_offset
+            _assert_cache_offset(kv_cache, offset)
+            _assert_cache_offset(draft_kv_cache, draft_offset)
+    finally:
+        _release_kv_cache(draft_kv_cache)
+        _release_kv_cache(kv_cache)

--- a/src/tiny_llm_ref/generate.py
+++ b/src/tiny_llm_ref/generate.py
@@ -7,6 +7,8 @@ from typing import Callable
 
 
 def _release_kv_cache(kv_cache):
+    if kv_cache is None:
+        return
     for layer in kv_cache:
         layer.release()
 
@@ -85,9 +87,51 @@ def speculative_generate(
     draft_tokenizer: TokenizerWrapper,
     tokenizer: TokenizerWrapper,
     prompt: str,
+    proposal_length: int = 4,
 ) -> str:
-    draft_kv_cache = draft_model.create_kv_cache()
+    if (
+        not isinstance(proposal_length, int)
+        or isinstance(proposal_length, bool)
+        or proposal_length < 0
+    ):
+        raise ValueError("proposal_length must be a non-negative integer")
+
+    def _encode(tokenizer):
+        return [
+            int(token) for token in tokenizer.encode(prompt, add_special_tokens=False)
+        ]
+
+    def _eos_ids(tokenizer):
+        eos_ids = getattr(tokenizer, "eos_token_ids", None)
+        if eos_ids is None:
+            eos_ids = {tokenizer.eos_token_id}
+        return {int(token) for token in eos_ids}
+
+    target_prompt_tokens = _encode(tokenizer)
+    draft_prompt_tokens = _encode(draft_tokenizer)
+    if not target_prompt_tokens:
+        raise ValueError("prompt must encode to at least one token")
+    if target_prompt_tokens != draft_prompt_tokens:
+        raise ValueError("draft and target tokenizers encode the prompt differently")
+    if _eos_ids(tokenizer) != _eos_ids(draft_tokenizer):
+        raise ValueError("draft and target tokenizers use different EOS token ids")
+
+    target_get_vocab = getattr(tokenizer, "get_vocab", None)
+    draft_get_vocab = getattr(draft_tokenizer, "get_vocab", None)
+    if not callable(target_get_vocab) or not callable(draft_get_vocab):
+        raise ValueError(
+            "draft and target tokenizers must expose comparable vocabularies"
+        )
+    if target_get_vocab() != draft_get_vocab():
+        raise ValueError("draft and target tokenizers use different token ids")
+
+    target_eos_ids = _eos_ids(tokenizer)
+    draft_eos_ids = _eos_ids(draft_tokenizer)
+    detokenizer = tokenizer.detokenizer
+    detokenizer.reset()
+
     kv_cache = model.create_kv_cache()
+    draft_kv_cache = None
 
     def _step(model, y, offset, kv_cache, n_tokens=1):
         logits = model(y[None], offset, kv_cache, logits_to_keep=n_tokens)
@@ -96,100 +140,183 @@ def speculative_generate(
         else:
             logits = logits[:, -1, :]
         logprobs = logits - mx.logsumexp(logits, keepdims=True)
-        sampler = lambda x: mx.argmax(x, axis=-1)
-        y = sampler(logprobs)
+        y = mx.argmax(logprobs, axis=-1).astype(mx.int32)
         return y, logprobs.squeeze(0)
 
-    # prefill with the prompt, using the large model
-    def _prefill(model, tokenizer, prompt, kv_cache):
-        prefill_tokens = mx.array(tokenizer.encode(prompt, add_special_tokens=False))
-        offset = 0
-        token, _ = _step(model, prefill_tokens, offset, kv_cache)
+    def _token_array(tokens):
+        return mx.array(tokens, dtype=mx.int32)
+
+    def _token_id(token):
+        return int(token.item())
+
+    def _prefill(model, prefill_tokens, kv_cache):
+        token, _ = _step(model, _token_array(prefill_tokens), 0, kv_cache)
         mx.eval(token)
-        if token.item() == tokenizer.eos_token_id:
+        return _token_id(token), len(prefill_tokens)
+
+    def _rewind_cache(kv_cache, revert_len):
+        if revert_len == 0:
             return
-        offset = prefill_tokens.size
-        return token, offset
+        for layer in kv_cache:
+            layer.rewind(revert_len)
+
+    def _assert_cache_offset(kv_cache, expected):
+        for layer in kv_cache:
+            if hasattr(layer, "offset"):
+                assert layer.offset == expected
+
+    def _print_text(text, progress):
+        newline = "\n"
+        print(f"+{progress} {text.replace(newline, ' ')[-80:]}")
+
+    def _emit(token_ids):
+        for token_id in token_ids:
+            detokenizer.add_token(token_id)
+        if token_ids:
+            _print_text(detokenizer.text, len(token_ids))
+
+    def _finish():
+        finalize = getattr(detokenizer, "finalize", None)
+        if callable(finalize):
+            finalize()
+        text = detokenizer.text
+        print(text)
+        return text
+
+    def _target_only(token_id, offset):
+        while True:
+            if token_id in target_eos_ids:
+                return _finish()
+            _emit([token_id])
+            token, _ = _step(
+                model,
+                _token_array([token_id]),
+                offset,
+                kv_cache,
+            )
+            mx.eval(token)
+            offset += 1
+            _assert_cache_offset(kv_cache, offset)
+            token_id = _token_id(token)
 
     try:
-        draft_token, draft_offset = _prefill(
-            draft_model, draft_tokenizer, prompt, draft_kv_cache
+        token_id, offset = _prefill(model, target_prompt_tokens, kv_cache)
+        _assert_cache_offset(kv_cache, offset)
+        if token_id in target_eos_ids:
+            return _finish()
+        if proposal_length == 0:
+            return _target_only(token_id, offset)
+
+        draft_kv_cache = draft_model.create_kv_cache()
+        draft_token_id, draft_offset = _prefill(
+            draft_model,
+            draft_prompt_tokens,
+            draft_kv_cache,
         )
-        token, offset = _prefill(model, tokenizer, prompt, kv_cache)
+        _assert_cache_offset(draft_kv_cache, draft_offset)
+        assert offset == draft_offset
+        if draft_token_id in draft_eos_ids:
+            return _target_only(token_id, offset)
 
-        def _decode_one(token, tokenizer):
-            if token.item() == tokenizer.eos_token_id:
-                return False
-            detokenizer = tokenizer.detokenizer
-            detokenizer.add_token(token.item())
-            return True
-
-        def draft_generate(model, last_token, offset, kv_cache, num_drafts):
-            tokens = []
+        def _draft_generate(last_token_id, offset, max_tokens):
+            tokens: list[int] = []
             current_offset = offset
-            for _ in range(num_drafts):
-                token, _ = _step(model, last_token, current_offset, kv_cache)
-                mx.eval(token)
-                tokens.append(token.item())
-                last_token = token
-                current_offset += 1
-            return tokens
-
-        num_drafts = 4
-
-        def _rewind_cache(kv_cache, revert_len):
-            for layer in kv_cache:
-                layer.rewind(revert_len)
-
-        def _print_text(text, progress):
-            newline = "\n"
-            print(f"+{progress} {text.replace(newline, ' ')[-80:]}")
-
-        # speculative decode
-        while True:
-            draft_tokens = draft_generate(
-                draft_model, token, draft_offset, draft_kv_cache, num_drafts
-            )
-            draft_offset += num_drafts
-            # assume both models use the same tokenizer
-            draft_tokens = mx.concat([token, mx.array(draft_tokens)])
-            new_tokens, _ = _step(model, draft_tokens, offset, kv_cache, num_drafts + 1)
-            new_tokens = new_tokens.tolist()[0]
-            offset += num_drafts + 1
-            last_new_token = new_tokens[-1]
-            new_tokens = mx.array([token.item()] + new_tokens[:-1])
-            assert len(new_tokens) == len(draft_tokens)
-            accept_all = True
-            for i in range(len(new_tokens)):
-                if new_tokens[i] != draft_tokens[i]:
-                    # revert the full draft generation; re-generate next time
-                    # or we matched full, then no rewind and use the last token
-                    assert i >= 1  # first token is always the same
-                    revert_len = len(draft_tokens) - i
-                    _rewind_cache(draft_kv_cache, revert_len - 1)
-                    draft_offset -= revert_len - 1
-                    _rewind_cache(kv_cache, revert_len)
-                    token = mx.array([new_tokens[i]])
-                    offset -= revert_len
-                    assert offset == draft_offset
-                    assert offset == kv_cache[0].offset
-                    _print_text(tokenizer._detokenizer.text, i)
-                    accept_all = False
-                    break
-                if not _decode_one(new_tokens[i], tokenizer):
-                    print(tokenizer._detokenizer.text)
-                    return tokenizer._detokenizer.text
-            if accept_all:
-                _print_text(tokenizer._detokenizer.text, len(new_tokens))
-                draft_generate(
+            for _ in range(max_tokens):
+                token, _ = _step(
                     draft_model,
-                    mx.array(draft_tokens[-1:]),
-                    draft_offset,
+                    _token_array([last_token_id]),
+                    current_offset,
                     draft_kv_cache,
-                    1,
                 )
-                token = mx.array([last_new_token])
-                draft_offset += 1
+                mx.eval(token)
+                last_token_id = _token_id(token)
+                tokens.append(last_token_id)
+                current_offset += 1
+                if last_token_id in draft_eos_ids:
+                    break
+            return tokens, current_offset
+
+        while True:
+            draft_tokens, draft_offset = _draft_generate(
+                token_id,
+                draft_offset,
+                proposal_length,
+            )
+            _assert_cache_offset(draft_kv_cache, draft_offset)
+
+            verification_ids = [token_id, *draft_tokens]
+            new_tokens, _ = _step(
+                model,
+                _token_array(verification_ids),
+                offset,
+                kv_cache,
+                len(verification_ids),
+            )
+            mx.eval(new_tokens)
+            target_predictions = [
+                int(value) for value in new_tokens.reshape(-1).tolist()
+            ]
+            assert len(target_predictions) == len(verification_ids)
+            offset += len(verification_ids)
+            _assert_cache_offset(kv_cache, offset)
+
+            aligned_target = [token_id, *target_predictions[:-1]]
+            mismatch_index = None
+            terminal_index = None
+            for i, (target_id, draft_id) in enumerate(
+                zip(aligned_target, verification_ids, strict=True)
+            ):
+                if target_id != draft_id:
+                    mismatch_index = i
+                    break
+                if target_id in target_eos_ids:
+                    terminal_index = i
+                    break
+
+            if terminal_index is not None:
+                _emit(aligned_target[:terminal_index])
+                target_rewind = len(verification_ids) - terminal_index
+                draft_rewind = len(draft_tokens) - terminal_index
+                _rewind_cache(kv_cache, target_rewind)
+                _rewind_cache(draft_kv_cache, draft_rewind)
+                offset -= target_rewind
+                draft_offset -= draft_rewind
+                assert offset == draft_offset
+                _assert_cache_offset(kv_cache, offset)
+                _assert_cache_offset(draft_kv_cache, draft_offset)
+                return _finish()
+
+            if mismatch_index is not None:
+                assert mismatch_index >= 1
+                _emit(aligned_target[:mismatch_index])
+                target_rewind = len(verification_ids) - mismatch_index
+                draft_rewind = len(draft_tokens) - mismatch_index
+                _rewind_cache(kv_cache, target_rewind)
+                _rewind_cache(draft_kv_cache, draft_rewind)
+                offset -= target_rewind
+                draft_offset -= draft_rewind
+                assert offset == draft_offset
+                _assert_cache_offset(kv_cache, offset)
+                _assert_cache_offset(draft_kv_cache, draft_offset)
+                token_id = aligned_target[mismatch_index]
+                if token_id in target_eos_ids:
+                    return _finish()
+                continue
+
+            _emit(aligned_target)
+            bonus_token_id = target_predictions[-1]
+            if bonus_token_id in target_eos_ids:
+                return _finish()
+
+            _, draft_offset = _draft_generate(
+                verification_ids[-1],
+                draft_offset,
+                1,
+            )
+            token_id = bonus_token_id
+            assert offset == draft_offset
+            _assert_cache_offset(kv_cache, offset)
+            _assert_cache_offset(draft_kv_cache, draft_offset)
     finally:
         _release_kv_cache(draft_kv_cache)
         _release_kv_cache(kv_cache)

--- a/tests_refsol/test_week_3_day_7.py
+++ b/tests_refsol/test_week_3_day_7.py
@@ -1,0 +1,491 @@
+"""Optional Week 3 speculative-decoding tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from .tiny_llm_base import speculative_generate
+
+
+EOS = 0
+PROMPT = [10, 11]
+PIECES = {
+    1: "A",
+    2: "B",
+    3: "C",
+    4: "D",
+    5: "E",
+    6: "F",
+    7: "G",
+    8: "H",
+    9: "I",
+}
+
+
+class FakeDetokenizer:
+    def __init__(self, tokenizer: "FakeTokenizer"):
+        self.tokenizer = tokenizer
+        self.tokens: list[int] = []
+        self.offset = 0
+        self.reset_count = 0
+        self.finalize_count = 0
+
+    def reset(self):
+        self.tokens = []
+        self.offset = 0
+        self.reset_count += 1
+
+    def add_token(self, token: int):
+        self.tokens.append(token)
+
+    def finalize(self):
+        self.finalize_count += 1
+
+    @property
+    def text(self) -> str:
+        return "".join(self.tokenizer.pieces[token] for token in self.tokens)
+
+    @property
+    def last_segment(self) -> str:
+        text = self.text
+        segment = text[self.offset :]
+        self.offset = len(text)
+        return segment
+
+
+class FakeTokenizer:
+    def __init__(
+        self,
+        prompt_tokens: list[int] | None = None,
+        *,
+        eos_token_ids: set[int] | None = None,
+        vocab: dict[str, int] | None = None,
+    ):
+        self.prompt_tokens = list(prompt_tokens or PROMPT)
+        self.eos_token_id = EOS
+        self.eos_token_ids = set(eos_token_ids or {EOS})
+        self.pieces = PIECES
+        self.vocab = vocab or {
+            "<eos>": EOS,
+            **{text: token for token, text in PIECES.items()},
+            "prompt-a": PROMPT[0],
+            "prompt-b": PROMPT[1],
+        }
+        self.created_detokenizers: list[FakeDetokenizer] = []
+        # A deliberately persistent private detokenizer catches implementations
+        # that reuse TokenizerWrapper internals across generation calls.
+        self._detokenizer = FakeDetokenizer(self)
+
+    def encode(self, prompt: str, add_special_tokens: bool = False) -> list[int]:
+        assert prompt == "prompt"
+        assert not add_special_tokens
+        return list(self.prompt_tokens)
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self.vocab)
+
+    @property
+    def detokenizer(self) -> FakeDetokenizer:
+        detokenizer = FakeDetokenizer(self)
+        self.created_detokenizers.append(detokenizer)
+        return detokenizer
+
+
+@dataclass
+class FakeCache:
+    offset: int = 0
+    rewind_calls: list[int] = field(default_factory=list)
+    release_count: int = 0
+
+    def rewind(self, n: int):
+        assert 0 < n <= self.offset
+        self.offset -= n
+        self.rewind_calls.append(n)
+
+    def release(self):
+        self.release_count += 1
+
+
+class ScriptedModel:
+    def __init__(self, outputs: list[list[int]], name: str):
+        self.outputs = [list(output) for output in outputs]
+        self.name = name
+        self.calls: list[dict[str, object]] = []
+        self.caches: list[FakeCache] = []
+
+    def create_kv_cache(self) -> list[FakeCache]:
+        cache = FakeCache()
+        self.caches.append(cache)
+        return [cache]
+
+    def __call__(self, tokens, offset, kv_cache, logits_to_keep=1):
+        cache = kv_cache[0]
+        assert tokens.dtype == mx.int32
+        assert offset == cache.offset
+        token_ids = [int(token) for token in tokens.reshape(-1).tolist()]
+        cache.offset += len(token_ids)
+
+        if not self.outputs:
+            raise AssertionError(f"{self.name} received an unexpected model call")
+        output = self.outputs.pop(0)
+        assert len(output) == logits_to_keep
+        self.calls.append(
+            {
+                "tokens": token_ids,
+                "offset": offset,
+                "logits_to_keep": logits_to_keep,
+                "dtype": tokens.dtype,
+            }
+        )
+
+        logits = np.full((1, len(output), 32), -1000.0, dtype=np.float32)
+        for position, token_id in enumerate(output):
+            logits[0, position, token_id] = 1000.0
+        return mx.array(logits)
+
+
+def _tokenizers() -> tuple[FakeTokenizer, FakeTokenizer]:
+    return FakeTokenizer(), FakeTokenizer()
+
+
+def _assert_released(*models: ScriptedModel):
+    for model in models:
+        assert all(cache.release_count == 1 for cache in model.caches)
+
+
+def test_target_prefill_eos_finishes_before_the_draft_runs():
+    target = ScriptedModel([[EOS]], "target")
+    draft = ScriptedModel([], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+    )
+
+    assert result == ""
+    assert len(target.calls) == 1
+    assert draft.calls == []
+    assert draft.caches == []
+    _assert_released(target)
+
+
+def test_zero_proposal_length_is_target_only_and_uses_int32_tokens():
+    target = ScriptedModel([[1], [2], [EOS]], "target")
+    draft = ScriptedModel([], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=0,
+    )
+
+    assert result == "AB"
+    assert [call["tokens"] for call in target.calls] == [PROMPT, [1], [2]]
+    assert all(call["dtype"] == mx.int32 for call in target.calls)
+    assert draft.calls == []
+    assert draft.caches == []
+    _assert_released(target)
+
+
+def test_draft_prefill_eos_falls_back_to_target_only():
+    target = ScriptedModel([[1], [2], [EOS]], "target")
+    draft = ScriptedModel([[EOS]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+    )
+
+    assert result == "AB"
+    assert [call["tokens"] for call in draft.calls] == [PROMPT]
+    assert [call["tokens"] for call in target.calls] == [PROMPT, [1], [2]]
+    _assert_released(target, draft)
+
+
+@pytest.mark.parametrize("mismatch_index", [1, 2, 3])
+def test_mismatch_rewinds_first_middle_and_final_proposal(mismatch_index: int):
+    proposal = [2, 3, 4]
+    predictions = [7, 7, 7, 7]
+    predictions[: mismatch_index - 1] = proposal[: mismatch_index - 1]
+    predictions[mismatch_index - 1] = EOS
+
+    target = ScriptedModel([[1], predictions], "target")
+    draft = ScriptedModel([[9], [2], [3], [4]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=3,
+    )
+
+    assert result == "".join(
+        PIECES[token] for token in [1, *proposal][0:mismatch_index]
+    )
+    assert target.caches[0].rewind_calls == [4 - mismatch_index]
+    expected_draft_rewind = 3 - mismatch_index
+    assert draft.caches[0].rewind_calls == (
+        [expected_draft_rewind] if expected_draft_rewind else []
+    )
+    _assert_released(target, draft)
+
+
+def test_low_acceptance_mismatches_match_the_complete_target_only_output():
+    target = ScriptedModel(
+        [
+            [1],
+            [3, 7],
+            [EOS, 7],
+        ],
+        "target",
+    )
+    draft = ScriptedModel([[9], [2], [4]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    speculative_result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=1,
+    )
+
+    target_only = ScriptedModel([[1], [3], [EOS]], "target-only")
+    target_only_draft = ScriptedModel([], "unused-draft")
+    target_only_draft_tokenizer, target_only_tokenizer = _tokenizers()
+    target_only_result = speculative_generate(
+        target_only_draft,
+        target_only,
+        target_only_draft_tokenizer,
+        target_only_tokenizer,
+        "prompt",
+        proposal_length=0,
+    )
+
+    assert speculative_result == target_only_result == "AC"
+    assert [call["tokens"] for call in target.calls] == [PROMPT, [1, 2], [3, 4]]
+    assert target.caches[0].rewind_calls == [1, 1]
+    assert draft.caches[0].rewind_calls == []
+    _assert_released(target, draft, target_only)
+    assert target_only_draft.caches == []
+
+
+def test_full_acceptance_stops_on_bonus_eos_without_a_followup_model_call():
+    target = ScriptedModel([[1], [2, 3, EOS]], "target")
+    draft = ScriptedModel([[9], [2], [3]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=2,
+    )
+
+    assert result == "ABC"
+    assert [call["tokens"] for call in target.calls] == [PROMPT, [1, 2, 3]]
+    # Prefill plus two proposal calls: no draft catch-up may follow target EOS.
+    assert [call["tokens"] for call in draft.calls] == [PROMPT, [1], [2]]
+    _assert_released(target, draft)
+
+
+def test_matching_eos_inside_a_short_proposal_is_terminal():
+    target = ScriptedModel([[1], [2, EOS, 7]], "target")
+    draft = ScriptedModel([[9], [2], [EOS]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=4,
+    )
+
+    assert result == "AB"
+    assert [call["tokens"] for call in draft.calls] == [PROMPT, [1], [2]]
+    assert target.caches[0].rewind_calls == [1]
+    assert draft.caches[0].rewind_calls == []
+    _assert_released(target, draft)
+
+
+def test_full_acceptance_catches_up_before_the_next_proposal():
+    target = ScriptedModel(
+        [
+            [1],
+            [2, 3, 4],
+            [5, 6, EOS],
+        ],
+        "target",
+    )
+    draft = ScriptedModel(
+        [
+            [9],
+            [2],
+            [3],
+            [9],
+            [5],
+            [6],
+        ],
+        "draft",
+    )
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=2,
+    )
+
+    assert result == "ABCDEF"
+    assert [call["offset"] for call in target.calls] == [0, 2, 5]
+    assert [call["offset"] for call in draft.calls] == [0, 2, 3, 4, 5, 6]
+    _assert_released(target, draft)
+
+
+def test_draft_proposal_stops_early_at_eos_without_terminating_target():
+    target = ScriptedModel(
+        [
+            [1],
+            [3, 7],
+            [EOS, 7],
+        ],
+        "target",
+    )
+    draft = ScriptedModel([[9], [EOS], [EOS]], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    result = speculative_generate(
+        draft,
+        target,
+        draft_tokenizer,
+        tokenizer,
+        "prompt",
+        proposal_length=4,
+    )
+
+    assert result == "AC"
+    assert [call["tokens"] for call in draft.calls] == [PROMPT, [1], [3]]
+    assert [call["logits_to_keep"] for call in target.calls] == [1, 2, 2]
+    _assert_released(target, draft)
+
+
+def test_repeated_calls_use_fresh_public_detokenizers():
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    results = []
+    for _ in range(2):
+        target = ScriptedModel([[1], [2], [EOS]], "target")
+        draft = ScriptedModel([], "draft")
+        results.append(
+            speculative_generate(
+                draft,
+                target,
+                draft_tokenizer,
+                tokenizer,
+                "prompt",
+                proposal_length=0,
+            )
+        )
+        _assert_released(target)
+
+    assert results == ["AB", "AB"]
+    assert len(tokenizer.created_detokenizers) == 2
+    assert [item.reset_count for item in tokenizer.created_detokenizers] == [1, 1]
+    assert tokenizer._detokenizer.tokens == []
+
+
+@pytest.mark.parametrize(
+    ("draft_tokenizer", "error"),
+    [
+        (FakeTokenizer([10, 12]), "encode the prompt differently"),
+        (FakeTokenizer(eos_token_ids={EOS, 31}), "different EOS token ids"),
+        (
+            FakeTokenizer(vocab={"<eos>": EOS, "different": 1}),
+            "different token ids",
+        ),
+    ],
+)
+def test_incompatible_tokenizers_fail_before_model_execution(
+    draft_tokenizer: FakeTokenizer,
+    error: str,
+):
+    target = ScriptedModel([], "target")
+    draft = ScriptedModel([], "draft")
+
+    with pytest.raises(ValueError, match=error):
+        speculative_generate(
+            draft,
+            target,
+            draft_tokenizer,
+            FakeTokenizer(),
+            "prompt",
+        )
+
+    assert target.caches == []
+    assert draft.caches == []
+
+
+def test_tokenizers_without_comparable_vocabularies_fail_before_execution():
+    target = ScriptedModel([], "target")
+    draft = ScriptedModel([], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+    draft_tokenizer.get_vocab = None
+
+    with pytest.raises(ValueError, match="comparable vocabularies"):
+        speculative_generate(
+            draft,
+            target,
+            draft_tokenizer,
+            tokenizer,
+            "prompt",
+        )
+
+    assert target.caches == []
+    assert draft.caches == []
+
+
+@pytest.mark.parametrize("proposal_length", [-1, 1.5, "4", True])
+def test_invalid_proposal_length_fails_before_model_execution(proposal_length):
+    target = ScriptedModel([], "target")
+    draft = ScriptedModel([], "draft")
+    draft_tokenizer, tokenizer = _tokenizers()
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        speculative_generate(
+            draft,
+            target,
+            draft_tokenizer,
+            tokenizer,
+            "prompt",
+            proposal_length=proposal_length,
+        )
+
+    assert target.caches == []
+    assert draft.caches == []


### PR DESCRIPTION
## Why

Week 3 speculative decoding was still unimplemented for learners, while the reference path crashed on the documented Qwen pair and mishandled EOS, tokenizer compatibility, detokenizer state, and proposal boundaries.

## What changed

- Implement the same int32-safe speculative loop in learner and reference code, including configurable and zero-length proposals, fail-closed tokenizer checks, authoritative EOS handling, and cache-offset preservation.
- Add the supplied Day 7 learner/reference regression matrix and clarify the corresponding chapter contracts.

## Review note

The exact parent fails the new matrix 20/20. This head passes learner and reference Day 7 20/20, Week 3 49 passed/1 skipped, the full reference suite 606 passed/8 skipped, and the documented Qwen 0.6B → 4B path returns the same complete `OK` output as target-only generation.

AI-Assisted: GPT-5.6 Sol + Forge
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
Reviewed-by: DeepSeek V4 Flash + Scholar (learner)
