### PR TITLE
Reconcile the course roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ implementation, test, and publication readiness is tracked below.
 
 The table distinguishes complete learner checkpoints (`Code`), focused tests
 (`Test`), and rendered chapters (`Doc`). Week 4's daily chapters are public for
-early review, but Days 1–3 remain incomplete learner checkpoints.
+early review and may still change.
 
 Persistent Week 4 runs can store sensitive transcripts under
 `.tiny-llm/sessions`, and model-directed file or command tools are not sandboxed.
@@ -88,23 +88,23 @@ Use a disposable workspace and read the
 | 1.5 | Load the Model | ✅ | ✅ | ✅ |
 | 1.6 | Generate Responses (aka Decoding) | ✅ | ✅ | ✅ |
 | 1.7 | Sampling | ✅ | ✅ | ✅ |
-| 2.1 | KV Cache | ✅ | ✅ | 🚧 |
-| 2.2 | Benchmark and Profile | 🚧 | 🚧 | 🚧 |
-| 2.3 | Quantized Matvec | ✅ | ✅ | 🚧 |
-| 2.4 | Fused Model Kernels | 🚧 | 🚧 | 🚧 |
-| 2.5 | Fused Decode Attention | 🚧 | 🚧 | 🚧 |
-| 2.6 | SIMD-Matrix Prefill | ✅ | ✅ | 🚧 |
-| 2.7 | Split-K Prefill | ✅ | ✅ | 🚧 |
-| 3.1 | Continuous Batching | ✅ | ✅ | 🚧 |
-| 3.2 | Chunked Prefill | ✅ | ✅ | 🚧 |
-| 3.3 | Paged KV Cache | ✅ | ✅ | 🚧 |
-| 3.4 | Direct Paged Attention | ✅ | ✅ | 🚧 |
-| 3.5 | Paged FlashAttention | ✅ | ✅ | 🚧 |
-| 3.6 (optional) | Speculative Decoding | 🚧 | 🚧 | 🚧 |
+| 2.1 | KV Cache | ✅ | ✅ | ✅ |
+| 2.2 | Benchmark and Profile | ✅ | ✅ | ✅ |
+| 2.3 | Quantized Matvec | ✅ | ✅ | ✅ |
+| 2.4 | Fused Model Kernels | ✅ | ✅ | ✅ |
+| 2.5 | Fused Decode Attention | ✅ | ✅ | ✅ |
+| 2.6 | SIMD-Matrix Prefill | ✅ | ✅ | ✅ |
+| 2.7 | Split-K Prefill | ✅ | ✅ | ✅ |
+| 3.1 | Continuous Batching | ✅ | ✅ | ✅ |
+| 3.2 | Chunked Prefill | ✅ | ✅ | ✅ |
+| 3.3 | Paged KV Cache | ✅ | ✅ | ✅ |
+| 3.4 | Direct Paged Attention | ✅ | ✅ | ✅ |
+| 3.5 | Paged FlashAttention | ✅ | ✅ | ✅ |
+| 3.6 (optional) | Speculative Decoding | ✅ | ✅ | ✅ |
 | 3.x (optional) | MoE (Mixture of Experts) | ✅ | ✅ | ✅ |
-| 4.1 | Agent Loop | 🚧 | 🚧 | ✅ |
-| 4.2 | Tools | 🚧 | 🚧 | ✅ |
-| 4.3 | Safety and Validation | 🚧 | 🚧 | ✅ |
+| 4.1 | Agent Loop | ✅ | ✅ | ✅ |
+| 4.2 | Tools | ✅ | ✅ | ✅ |
+| 4.3 | Safety and Validation | ✅ | ✅ | ✅ |
 | 4.4 | Interactive Sessions | ✅ | ✅ | ✅ |
 | 4.5 | Context Compaction | ✅ | ✅ | ✅ |
 | 4.6 | Control and Recovery | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Why

The roadmap still marks published chapters and reviewed learner checkpoints as WIP after their code, tests, and documentation landed.

## What changed

Reconcile the evidence-backed Week 2–4 status cells and remove the stale claim that Week 4 Days 1–3 remain incomplete.

AI-Assisted: GPT-5.6 Sol + Sentinel
Reviewed-by: GPT-5.6 Sol + Oracle (consistency)
