### PR TITLE
Add course links to sponsor page

### DIFF
--- a/book/src/sponsor.md
+++ b/book/src/sponsor.md
@@ -89,3 +89,8 @@ The result is a course where every explanation, command, and test has been check
 </div>
 
 </div>
+
+## Start the Course
+
+- [View the Tiny-LLM GitHub repository](https://github.com/skyzh/tiny-llm)
+- [Start the course from the beginning](./preface.md)


### PR DESCRIPTION
## Why

The sponsor page should provide useful links to the project and course.

## What changed

Add two links at the end of the sponsor page: the canonical Tiny-LLM GitHub repository and the course preface.

AI-Assisted: GPT-5.6 Sol + Forge
