### PR TITLE
Align the sponsor page with Mini-LSM

### DIFF
--- a/book/custom.css
+++ b/book/custom.css
@@ -18,19 +18,21 @@
 
 .raft-card-avatar {
     flex-shrink: 0;
-    width: 40px;
-    height: 40px;
-    
+    width: 48px;
+    height: 48px;
     display: flex;
     align-items: center;
     justify-content: center;
+    border: 2px solid var(--avatar-border, #141111);
+    overflow: hidden;
     background: var(--avatar-bg, #e8ecf0);
-    color: var(--avatar-fg, #57606a);
 }
 
-.raft-card-avatar svg {
-    width: 28px;
-    height: 28px;
+.raft-card-avatar svg,.raft-card-avatar img {
+    width: 44px;
+    height: 44px;
+    image-rendering: pixelated;
+    display: block;
 }
 
 .raft-card-body {

--- a/book/src/sponsor.md
+++ b/book/src/sponsor.md
@@ -2,13 +2,13 @@
   tiny-llm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Sponsor
+# Sponsored by Raft.build
 
-Tiny-LLM is human-authored by **Chi Z** ([skyzh](https://github.com/skyzh)). The course is sponsored by **[Raft](https://raft.build)** — a real-time collaboration platform where humans and AI agents work together as teammates.
+The course is sponsored by **[Raft.build](https://raft.build)** — a real-time collaboration platform where humans and AI agents work together as teammates.
 
 ## How Raft Helped Build This Course
 
-Chi wrote every chapter, designed the exercises, and made every decision about what to teach. Raft gave him a team of persistent specialist agents who worked alongside him in channels, threads, and tasks — claiming work, running learner simulations, implementing scoped fixes, independently reviewing exact commits, preserving evidence, and applying a consistent standard across all chapters.
+Tiny-LLM is human-authored by **Chi Z** ([skyzh](https://github.com/skyzh)). He wrote every chapter, designed the exercises, and made every decision about what to teach. Raft gave him a team of persistent specialist agents who worked alongside him in channels, threads, and tasks — claiming work, running learner simulations, implementing scoped fixes, independently reviewing exact commits, preserving evidence, and applying a consistent standard across all chapters.
 
 The result is a course where every explanation, command, and test has been checked not just by the author, but by independent reviewers, simulated learners, and evidence-backed validation — all working together through Raft.
 

--- a/book/src/sponsor.md
+++ b/book/src/sponsor.md
@@ -8,7 +8,7 @@ The course is sponsored by **[Raft.build](https://raft.build)** — a real-time 
 
 ## How Raft Helped Build This Course
 
-Tiny-LLM is human-authored by **Chi Z** ([skyzh](https://github.com/skyzh)). He wrote every chapter, designed the exercises, and made every decision about what to teach. Raft gave him a team of persistent specialist agents who worked alongside him in channels, threads, and tasks — claiming work, running learner simulations, implementing scoped fixes, independently reviewing exact commits, preserving evidence, and applying a consistent standard across all chapters.
+The learning steps are designed by the course authors. Raft gave them a team of persistent specialist agents who worked alongside them in channels, threads, and tasks — claiming work, running learner simulations, implementing scoped fixes, independently reviewing exact commits, preserving evidence, and applying a consistent standard across all chapters.
 
 The result is a course where every explanation, command, and test has been checked not just by the author, but by independent reviewers, simulated learners, and evidence-backed validation — all working together through Raft.
 


### PR DESCRIPTION
## Why

The merged sponsor page uses 44px image avatars, but its CSS still targets only inline SVGs inside smaller borderless containers. That makes Tiny-LLM render differently from the current Mini-LSM sponsor page.

## What changed

- Match Mini-LSM’s avatar container and image rules, including the border, clipping, pixelated rendering, and existing narrow layout.
- Match Mini-LSM’s sponsor heading and introduction, describe the learning steps as designed by the course authors, and retain the course-specific contribution cards.

AI-Assisted: GPT-5.6 Sol + Forge
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: DeepSeek V4 Flash + Scholar (learner)
