### PR TITLE
docs: align Week 2 evidence contracts

### DIFF
--- a/book/src/appendix-performance.md
+++ b/book/src/appendix-performance.md
@@ -67,7 +67,7 @@ below contain the measurements.
 | RMSNorm | BF16 I/O with the sum of squares accumulated in FP32 | Fuse reduction, normalization, and weight multiply into one dispatch | Retained at Qwen hidden dimensions after both operator and decode gains; unknown dimensions require remeasurement | Readable RMSNorm and the Day 3 checkpoint remain selectable | Adding isolated microseconds as if checkpoint gains were independent |
 | RoPE | One valid offset per batch row; even rotated dimension; tail values preserved | Fuse angle generation and pair rotation without intermediate graphs | Retained for Qwen decode rows; head-count and rotated-dimension changes require remeasurement | Readable RoPE and the RMSNorm-only checkpoint remain selectable | Benchmarking a cached or precomputed angle path against fresh angle construction |
 | SwiGLU | Gate and up tensors have identical shape and dtype | Fuse SiLU and the gate/up product into one elementwise dispatch | Retained for Qwen MLP shapes; tiny tensors and other dtypes are not a performance claim | Readable SiLU-product and the RoPE checkpoint remain selectable | Accepting an operator win without a repeated complete-model gain |
-| Decode attention | `Hq % Hkv == 0`, `D <= 256`, FP32 online-softmax state, and causal/explicit mask semantics | Avoid score/probability tensors and merge softmax while walking K/V | Model dispatch is `L <= 8`, `S <= 128`, and no explicit mask; it loses past the measured context crossover and is under-filled at very short contexts | Readable grouped attention handles longer queries, longer contexts, and explicit masks | Fixed implementation order, GPU performance-state drift, or treating correctness at `S=1` as schedule efficiency |
+| Decode attention | `Hq % Hkv == 0`, `D <= 256`, FP32 online-softmax state, and causal/explicit mask semantics | Avoid score/probability tensors and merge softmax while walking K/V | Model dispatch is `L <= 2`, `S <= 256`, and no explicit array mask; the context sweep wins 6/6 passes through 256, while the query sweep is repeat-consistent only through `L=2` | Readable grouped attention handles longer queries, longer contexts, and explicit array masks | Fixed implementation order, GPU performance-state drift, extrapolating beyond 256, or treating correctness at `S=1` as schedule efficiency |
 | SIMD-matrix prefill | W4/group-128 layout, BF16 storage, FP32 tile accumulation, and correct partial tiles | Reuse activation and dequantized-weight tiles across prompt rows | Performance-lab path for `M > 8`; partial and new model shapes need both correctness and timing sweeps | Readable MLX matmul is the correctness oracle; Day 3 matvec remains the short-row dispatch and vanilla Metal is a bring-up control | Comparing all-logit course prefill with last-logit MLX serving |
 | Split-K prefill | Partitions align to quantization groups; partial planes are disjoint; final reduction is FP32 | Add independent groups only while the ordinary result grid is under-filled | Helps short narrow Qwen projections, is neutral around the 128-token acceptance shape, and loses once the base grid is occupied | `split_k <= 1` dispatches exactly to the Day 6 unsplit kernel | Profiling independent layers can hide under-occupancy that appears in the dependency-ordered model |
 
@@ -191,16 +191,17 @@ it establishes the synchronized benchmark and profile that choose Day 3.
 | Day 2 | Benchmark and profile | 730.43 | 24.63 | 24.01 | Measure dense projection weight traffic. |
 | Day 3 | Quantized matvec | 105.00 | 58.71 | 37.95 | Keep weights packed and add the x4 decode kernel. |
 | Day 4 | Fused model kernels | 105.97 | 75.21 | 44.33 | Remove the newly exposed pointwise graph launches. |
-| Day 5 | Bounded decode attention | 105.99 | 75.75 | 44.50 | Guard inactive at this shape; no expected change. |
+| Day 5 | Bounded decode attention | 105.99 | 75.75 | 44.50 | Historical row from before the guard extended through `S=256`; do not use it as the current checkpoint delta. |
 | Day 6 | SIMD-matrix prefill | 797.45 | 75.12 | 69.17 | Fix the quantized matrix path exposed by Day 3. |
 | Day 7 | Split-K prefill | 792.55 | 75.41 | 69.37 | Fill the GPU only for under-occupied short projections. |
 | Baseline | MLX 0.32.0 | 830.49 | 89.37 | 81.30 | External denominator. |
 
-Day 5's custom path is inactive throughout this fixed workload. Prefill has
-`L=128`; after cache append, the first timed decode step sees `S=129` and every
-later step is longer. The small observed Day 4-to-Day 5 difference is therefore
-run noise, not an accepted attention gain. A matched short-context checkpoint
-below evaluates the bounded kernel where it actually dispatches.
+The checked-in progression file predates the current `L <= 2`, `S <= 256`
+guard. With the current implementation, prefill has `L=128` and stays on the
+readable path, while timed one-token decode steps see `S=129` through `S=256`
+and enter the custom path. The historical Day 4-to-Day 5 difference is not a
+current end-to-end measurement; the balanced context and query sweeps below are
+the checked evidence for the production guard.
 
 ### The Kernel Profile That Selects Each Chapter
 
@@ -239,12 +240,13 @@ The profile makes the progression concrete:
 - After packed matvec, the pointwise group is 35.8% while attention is only
   4.5% at the 128-token acceptance context. Day 4 therefore removes the
   measured normalization, position, and activation overhead first.
-- After the Day 4 pointwise kernels, a context and operator sweep isolates a
-  removable attention gap through `S=128`. Day 5 tests online softmax there and
-  retains it only after a matched 32-token-prompt model run also improves.
-- Returning to the fixed workload leaves Day 5 inactive by design. Its
-  128-token prefill makes the vanilla quantized projection path 99.0% of
-  attributed time, which selects the cooperative matrix kernel in Day 6.
+- After the Day 4 pointwise kernels, the balanced operator sweeps isolate a
+  removable attention gap through `S=256` and a repeat-consistent query-length
+  win through `L=2`. Day 5 tests online softmax inside those bounds.
+- At the fixed workload, 128-token prefill remains outside the query-length
+  guard. Its profile makes the vanilla quantized projection path 99.0% of
+  attributed prefill time, which selects the cooperative matrix kernel in Day
+  6; one-token decode uses the bounded Day 5 path.
 - After Day 6, projections remain most of the inherent prefill work, but the
   long-shape operator comparison is already close to MLX. The 32-token shape
   sweep then isolates under-occupied Qwen projections and selects Split-K only
@@ -283,8 +285,8 @@ row and synchronized attribution answer different parts of the handoff:
 | KV growth | 0.33 ms, 0.8% | The dense cache already removed prefix recomputation. |
 
 The operator-family result is sufficient to select Day 3. The optional Day 2
-Xcode control provides an inspectable vanilla Metal projection at the same Qwen
-shape. That isolated packed-W4 control is not the Day 2 model's dense
+Xcode workflow can inspect a vanilla Metal projection at the same Qwen shape if
+you generate a trace. That isolated packed-W4 control is not the Day 2 model's dense
 projection; it exists so a later trace can compare schedules without pretending
 that one shader ranked the complete model.
 
@@ -312,11 +314,11 @@ uses them, but normalization, position, and activation now occupy 35.8% and are
 the larger removable gap. That combination, rather than the absolute height of
 the projection bar, selects Day 4.
 
-The [source-enabled matvec profile](#week-2-xcode-checkpoint-contract) is the
-optional kernel-internal attachment for this checkpoint. Use its Memory view
-and weighted source lines to identify additional matvec headroom, but do not let
-that shader-local result displace the larger pointwise model gap established by
-the matched operator table.
+A [source-enabled matvec capture](#week-2-xcode-checkpoint-contract) is an
+optional kernel-internal investigation for this checkpoint. If you generate
+one, use its Memory view and weighted source lines to identify additional
+matvec headroom, but do not let that shader-local result displace the larger
+pointwise model gap established by the matched operator table.
 
 ### Day 4: Fused Model Kernels
 
@@ -331,10 +333,11 @@ The cumulative model and operator results agree on all three retained changes:
 
 The pointwise group falls from 35.8% after Day 3 to 10.5%. Projections are now
 80.5% of attributed decode time but are already close to their MLX operator
-latencies. In the optional Xcode checkpoint, verify that the RMSNorm, RoPE, and
-SwiGLU pipelines all dispatched. The `S=32`, `S=128`, and `S=160` sweep then
-isolates a short-context attention opportunity and its fallback boundary. That
-evidence selects a bounded Day 5 experiment; the longer losing range does not.
+latencies. An optional learner-generated Xcode trace can verify that the
+RMSNorm, RoPE, and SwiGLU pipelines all dispatched. The balanced
+`S=32,128,160,192,256` sweep then isolates an attention opportunity through the
+largest measured context; the query-length sweep supplies the other dispatch
+boundary.
 
 ### Day 5: Fused Decode Attention
 
@@ -347,28 +350,44 @@ that workload, fused attention raises median decode from 59.90 to 61.78 tok/s
 denominator. The raw samples are checked in at
 `benchmark_results/m4-pro-qwen3-4b-week2-short-context-mlx-0.32.0.json`.
 
-The model-equivalent operator microbenchmark includes the FP32 promotion and
-output cast used by the readable fallback:
+The current context sweep includes the FP32 promotion and output cast used by
+the readable fallback. It uses six forward/reverse context passes, rotates
+every implementation order, and retains 60 samples per implementation and
+pass:
 
-| Cached context | Readable | Fused | MLX | Fused vs readable |
-|---:|---:|---:|---:|---:|
-| 32 | 129.2 us | 111.3 us | 96.5 us | 1.16x faster |
-| 128 | 182.6 us | 166.8 us | 147.4 us | 1.09x faster |
-| 160 | 229.6 us | 237.9 us | 163.5 us | 3.6% slower |
-| 192 | 229.2 us | 240.9 us | 160.1 us | 5.1% slower |
-| 256 | 241.4 us | 265.1 us | 154.8 us | 9.8% slower |
+| Cached context | Readable | Fused | MLX | Fused vs readable | Pass wins |
+|---:|---:|---:|---:|---:|---:|
+| 32 | 143.0 us | 125.7 us | 116.3 us | 1.138x | 6/6 |
+| 128 | 149.3 us | 136.3 us | 120.6 us | 1.095x | 6/6 |
+| 160 | 151.2 us | 140.1 us | 120.9 us | 1.079x | 6/6 |
+| 192 | 154.0 us | 143.9 us | 121.9 us | 1.071x | 6/6 |
+| 256 | 158.0 us | 150.7 us | 122.8 us | 1.048x | 6/6 |
 
-The measured crossover narrows the reference dispatch guard to contexts of at
-most 128 tokens. Larger contexts retain the readable path. The operator sweep
-and matched short-context model gain establish where the schedule is valid; an
-optional Xcode `S=128` replay verifies the intended dispatch and its hot loop.
+The query-length sweep holds `S=128`, Qwen3-4B's 4:1 GQA ratio, and the causal
+form while balancing L1/L2/L4/L8 order over six passes:
 
-The fixed 128-token acceptance workload remains a neutral control because it
-never enters the guard. Returning to that workload and profiling its prefill
-attributes 1,196.34 ms of 1,208.78 ms, or 99.0%, to quantized projections;
+| Query length | Readable | Fused | MLX | Fused vs readable | Pass wins |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 244.4 us | 213.1 us | 155.9 us | 1.147x | 6/6 |
+| 2 | 341.4 us | 258.8 us | 185.3 us | 1.319x | 6/6 |
+| 4 | 322.7 us | 297.3 us | 197.4 us | 1.085x | 4/6 |
+| 8 | 377.7 us | 491.5 us | 290.6 us | 0.768x | 0/6 |
+
+At `L=1`, the causal mask permits the entire existing cache and is equivalent
+to unmasked one-token decode; longer rows measure causal multi-token chunks.
+The context sweep supports `S <= 256`, while `L=2` is the largest
+repeat-consistent query-length win. Those results define the current
+`L <= 2`, `S <= 256` guard. The checked raw records are
+`benchmark_results/m4-pro-qwen3-4b-week2-attention-context-sweep-mlx-0.32.0.json`
+and
+`benchmark_results/m4-pro-qwen3-4b-week2-attention-query-sweep-mlx-0.32.0.json`.
+An optional Xcode replay can inspect a dispatch if you generate a trace, but it
+is not checked-in acceptance evidence.
+
+In the fixed 128-token workload, prefill remains outside the query-length guard
+and attributes 1,196.34 ms of 1,208.78 ms, or 99.0%, to quantized projections;
 attention accounts for 6.08 ms and the pointwise group for 6.35 ms. That
-unchanged prefill bottleneck selects the matrix-shaped projection kernel in
-Day 6.
+prefill bottleneck selects the matrix-shaped projection kernel in Day 6.
 
 ### Day 6: Use Cooperative Loads for Quantized Prefill
 
@@ -548,19 +567,21 @@ by this result.
 ## Week 2 Xcode Checkpoint Contract
 
 The synchronized operator attribution selects a family; a source-enabled Xcode
-replay explains what happens inside one representative shader from that family.
-Preserve the same six whole-window screenshots from a large, non-full-screen
-Xcode window for every Day 2–7 checkpoint: performance overview, left and right
-performance limiters, left and right memory counters, and the Cost Graph with
-20–30 weighted source lines around the hot loop. The
+replay can explain what happens inside one representative shader from that
+family. The repository does not include reference `.gputrace` files or Xcode
+screenshots, so the balanced JSON tables above remain the checked-in evidence.
+If you generate a trace for your implementation, preserve the same six
+whole-window views from a large, non-full-screen Xcode window: performance
+overview, left and right performance limiters, left and right memory counters,
+and the Cost Graph with 20–30 weighted source lines around the hot loop. The
 [advanced profiling appendix](./week2-advanced-profiling.md) gives the capture
 and replay procedure.
 
-For the reference M4 Pro measurements, record macOS, Xcode, Metal compiler,
-MLX, performance state, source revision, trace name, implementation, and tensor
-shape beside each set. Xcode replay time is diagnostic; the Overview must show
-the actual execution mode, while the balanced fresh-process tables above remain
-the acceptance evidence.
+For any learner-generated capture, record macOS, Xcode, Metal compiler, MLX,
+performance state, source revision, trace name, implementation, and tensor
+shape beside the set. Xcode replay time is diagnostic; the Overview should show
+the actual execution mode, while a balanced fresh-process benchmark remains the
+acceptance evidence.
 
 ## Optimization Map
 

--- a/book/src/week2-01-kv-cache.md
+++ b/book/src/week2-01-kv-cache.md
@@ -269,8 +269,8 @@ one cumulative checkpoint.
 Day 1 is an algorithmic checkpoint, so it does not invent a shader-level
 limiter from a GPU trace. The end-to-end result proves that prefix
 recomputation disappeared. Day 2 keeps this model unchanged, measures its
-operator families, and defines the consistent Xcode checkpoint series around
-an isolated vanilla Metal quantized-projection control in the
-[reference capture contract](./appendix-performance.md#week-2-xcode-checkpoint-contract).
+operator families, and introduces an optional Xcode procedure for inspecting
+an isolated vanilla Metal quantized-projection control if you generate a trace.
+See the [capture contract](./appendix-performance.md#week-2-xcode-checkpoint-contract).
 
 {{#include copyright.md}}

--- a/book/src/week2-02-benchmarking.md
+++ b/book/src/week2-02-benchmarking.md
@@ -251,9 +251,9 @@ Attach two results to the checkpoint report: the fresh-process JSON with your
 solution and MLX, and the kernel-group JSON with absolute times as well as
 shares. The first says how far decode is from MLX; the second says which
 operator family owns the current implementation's time. The optional advanced
-lab replays an inspectable vanilla Metal quantized projection and captures the
-same Xcode views used by every later checkpoint. That isolated trace does not replace the
-dependency-aware attribution that ranks the complete operator families.
+lab can replay an inspectable vanilla Metal quantized projection if you generate
+a trace. That shader-local replay does not replace the dependency-aware
+attribution that ranks the complete operator families.
 
 Continue to Day 3 when projection work is the largest removable cost and its
 dense weight traffic scales with the roofline calculation. If another family
@@ -261,10 +261,10 @@ dominates your profile, inspect that family before copying the reference
 solution's next step. The
 [reference checkpoint](./appendix-performance.md#day-2-measure-before-optimizing)
 pairs its end-to-end result with the synchronized attribution while keeping
-machine-specific values in the appendix. Its Xcode control makes the schedule
-concrete: the vanilla packed-weight Metal projection spends each output thread
-walking the full reduction independently. The Day 2 model itself still uses
-dense weights; the complete-model attribution, not this isolated control,
-selects the Day 3 storage and scheduling change before the smaller families.
+machine-specific values in the appendix. The optional vanilla Metal control
+makes the schedule inspectable: each output thread walks the full reduction
+independently. The Day 2 model itself still uses dense weights; the
+complete-model attribution, not this isolated control, selects the Day 3
+storage and scheduling change before the smaller families.
 
 {{#include copyright.md}}

--- a/book/src/week2-03-quantized-matvec.md
+++ b/book/src/week2-03-quantized-matvec.md
@@ -105,55 +105,35 @@ Logical weight matrix W: K × N
 Group size: G = 128
 Number of groups per row = N / G
 
-For each group of G consecutive values in a row:
-  1. Find min and max values
-  2. Compute scale and bias to map [min, max] → [0, 15] (4-bit range)
-  3. Quantize each value to an integer code from 0 through 15
+For each stored group of G consecutive values in a row:
+  1. Unpack each unsigned 4-bit code q in [0, 15]
+  2. Load the group's stored scale s and bias b
+  3. Reconstruct each value as q * s + b
 ```
 
-### Map a Group Into 16 Codes
+### Reconstruct a Stored Group
 
-Affine quantization maps the minimum and maximum weight in each group onto the
-lowest and highest 4-bit codes. For a weight $w$, compute its code $q$ and its
-reconstructed value $\hat{w}$ as:
-
-$$
-q = \operatorname{clamp}\left(\operatorname{round}\left(\frac{w - b}{s}\right), 0, 15\right)
-$$
+The checkpoint already contains the packed codes and their affine parameters.
+For an unpacked unsigned code $q$, use the stored scale $s$ and bias $b$
+directly:
 
 $$
 \hat{w} = q s + b
 $$
 
-Here $s$ is the scale and $b$ is the bias. Given a group with minimum value
-$v_{\min}$ and maximum value $v_{\max}$:
+The codes are unsigned, but the stored scale is signed. A positive scale maps
+code 0 to the lower endpoint and code 15 toward the upper endpoint. A negative
+scale reverses that orientation: code 0 is the upper endpoint and code 15 moves
+toward the lower endpoint. Both orientations occur in the shipped Qwen3-4B MLX
+checkpoint, so do not recompute `scale` and `bias` from an assumed min/max
+orientation.
 
-$$
-s = \frac{v_{\max} - v_{\min}}{2^4 - 1}
-  = \frac{v_{\max} - v_{\min}}{15}
-$$
-
-$$
-b = v_{\min}
-$$
-
-For example, consider a shortened group with five values:
+For example, these two stored parameter pairs reconstruct the same endpoint
+range in opposite code order:
 
 ```plain
-Group values: [-0.5, -0.3, 0.1, 0.4, 0.8]
-min = -0.5, max = 0.8
-
-scale = (0.8 - (-0.5)) / 15 = 1.3 / 15 ≈ 0.0867
-bias = -0.5
-
-Quantization:
-  -0.5 → round((-0.5 - (-0.5)) / 0.0867) = 0
-  -0.3 → round((-0.3 - (-0.5)) / 0.0867) = 2
-   0.1 → round((0.1 - (-0.5)) / 0.0867) = 7
-   0.4 → round((0.4 - (-0.5)) / 0.0867) = 10
-   0.8 → round((0.8 - (-0.5)) / 0.0867) = 15
-
-Quantized: [0, 2, 7, 10, 15] (4 bits each)
+positive orientation: scale =  0.0867, bias = -0.5  => q=0 is -0.5, q=15 is about 0.8
+negative orientation: scale = -0.0867, bias =  0.8  => q=0 is  0.8, q=15 is about -0.5
 ```
 
 All required quantized-matmul tests use `group_size = 128` and BF16 scales,
@@ -347,8 +327,8 @@ matrix and its dequantization parameters:
 | Field | Shape | Description |
 |-------|-------|-------------|
 | `weight` | $(K, N/8)$ uint32 | Packed quantized weights. Each uint32 stores eight consecutive 4-bit values. |
-| `scales` | $(K, N/G)$ bfloat16 | Per-group scale factors for dequantization. Each group of $G$ consecutive values shares one scale. Recall: $\text{scale} = (v_{max} - v_{min}) / 15$ |
-| `biases` | $(K, N/G)$ bfloat16 | Per-group bias (offset) for dequantization. Recall: $\text{bias} = v_{min}$ |
+| `scales` | $(K, N/G)$ bfloat16 | Stored signed per-group scale factors for dequantization. The sign determines which endpoint maps to the low codes. |
+| `biases` | $(K, N/G)$ bfloat16 | Stored per-group offsets. Code 0 reconstructs to this value. |
 | `group_size` | int | Number of consecutive values that share the same scale/bias. For the Qwen3 MLX 4-bit weights used here, this is `128`. |
 | `bits` | int | Quantization bit width (typically 4, meaning values are in range $[0, 15]$) |
 
@@ -660,16 +640,16 @@ them in every layer; once their operator latency is close to MLX, that bar is
 no longer the largest removable gap.
 
 The [Xcode checkpoint contract](./appendix-performance.md#week-2-xcode-checkpoint-contract)
-records the pipeline, limiters, memory traffic, and highest-cost source lines
-with the consistent screenshot set from the advanced appendix.
+describes how to inspect the pipeline, limiters, memory traffic, and
+highest-cost source lines if you generate the optional trace.
 Continue to Day 4 when the matched projection table is close to MLX and the
 post-Day-3 profile makes normalization, position, and activation the largest
 removable gap. If the projection comparison is still far behind, keep tuning
 the matvec instead. The
 [reference checkpoint](./appendix-performance.md#day-3-keep-weights-packed)
-pairs the model delta, projection microbenchmarks, attribution, and the
-source-enabled matvec trace. Its matched operator result is the reason the hot
-masked products do not become Day 4: after the projection gap shrinks, the
-pointwise cluster is the larger removable model cost.
+pairs the model delta, projection microbenchmarks, and attribution. Its matched
+operator result is the reason the hot matvec products do not remain the next
+target: after the projection gap shrinks, the pointwise cluster is the larger
+removable model cost.
 
 {{#include copyright.md}}

--- a/book/src/week2-04-fused-model-kernels.md
+++ b/book/src/week2-04-fused-model-kernels.md
@@ -70,8 +70,7 @@ squared tensor. Instantiate the required kernel for bfloat16. Keep
 the reduction, normalization, and weight multiplication in float, then cast the
 final result once. The readable Week 1 equation rounds once before applying the
 weight, so compare the two with a tolerance rather than expecting bit-identical
-results. The single final cast also tracks the MLX model more closely in the
-Qwen3-4B end-to-end correctness test.
+results.
 
 The C++ primitive validates shape and dtype, allocates the output through MLX,
 binds the buffers and scalar constants, allocates eight float partial sums, and
@@ -206,11 +205,12 @@ stay.
 
 After the pointwise cluster shrinks, sweep cached context rather than assuming
 attention is next. Continue to Day 5 when attention is a removable gap at
-`S <= 128` and the projection operators are already close to their
-denominator. Measurements at `S >= 160` define the fallback range; they do not
-justify a kernel that dispatches only through 128. Day 5 must still prove that
-its replacement moves a complete-model workload that actually enters that
-guard. The
+the measured contexts and the projection operators are already close to their
+denominator. The checked M4 Pro sweep covers `S=32,128,160,192,256` and the
+custom operator wins all six balanced passes at every point, which supports a
+context guard through `S <= 256` but says nothing about longer caches. Day 5
+must also test query length and prove that its replacement moves a
+complete-model workload that actually enters the final guard. The
 [reference checkpoint](./appendix-performance.md#day-4-fused-model-kernels)
 pairs the cumulative gains with all three operator microbenchmarks and the
 updated attribution. Use the optional trace to verify that the intended three

--- a/book/src/week2-05-decode-attention.md
+++ b/book/src/week2-05-decode-attention.md
@@ -195,8 +195,9 @@ validated range.
 
 Measure the attention operator and the cumulative checkpoint separately. The
 first progression is the matched short-context acceptance test for this
-bounded kernel. The second keeps the fixed Week 2 denominator as a neutral
-control and exposes its unchanged 128-token prefill profile:
+bounded kernel. The second keeps the fixed Week 2 denominator: its 128-token
+prefill remains outside the query-length guard, while timed one-token decode
+steps with `S=129` through `S=256` enter the current context guard:
 
 ```bash
 pdm run bench-week2-operators --solution tiny_llm --model qwen3-4b \
@@ -260,8 +261,11 @@ and medians, is
 `benchmark_results/m4-pro-qwen3-4b-week2-attention-context-sweep-mlx-0.32.0.json`.
 
 The production-boundary sweep held context at 128, selected Qwen3-4B's 4:1 GQA
-ratio and causal mask, and balanced L1/L2/L4/L8 order over six passes. Each pass
-also rotated the three implementation orders and retained every sample:
+ratio, and balanced L1/L2/L4/L8 order over six passes. It used the causal form
+for every query length: at `L=1` that mask permits the entire existing cache and
+is equivalent to unmasked one-token decode, while `L>1` measures causal
+multi-token chunks. Each pass also rotated the three implementation orders and
+retained every sample:
 
 | Query length | Readable | Metal | MLX | Metal speedup | Pass wins |
 |---:|---:|---:|---:|---:|---:|
@@ -286,15 +290,15 @@ pdm run bench-week2-operators --solution tiny_llm_ref --model qwen3-4b \
 The checked raw record is
 `benchmark_results/m4-pro-qwen3-4b-week2-attention-query-sweep-mlx-0.32.0.json`.
 
-The fixed `128/129` control does not execute the custom attention kernel:
-prefill has `L=128`, and the first decode call appends the new token before the
-guard sees `S=129`. Treat any Day 4-to-Day 5 difference in that table as noise,
-not an attention gain. Return to its 128-token prefill attribution and continue
-to Day 6 only when quantized matrix-shaped projections dominate it.
+In the fixed `128/129` workload, prefill has `L=128` and uses the readable path.
+The first timed decode call appends the new token before the guard sees `S=129`;
+the one-token decode calls through `S=256` therefore use the custom path. Keep
+the prefill attribution separate from any decode change, and continue to Day 6
+only when quantized matrix-shaped projections dominate prefill.
 The [reference checkpoint](./appendix-performance.md#day-5-fused-decode-attention)
 pairs the context microbenchmarks with the matched short-context model delta,
 fixed-workload control, and prefill attribution. The optional Xcode replay
-verifies the attention dispatch inside its measured guard; the fixed workload's
+can inspect the attention dispatch if you generate a trace; the fixed workload's
 unchanged prefill exposes the next matrix-shaped projection bottleneck.
 
 {{#include copyright.md}}

--- a/book/src/week2-advanced-profiling.md
+++ b/book/src/week2-advanced-profiling.md
@@ -137,9 +137,11 @@ throughput result. Record the execution mode shown in **Overview** instead of
 assuming serialization. Keep the trace window open until every evidence view
 is captured; reopening and reprofiling a large trace can take minutes.
 
-## Preserve the Same Screenshot Set
+## Keep Learner-Generated Screenshots Consistent
 
-Save the same six images for every Day 2–7 reference checkpoint:
+The repository does not include reference `.gputrace` files or Xcode
+screenshots. If you capture them for your own implementation, use the same six
+views for each checkpoint you investigate:
 
 ```text
 week2-dayN-xcode-overview.png
@@ -150,11 +152,11 @@ week2-dayN-xcode-memory-right.png
 week2-dayN-xcode-cost-source.png
 ```
 
-The overview must keep every relevant pipeline visible. Day 4 therefore shows
-RMSNorm, RoPE, and SwiGLU together; Day 7 shows both the Split-K accumulation
-and reduction when the reduction has material cost. The Cost Graph image is
-the critical source attachment: a function name without the hottest loop and
-its weighted source-line percentages is incomplete.
+Keep every relevant pipeline visible in the overview. A Day 4 capture should
+show RMSNorm, RoPE, and SwiGLU together; a Day 7 capture should show both the
+Split-K accumulation and reduction when the reduction has material cost. A
+useful Cost Graph image includes the hottest loop and its weighted source-line
+percentages, not only the function name.
 
 Place the trace name, source commit, implementation, tensor shape, hardware,
 macOS, Xcode, Metal compiler, MLX version, and performance state in the figure
@@ -165,13 +167,15 @@ Counter and source-cost percentages are comparable within one replay. They are
 not percentages of end-to-end model time, and the measured values are not
 targets for another machine. The
 [M4 Pro evidence ledger](./appendix-performance.md#week-2-xcode-checkpoint-contract)
-defines where each screenshot set belongs beside the operator and model
-measurements that give it meaning.
+explains how a learner-generated screenshot set relates to the operator and
+model measurements that give it meaning.
 
-Missing source lines mean the extension was not rebuilt with
-`MLX_METAL_DEBUG`. Missing counter samples mean the profiler is unsupported on
-that OS, Xcode, or GPU combination. Neither result justifies an ALU- or
-bandwidth-bound claim.
+Missing source lines can mean that the extension was not rebuilt with
+`MLX_METAL_DEBUG`, that the captured pipeline is not the intended one, or that
+source mapping failed. Missing counter samples can reflect an unsupported
+OS/Xcode/GPU combination, capture settings, or a failed replay. Check those
+causes before drawing a limiter conclusion; neither symptom by itself justifies
+an ALU- or bandwidth-bound claim.
 
 ## Longer Traces with Instruments
 


### PR DESCRIPTION
## Why

The Week 2 prose had drifted from the shipped quantized checkpoint, the current decode-attention dispatch, and the checked benchmark evidence. It also described Xcode trace artifacts that are not checked into the repository.

## What changed

- teach exact packed-code reconstruction from the checkpoint's stored signed scale and bias
- align decode-attention dispatch and evidence with the shipped `L <= 2`, `S <= 256` boundary and balanced six-pass JSON sweeps, including the causal and profiler-diagnostic limits
- make Xcode capture artifacts explicitly optional and learner-generated, and remove the unsupported single-cast comparison

AI-Assisted: GPT-5.6 Sol + Tuner
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
