### PR TITLE
Synchronize starter extension interfaces

### DIFF
--- a/book/src/week1-07-sampling-prepare.md
+++ b/book/src/week1-07-sampling-prepare.md
@@ -121,6 +121,9 @@ pdm run build-ext-test
 ```
 
 It should print `correct: True`.
+The other exported extension names are fail-closed starter stubs labeled with
+the Week 2 or Week 3 checkpoint that implements them; this setup check calls
+only `axpby`.
 
 If you are new to C++ or Metal, try a few small exercises before continuing. For example, implement element-wise operations
 such as `exp`, `sin`, and `cos`, then use them in place of the corresponding MLX operations in your model

--- a/book/src/week2-02-benchmark-quantize.md
+++ b/book/src/week2-02-benchmark-quantize.md
@@ -552,6 +552,13 @@ src/tiny_llm/quantize.py
 src/tiny_llm/embedding.py
 ```
 
+Modify these exact starter functions:
+
+- `QuantizedWeights.from_mlx_layer`, `dequantize_weights`, and
+  `quantized_linear` in `src/tiny_llm/quantize.py`;
+- `QuantizedEmbedding.__call__` and `QuantizedEmbedding.as_linear` in
+  `src/tiny_llm/embedding.py`.
+
 The starter code provides `QuantizedWeights`, a container for a quantized
 matrix and its dequantization parameters:
 
@@ -594,22 +601,21 @@ src/extensions/src/quantized_matmul.cpp
 src/extensions/CMakeLists.txt
 ```
 
-Register quantized matrix multiplication as an MLX C++ extension. Follow the
-existing `axpby` example for array validation, lazy primitive construction,
-bindings, and Metal dispatch. Your solution is GPU-only; its `eval_cpu` method
-should raise a clear unsupported-device error.
+The starter already contains the declaration, fail-closed source stub, binding,
+and build registration. Keep the C++ declarations and definitions in the
+`tiny_llm_ext` namespace and modify these exact functions:
 
-You will update four files. Keep the C++ declarations and definitions in the
-`tiny_llm_ext` namespace:
-
-- **`tiny_llm_ext.h`** — Declare the `quantized_matmul(...)` function signature
-  and define a `QuantizedMatmul` primitive class (inheriting `mx::Primitive`).
-  Store `group_size` and `bits` as private members.
-- **`bindings.cpp`** — Add an `m.def(...)` call to expose the function to Python.
-- **`quantized_matmul.cpp`** — Implement `quantized_matmul(...)` to validate
+- **`tiny_llm_ext.h`** — Read the Week 2 Day 2 `quantized_matmul(...)`
+  declaration and `QuantizedMatmul` primitive interface; keep its signature in
+  sync with the binding.
+- **`bindings.cpp`** — Verify the existing `m.def("quantized_matmul", ...)`
+  entry; do not create a second binding.
+- **`quantized_matmul.cpp`** — Replace the body of
+  `tiny_llm_ext::quantized_matmul(...)` to validate
   inputs, determine the output shape, return a lazy `mx::array`, and reject CPU
-  evaluation explicitly.
-- **`CMakeLists.txt`** — Add the new C++ source to the extension target.
+  evaluation explicitly in `QuantizedMatmul::eval_cpu(...)`.
+- **`CMakeLists.txt`** — Verify the existing `quantized_matmul.cpp` source
+  registration; do not add a duplicate.
 
 The extension API is infrastructure: it lets an `mx.array` graph node schedule
 the Metal loop you write in the next task. MLX owns the array lifetime and
@@ -659,6 +665,14 @@ knob helped.
 src/extensions/src/quantized_matmul.metal
 src/extensions/src/quantized_matmul.cpp
 ```
+
+Modify these exact starter functions:
+
+- `QuantizedMatmul::eval_gpu` in `quantized_matmul.cpp`;
+- `quantized_matmul_vanilla_w4a16_g128` and
+  `quantized_matvec_x4_fast_w4a16_g128` in `quantized_matmul.metal`;
+- `quantized_matmul_vanilla` and `quantized_matvec_custom` in
+  `src/tiny_llm/quantize.py` for the explicit comparison paths.
 
 Write the Metal kernels and connect `eval_gpu` to them. The Python
 `quantized_matmul` wrapper always dispatches the primitive you implement on
@@ -817,6 +831,11 @@ it is not the implementation under test.
 ```
 src/tiny_llm/qwen3_week2.py
 ```
+
+Modify `Qwen3ModelWeek2.__init__`, `Qwen3MultiHeadAttention.__call__`,
+`Qwen3MLP.__call__`, and `Qwen3ModelWeek2.__call__` in this task. These are the
+exact points that load quantized weights, replace dense projections, and keep
+only the requested logits row.
 
 Integrate quantized matrix multiplication into the Week 2 Qwen3 model so that
 the linear layers remain quantized throughout inference.

--- a/book/src/week2-03-fused-model-kernels.md
+++ b/book/src/week2-03-fused-model-kernels.md
@@ -51,6 +51,13 @@ purpose-built kernel versus a graph of several general-purpose kernels.
 
 ## Task 1: RMSNorm
 
+Modify `tiny_llm_ext::rms_norm`, `Week2RMSNorm::eval_cpu`, and
+`Week2RMSNorm::eval_gpu` in `src/extensions/src/week2_kernels.cpp`, the
+`week2_rms_norm` function in `src/extensions/src/week2_kernels.metal`, and
+`FastRMSNorm.__call__` in `src/tiny_llm/week2_kernels.py`. The starter header,
+binding, C++/Metal files, and CMake registration already exist for this
+checkpoint; replace the fail-closed bodies instead of adding parallel APIs.
+
 Begin with one SIMD group per input row, then profile it. A 2,560-element hidden
 row gives 32 lanes roughly 80 serial elements each; the optimized kernel launches 256
 threads, or eight SIMD groups, per row. Each group reduces its portion with
@@ -89,6 +96,11 @@ pdm run bench --solution tiny_llm --loader week2 \
 
 ## Task 2: RoPE
 
+Modify `tiny_llm_ext::rope`, `Week2RoPE::eval_cpu`, and
+`Week2RoPE::eval_gpu` in `src/extensions/src/week2_kernels.cpp`, the
+`week2_rope` function in `src/extensions/src/week2_kernels.metal`, and
+`FastRoPE.__call__` in `src/tiny_llm/week2_kernels.py`.
+
 Implement RoPE for the model's native `B, L, H, D` layout. A naive element
 kernel calculates the same angle, sine, and cosine separately for both members
 of every pair and again for every head. Instead, assign one thread a pair index
@@ -125,6 +137,11 @@ pdm run bench --solution tiny_llm --loader week2 \
 
 ## Task 3: SwiGLU
 
+Modify `tiny_llm_ext::swiglu`, `Week2SwiGLU::eval_cpu`, and
+`Week2SwiGLU::eval_gpu` in `src/extensions/src/week2_kernels.cpp`, the
+`week2_swiglu` function in `src/extensions/src/week2_kernels.metal`, and
+`swiglu` in `src/tiny_llm/week2_kernels.py`.
+
 SwiGLU combines the gate and up branches:
 
 ```plain
@@ -146,6 +163,11 @@ pdm run bench --solution tiny_llm --loader week2 \
 ```
 
 ## Task 4: Verify the Cumulative Model
+
+Verify the cumulative switches in `Qwen3ModelWeek2.__init__` and the call sites
+in `Qwen3MultiHeadAttention.__call__` and `Qwen3MLP.__call__`. Task 4 should not
+introduce another extension function; it composes the three functions from
+Tasks 1-3.
 
 After exposing all three kernels through C++ MLX primitives, run the complete
 test file to verify their composition. Keep `qwen3_week1.py` on its Week 1

--- a/book/src/week2-04-decode-attention.md
+++ b/book/src/week2-04-decode-attention.md
@@ -64,7 +64,7 @@ Modify `tiny_llm_ext::decode_attention`,
 in `src/extensions/src/week2_kernels.metal`, and `decode_attention_custom` in
 `src/tiny_llm/week2_kernels.py`. The starter declaration, binding, source
 stub, Metal file, and CMake registration are already present and labeled Week
-2 Day 5; replace those fail-closed bodies rather than adding new names.
+2 Day 4; replace those fail-closed bodies rather than adding new names.
 
 Expose `decode_attention_custom` for the Metal implementation. Cache the
 scaled query fragment in registers before walking the cache; loading it again

--- a/book/src/week2-04-decode-attention.md
+++ b/book/src/week2-04-decode-attention.md
@@ -25,6 +25,10 @@ dispatch.
 
 ## Task 1: Preserve the Interface
 
+Modify `scaled_dot_product_attention` in
+`src/tiny_llm/week2_kernels.py`. Keep this readable function as the oracle and
+fallback; Task 2 modifies the separate `decode_attention_custom` entry point.
+
 Implement `scaled_dot_product_attention` in `week2_kernels.py` with these
 model-facing shapes:
 
@@ -53,6 +57,14 @@ correctness oracle and ablation, not as the completed optimized path: its
 matmuls are MLX-provided operator implementations.
 
 ## Task 2: Implement Online Softmax in Metal
+
+Modify `tiny_llm_ext::decode_attention`,
+`Week2DecodeAttention::eval_cpu`, and `Week2DecodeAttention::eval_gpu` in
+`src/extensions/src/week2_kernels.cpp`, the `week2_decode_attention` function
+in `src/extensions/src/week2_kernels.metal`, and `decode_attention_custom` in
+`src/tiny_llm/week2_kernels.py`. The starter declaration, binding, source
+stub, Metal file, and CMake registration are already present and labeled Week
+2 Day 5; replace those fail-closed bodies rather than adding new names.
 
 Expose `decode_attention_custom` for the Metal implementation. Cache the
 scaled query fragment in registers before walking the cache; loading it again
@@ -110,6 +122,11 @@ complete-model result for each schedule, then repeat the experiment when
 context length changes.
 
 ## Task 3: Integrate and Measure
+
+Modify `Qwen3MultiHeadAttention.__call__` in
+`src/tiny_llm/qwen3_week2.py` to apply the measured dispatch guard. Keep
+`scaled_dot_product_attention` as the explicit fallback and call
+`decode_attention_custom` only inside the supported region.
 
 Route short-query, short-context Week 2 attention through the Metal
 implementation. Dispatch back to the Python `mlx.core` composition when the cached

--- a/book/src/week2-05-simd-matrix-prefill.md
+++ b/book/src/week2-05-simd-matrix-prefill.md
@@ -68,6 +68,12 @@ it does not call MLX's quantized-matmul operator.
 
 ## Task 1: Preserve the Workload Dispatch
 
+Modify `QuantizedMatmul::eval_gpu` in
+`src/extensions/src/quantized_matmul.cpp` and
+`quantized_matmul_simdgroup_w4a16_g128` in
+`src/extensions/src/quantized_matmul.metal`. Keep the Day 2
+`quantized_matvec_x4_fast_w4a16_g128` function intact for `M <= 8`.
+
 Keep the Day 2 decode schedule and add the matrix schedule behind the same
 quantized-linear interface:
 
@@ -82,12 +88,21 @@ column tiles. The result must retain the model-facing 16-bit dtype.
 
 ## Task 2: Make Device Loads Contiguous
 
+Continue modifying `quantized_matmul_simdgroup_w4a16_g128` (and its private
+Metal helper, if you factor one) in
+`src/extensions/src/quantized_matmul.metal`; do not change the public
+`quantized_matmul` binding.
+
 Use a cooperative block loader so adjacent threads and each thread's local
 reads form contiguous transactions. This is a requirement of the schedule,
 not a cosmetic detail. Benchmark Q, K/V, gate/up, and down projections separately
 at their Qwen3-4B dimensions so both wide and narrow output grids are covered.
 
 ## Task 3: Hoist Quantization Parameters
+
+Continue modifying `quantized_matmul_simdgroup_w4a16_g128` in
+`src/extensions/src/quantized_matmul.metal`. This task changes the tiled
+kernel's load/reuse strategy, not its C++ or Python signature.
 
 One scale and bias apply to 128 reduction values. Loading them for every
 32-value tile repeats the same device access four times. Have one thread load
@@ -100,12 +115,20 @@ accumulator remains FP32. Cast once when writing the final model output.
 
 ## Task 4: Project Only Required Logits
 
+Modify `Qwen3ModelWeek2.__call__` in `src/tiny_llm/qwen3_week2.py` so
+`logits_to_keep=1` slices before the vocabulary projection. Do not add a new
+extension function for this model-level optimization.
+
 Generation needs only the final prompt row to produce the first sampled token.
 Accept `logits_to_keep=1` and apply the vocabulary projection only to that row.
 The benchmark applies the same last-logit workload to MLX, while prompt-scoring
 callers can still request every logit row.
 
 ## Task 5: Verify, Benchmark, and Name the Next Bottleneck
+
+Task 5 adds no function. Verify the cumulative
+`QuantizedMatmul::eval_gpu`/`quantized_matmul_simdgroup_w4a16_g128` path and
+the `Qwen3ModelWeek2.__call__` projection boundary from Tasks 1-4.
 
 ```bash
 pdm run build-ext

--- a/book/src/week2-06-split-k-prefill.md
+++ b/book/src/week2-06-split-k-prefill.md
@@ -39,7 +39,7 @@ original two-dimensional grid is under-filled.
 ## Task 1: Reproduce the Under-Filled Grid
 
 Task 1 changes no function. Benchmark the existing
-`quantized_matmul_simdgroup_w4a16_g128` Day 6 kernel before editing the Split-K
+`quantized_matmul_simdgroup_w4a16_g128` Day 5 kernel before editing the Split-K
 stubs.
 
 Begin with the narrow K projection at `M=32` before changing dispatch. This is
@@ -59,7 +59,7 @@ lengths may already have enough row-by-column tiles and should become controls.
 ## Task 2: Reuse the Day 5 Kernel for Each Partition
 
 Implement `quantized_matmul_simdgroup_splitk_w4a16_g128` in
-`src/extensions/src/quantized_matmul.metal`, reusing the Day 6 tiled helper
+`src/extensions/src/quantized_matmul.metal`, reusing the Day 5 tiled helper
 behind `quantized_matmul_simdgroup_w4a16_g128`.
 
 Add `group_id.z` as the partition index. Every partition must:

--- a/book/src/week2-06-split-k-prefill.md
+++ b/book/src/week2-06-split-k-prefill.md
@@ -38,6 +38,10 @@ original two-dimensional grid is under-filled.
 
 ## Task 1: Reproduce the Under-Filled Grid
 
+Task 1 changes no function. Benchmark the existing
+`quantized_matmul_simdgroup_w4a16_g128` Day 6 kernel before editing the Split-K
+stubs.
+
 Begin with the narrow K projection at `M=32` before changing dispatch. This is
 the smallest baseline needed to reproduce the under-filled Day 5 grid; Task 4
 runs the full all-projection, all-row sweep after Split-K exists:
@@ -54,6 +58,10 @@ lengths may already have enough row-by-column tiles and should become controls.
 
 ## Task 2: Reuse the Day 5 Kernel for Each Partition
 
+Implement `quantized_matmul_simdgroup_splitk_w4a16_g128` in
+`src/extensions/src/quantized_matmul.metal`, reusing the Day 6 tiled helper
+behind `quantized_matmul_simdgroup_w4a16_g128`.
+
 Add `group_id.z` as the partition index. Every partition must:
 
 - have the same reduction length;
@@ -68,6 +76,12 @@ BF16-appropriate tolerance. An FP32 temporary is a useful bring-up oracle, but
 it doubles the partial-buffer traffic.
 
 ## Task 3: Choose Partitions From Occupancy
+
+Modify `QuantizedMatmul::eval_gpu` in
+`src/extensions/src/quantized_matmul.cpp` to select the partition count and
+dispatch the Split-K kernel. Keep `tiny_llm_ext::quantized_matmul` and its
+Python binding unchanged; the existing `use_split_k` argument carries this
+cumulative checkpoint.
 
 Use a small explicit policy:
 
@@ -103,6 +117,11 @@ Expose the policy through a cumulative `split-k` checkpoint. Keep Day 5
 selectable so the benchmark always has an unsplit control.
 
 ## Task 4: Reduce and Verify
+
+Implement `quantized_matmul_splitk_reduce` in
+`src/extensions/src/quantized_matmul.metal` and complete the corresponding
+reduction dispatch in `QuantizedMatmul::eval_gpu`. Do not add a second public
+matmul function.
 
 Launch one reduction thread per output element. Sum all partition values in
 FP32 and cast once to the model dtype. Test:

--- a/book/src/week3-03-paged-attention-part1.md
+++ b/book/src/week3-03-paged-attention-part1.md
@@ -311,6 +311,15 @@ Before implementing, make sure the following are clear:
 src/tiny_llm/paged_kv_cache.py
 ```
 
+Modify `TinyKvPagedPool.__init__`, `allocate_page`, `write_page_slice`, and
+`free_page` in this task. For the slice-sized device
+write, replace the Week 3 Day 3 stubs `tiny_llm_ext::paged_cache_update`,
+`PagedCacheUpdate::eval_cpu`, and `PagedCacheUpdate::eval_gpu` in
+`src/extensions/src/paged_attention.cpp`, and implement
+`paged_cache_update_kernel` in `src/extensions/src/paged_attention.metal`.
+Their declaration, binding, source/Metal files, and CMake registration already
+exist; do not create a second paged-cache API.
+
 Design layer-owned page pools that:
 
 - own a free-page allocator,
@@ -332,6 +341,10 @@ allocated page ids.
 src/tiny_llm/paged_kv_cache.py
 ```
 
+Modify `TinyKvPagedCache.__init__`, `update_and_fetch`, `release`, and
+`rewind`. Use `TinyKvPagedPool.write_page_slice` from Task 1 for
+every physical append.
+
 Replace the "one layer cache = one dense KV tensor" model with:
 
 - `page_ids`
@@ -346,6 +359,12 @@ Replace the "one layer cache = one dense KV tensor" model with:
 src/tiny_llm/paged_kv_cache.py
 src/tiny_llm/qwen3_week3.py
 ```
+
+Modify `TinyKvPagedCache.gather_dense` in
+`src/tiny_llm/paged_kv_cache.py`, plus `Qwen3ModelWeek3.__init__`,
+`Qwen3ModelWeek3.create_kv_cache`, and `Qwen3MultiHeadAttention.__call__` in
+`src/tiny_llm/qwen3_week3.py`. This checkpoint deliberately does not implement
+`paged_attention`; Day 4 owns that function.
 
 Build a compatibility path that reconstructs dense K/V from pages and compares it against `TinyKvFullCache`.
 

--- a/book/src/week3-04-paged-attention-part2.md
+++ b/book/src/week3-04-paged-attention-part2.md
@@ -273,6 +273,11 @@ src/tiny_llm/kv_cache.py
 src/tiny_llm/batch.py
 ```
 
+Modify `TinyKvPagedCache.block_table`, `context_lens`, `paged_metadata`, and
+`update_and_fetch_paged` in `src/tiny_llm/paged_kv_cache.py`. Then update
+`Request.try_prefill` and `_step` in `src/tiny_llm/batch.py` to carry those
+arrays for every active request.
+
 Extend the batch cache and scheduler so they can prepare:
 
 - `block_table`
@@ -288,21 +293,23 @@ src/extensions/src/paged_attention.cpp
 src/extensions/src/paged_attention.metal
 ```
 
-Complete every learner-extension integration point before rebuilding:
+Modify these exact starter functions:
 
-- extend `src/extensions/src/paged_attention.cpp` and
-  `src/extensions/src/paged_attention.metal` with the direct-attention
-  operation and kernel,
-- register those C++ and Metal sources in their respective lists in
-  `src/extensions/CMakeLists.txt`,
-- declare `paged_attention` in `src/extensions/src/tiny_llm_ext.h`, and
-- register its Python binding in `src/extensions/bindings.cpp`.
+- `paged_attention` in `src/tiny_llm/attention.py`;
+- `tiny_llm_ext::paged_attention`, `PagedAttention::eval_cpu`, and
+  `PagedAttention::eval_gpu` in `src/extensions/src/paged_attention.cpp`;
+- `paged_attention_decode` and `paged_attention_scalar_f32` in
+  `src/extensions/src/paged_attention.metal`.
 
-Then rebuild:
-
-```bash
-pdm run build-ext
-```
+This checkpoint also turns the already-readable quantized token lookup into
+the Week 3 one-dispatch path. Modify `QuantizedEmbedding.__call__` in
+`src/tiny_llm/embedding.py`, `tiny_llm_ext::quantized_embedding` plus
+`QuantizedEmbedding::eval_cpu`/`eval_gpu` in
+`src/extensions/src/quantized_matmul.cpp`, and
+`quantized_embedding_w4a16_g128` in
+`src/extensions/src/quantized_matmul.metal`. The starter declarations,
+bindings, stubs, and build registrations for both operations already exist and
+remain fail-closed until you replace them.
 
 Add a paged attention interface whose inputs come from the paged runtime rather
 than a dense reconstructed `S` dimension. Preserve the Week 2 precision
@@ -365,6 +372,10 @@ dense-only special case: Day 5 optimizes this same paged contract.
 src/tiny_llm/qwen3_week3.py
 ```
 
+Modify `Qwen3MultiHeadAttention.__call__`, `Qwen3ModelWeek3.__init__`, and
+`Qwen3ModelWeek3.__call__` to select the paged path and enable the custom
+embedding only at this cumulative checkpoint.
+
 Update the model so it can route to paged attention when the cache provides paged runtime metadata.
 
 Append K/V to the page pool and pass its metadata to attention for every query
@@ -388,6 +399,10 @@ dense-gather teaching ablation, not the completed serving path.
 ```
 src/tiny_llm/batch.py
 ```
+
+Modify `Request.try_prefill`, `Request.decode_done`, `_step`, and
+`batch_generate`. Request cleanup must call `TinyKvPagedCache.release` for
+every layer cache.
 
 Update request admission, slot reuse, and request removal so that:
 

--- a/book/src/week3-05-flash-attention.md
+++ b/book/src/week3-05-flash-attention.md
@@ -70,6 +70,11 @@ workload-specific GPU schedules.
 
 ## Task 1: Tile Queries and Paged K/V
 
+Begin `paged_attention_mma_bf16_d128` in
+`src/extensions/src/paged_attention.metal`. Keep
+`paged_attention_decode` and `paged_attention_scalar_f32` from Day 4 unchanged;
+they remain the short-query and generic controls.
+
 Use eight SIMD groups to cover a 64-row query block. Each SIMD group owns eight
 query rows and represents matrix operands as 8×8 fragments. Stage 32 logical
 K/V positions per iteration.
@@ -101,6 +106,10 @@ partially full, and physical page ids need not be consecutive.
 
 ## Task 2: Compute Tiled Online Softmax
 
+Continue modifying `paged_attention_mma_bf16_d128` in
+`src/extensions/src/paged_attention.metal`. This task fills the tiled
+online-softmax body; it does not add another public function.
+
 For each query tile, maintain one running maximum, one running sum, and an
 unnormalized output accumulator per row. For each K/V tile:
 
@@ -131,6 +140,12 @@ optimization.
 
 ## Task 3: Validate the Page Boundary
 
+Complete the long-query selection in `PagedAttention::eval_gpu` in
+`src/extensions/src/paged_attention.cpp`, then test
+`paged_attention_mma_bf16_d128` against the Day 4 kernels. Keep
+`tiny_llm_ext::paged_attention` and the Python `paged_attention` signature
+unchanged.
+
 Use the GPU-debugging ladder from Week 2 Day 2:
 
 1. compare Day 4 page-walking attention with the readable equation written
@@ -156,6 +171,10 @@ pdm run test --week 3 --day 5
 ```
 
 ## Task 4: Integrate and Measure
+
+Verify the existing dispatch in `Qwen3MultiHeadAttention.__call__` and the
+shape selection inside `PagedAttention::eval_gpu`. Task 4 adds no new
+extension function.
 
 The Week 3 model should use the tiled paged path automatically for supported
 long prefills. Short queries continue through the vector paged-decode schedule.

--- a/book/src/week3-optional-moe.md
+++ b/book/src/week3-optional-moe.md
@@ -181,6 +181,17 @@ src/tiny_llm/moe.py
 Implement `grouped_quantized_matmul`, then use it from `grouped_expert_linear`.
 This is the quantized grouped-matmul core of MoE.
 
+This optional interface is **intentionally not predeclared** in
+`src/extensions/src/tiny_llm_ext.h`, the bindings, or the core CMake target.
+The required Week 2/3 interfaces are scaffolded from setup, but this optional
+chapter is a staged reveal: if you choose the extension variant, add the new
+`tiny_llm_ext::grouped_quantized_matmul` declaration, binding, C++ source
+function, `grouped_quantized_matmul` Metal kernel, and build registration here.
+Then modify the existing `grouped_expert_linear` function in
+`src/tiny_llm/moe.py` to call it. Keeping it out of the core starter prevents
+an optional future interface from appearing to be required by earlier
+checkpoints.
+
 `grouped_quantized_matmul` accepts:
 
 ```plain
@@ -244,6 +255,8 @@ right matrix.
 src/tiny_llm/moe.py
 ```
 
+Modify the existing `route_topk` function in this file.
+
 Implement `route_topk`. It accepts hidden states and router weights, then
 returns:
 
@@ -262,6 +275,9 @@ the model config.
 ```
 src/tiny_llm/moe.py
 ```
+
+Modify `Moe.__init__` and `Moe.__call__`, composing the
+`grouped_expert_linear` and `route_topk` functions from Tasks 1-2.
 
 Implement `Moe` by composing Task 1 and Task 2:
 
@@ -282,6 +298,10 @@ branch in this block.
 src/tiny_llm/qwen3_week3.py
 src/tiny_llm/models.py
 ```
+
+Modify `is_qwen3_moe_sparse_layer` and `Qwen3ModelWeek3.__init__` in
+`src/tiny_llm/qwen3_week3.py`, plus `dispatch_model` in
+`src/tiny_llm/models.py`.
 
 Add a Qwen3-MoE loader path that reuses the Week 3 Qwen3 attention and paged KV
 cache behavior, but swaps selected block MLPs for `Moe`.

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -36,6 +36,9 @@ target_sources(
   tiny_llm_ext
   PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}/src/axpby.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/quantized_matmul.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/week2_kernels.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/src/paged_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/src/utils.cpp
 )
 
@@ -58,6 +61,9 @@ if(MLX_BUILD_METAL)
     tiny_llm_ext
     SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/axpby.metal
+    ${CMAKE_CURRENT_LIST_DIR}/src/quantized_matmul.metal
+    ${CMAKE_CURRENT_LIST_DIR}/src/week2_kernels.metal
+    ${CMAKE_CURRENT_LIST_DIR}/src/paged_attention.metal
     INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}
     ${MLX_INCLUDE_DIRS}

--- a/src/extensions/bindings.cpp
+++ b/src/extensions/bindings.cpp
@@ -32,7 +32,7 @@ NB_MODULE(_ext, m) {
             array: ``alpha * x + beta * y``
       )");
 
-    // Week 2, Day 3. Days 6-7 extend the schedule behind this stable binding.
+    // Week 2, Day 2. Days 5-6 extend the schedule behind this stable binding.
     m.def("quantized_matmul", &tiny_llm_ext::quantized_matmul, "scales"_a, "biases"_a, "group_size"_a, "bits"_a, "a"_a,
           "b"_a, "transpose_b"_a = false, "use_simdgroup"_a = true, "use_split_k"_a = false, "stream"_a = nb::none());
 
@@ -40,13 +40,13 @@ NB_MODULE(_ext, m) {
     m.def("quantized_embedding", &tiny_llm_ext::quantized_embedding, "indices"_a, "scales"_a, "biases"_a, "weight"_a,
           "group_size"_a, "bits"_a, "stream"_a = nb::none());
 
-    // Week 2, Day 4.
+    // Week 2, Day 3.
     m.def("rms_norm", &tiny_llm_ext::rms_norm, "x"_a, "weight"_a, "eps"_a, "stream"_a = nb::none());
     m.def("rope", &tiny_llm_ext::rope, "x"_a, "offsets"_a, "dims"_a, "base"_a, "traditional"_a = false,
           "stream"_a = nb::none());
     m.def("swiglu", &tiny_llm_ext::swiglu, "gate"_a, "up"_a, "stream"_a = nb::none());
 
-    // Week 2, Day 5.
+    // Week 2, Day 4.
     m.def("decode_attention", &tiny_llm_ext::decode_attention, "query"_a, "key"_a, "value"_a, "mask"_a, "scale"_a,
           "is_causal"_a, "has_mask"_a, "num_heads"_a, "num_kv_heads"_a, "stream"_a = nb::none());
 

--- a/src/extensions/bindings.cpp
+++ b/src/extensions/bindings.cpp
@@ -31,4 +31,31 @@ NB_MODULE(_ext, m) {
         Returns:
             array: ``alpha * x + beta * y``
       )");
+
+    // Week 2, Day 3. Days 6-7 extend the schedule behind this stable binding.
+    m.def("quantized_matmul", &tiny_llm_ext::quantized_matmul, "scales"_a, "biases"_a, "group_size"_a, "bits"_a, "a"_a,
+          "b"_a, "transpose_b"_a = false, "use_simdgroup"_a = true, "use_split_k"_a = false, "stream"_a = nb::none());
+
+    // Week 3, Day 4. Earlier checkpoints keep the readable selected-row lookup.
+    m.def("quantized_embedding", &tiny_llm_ext::quantized_embedding, "indices"_a, "scales"_a, "biases"_a, "weight"_a,
+          "group_size"_a, "bits"_a, "stream"_a = nb::none());
+
+    // Week 2, Day 4.
+    m.def("rms_norm", &tiny_llm_ext::rms_norm, "x"_a, "weight"_a, "eps"_a, "stream"_a = nb::none());
+    m.def("rope", &tiny_llm_ext::rope, "x"_a, "offsets"_a, "dims"_a, "base"_a, "traditional"_a = false,
+          "stream"_a = nb::none());
+    m.def("swiglu", &tiny_llm_ext::swiglu, "gate"_a, "up"_a, "stream"_a = nb::none());
+
+    // Week 2, Day 5.
+    m.def("decode_attention", &tiny_llm_ext::decode_attention, "query"_a, "key"_a, "value"_a, "mask"_a, "scale"_a,
+          "is_causal"_a, "has_mask"_a, "num_heads"_a, "num_kv_heads"_a, "stream"_a = nb::none());
+
+    // Week 3, Day 3.
+    m.def("paged_cache_update", &tiny_llm_ext::paged_cache_update, "pages"_a, "values"_a, "page_id"_a, "start"_a,
+          "stream"_a = nb::none());
+
+    // Week 3, Day 4. Day 5 replaces only the long-query schedule.
+    m.def("paged_attention", &tiny_llm_ext::paged_attention, "query"_a, "key_pages"_a, "value_pages"_a, "block_table"_a,
+          "context_lens"_a, "scale"_a = 1.0, "is_causal"_a = false, "num_kv_heads"_a, "num_heads"_a,
+          "stream"_a = nb::none());
 }

--- a/src/extensions/src/paged_attention.cpp
+++ b/src/extensions/src/paged_attention.cpp
@@ -1,0 +1,43 @@
+#include <stdexcept>
+#include <string>
+
+#include "tiny_llm_ext.h"
+
+namespace tiny_llm_ext {
+
+namespace {
+
+[[noreturn]] void checkpoint_todo(const char *function, const char *checkpoint) {
+    throw std::runtime_error(std::string(function) + " is a starter stub; implement it in " + checkpoint);
+}
+
+}  // namespace
+
+// Week 3, Day 3.
+mx::array paged_cache_update(const mx::array &, const mx::array &, int, int, mx::StreamOrDevice) {
+    checkpoint_todo("paged_cache_update", "Week 3, Day 3");
+}
+
+void PagedCacheUpdate::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("PagedCacheUpdate::eval_cpu", "Week 3, Day 3");
+}
+
+void PagedCacheUpdate::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("PagedCacheUpdate::eval_gpu", "Week 3, Day 3");
+}
+
+// Week 3, Day 4. Day 5 replaces the long-query schedule behind this API.
+mx::array paged_attention(const mx::array &, const mx::array &, const mx::array &, const mx::array &, const mx::array &,
+                          float, bool, int, int, mx::StreamOrDevice) {
+    checkpoint_todo("paged_attention", "Week 3, Day 4");
+}
+
+void PagedAttention::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("PagedAttention::eval_cpu", "Week 3, Day 4");
+}
+
+void PagedAttention::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("PagedAttention::eval_gpu", "Week 3, Day 4");
+}
+
+}  // namespace tiny_llm_ext

--- a/src/extensions/src/paged_attention.metal
+++ b/src/extensions/src/paged_attention.metal
@@ -1,0 +1,14 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Week 3, Day 3:
+//   paged_cache_update_kernel
+// Week 3, Day 4:
+//   paged_attention_decode
+//   paged_attention_scalar_f32
+// Week 3, Day 5:
+//   paged_attention_mma_bf16_d128
+//
+// The public C++ API remains paged_attention across Days 4-5. Day 5 replaces
+// only the long-query schedule behind that stable boundary.

--- a/src/extensions/src/quantized_matmul.cpp
+++ b/src/extensions/src/quantized_matmul.cpp
@@ -13,18 +13,18 @@ namespace {
 
 }  // namespace
 
-// Week 2, Day 3. Days 6 and 7 extend the dispatch policy behind this API.
+// Week 2, Day 2. Days 5 and 6 extend the dispatch policy behind this API.
 mx::array quantized_matmul(const mx::array &, const mx::array &, int, int, const mx::array &, const mx::array &, bool,
                            bool, bool, mx::StreamOrDevice) {
-    checkpoint_todo("quantized_matmul", "Week 2, Day 3");
+    checkpoint_todo("quantized_matmul", "Week 2, Day 2");
 }
 
 void QuantizedMatmul::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("QuantizedMatmul::eval_cpu", "Week 2, Day 3");
+    checkpoint_todo("QuantizedMatmul::eval_cpu", "Week 2, Day 2");
 }
 
 void QuantizedMatmul::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("QuantizedMatmul::eval_gpu", "Week 2, Day 3");
+    checkpoint_todo("QuantizedMatmul::eval_gpu", "Week 2, Day 2");
 }
 
 // Week 3, Day 4. The earlier Week 2 checkpoints keep the readable row lookup.

--- a/src/extensions/src/quantized_matmul.cpp
+++ b/src/extensions/src/quantized_matmul.cpp
@@ -1,0 +1,44 @@
+#include <stdexcept>
+#include <string>
+
+#include "tiny_llm_ext.h"
+
+namespace tiny_llm_ext {
+
+namespace {
+
+[[noreturn]] void checkpoint_todo(const char *function, const char *checkpoint) {
+    throw std::runtime_error(std::string(function) + " is a starter stub; implement it in " + checkpoint);
+}
+
+}  // namespace
+
+// Week 2, Day 3. Days 6 and 7 extend the dispatch policy behind this API.
+mx::array quantized_matmul(const mx::array &, const mx::array &, int, int, const mx::array &, const mx::array &, bool,
+                           bool, bool, mx::StreamOrDevice) {
+    checkpoint_todo("quantized_matmul", "Week 2, Day 3");
+}
+
+void QuantizedMatmul::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("QuantizedMatmul::eval_cpu", "Week 2, Day 3");
+}
+
+void QuantizedMatmul::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("QuantizedMatmul::eval_gpu", "Week 2, Day 3");
+}
+
+// Week 3, Day 4. The earlier Week 2 checkpoints keep the readable row lookup.
+mx::array quantized_embedding(const mx::array &, const mx::array &, const mx::array &, const mx::array &, int, int,
+                              mx::StreamOrDevice) {
+    checkpoint_todo("quantized_embedding", "Week 3, Day 4");
+}
+
+void QuantizedEmbedding::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("QuantizedEmbedding::eval_cpu", "Week 3, Day 4");
+}
+
+void QuantizedEmbedding::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("QuantizedEmbedding::eval_gpu", "Week 3, Day 4");
+}
+
+}  // namespace tiny_llm_ext

--- a/src/extensions/src/quantized_matmul.metal
+++ b/src/extensions/src/quantized_matmul.metal
@@ -5,12 +5,12 @@ using namespace metal;
 // Starter interface map. Implement the named kernels at these checkpoints;
 // their argument lists are defined by the matching C++ encoder you complete.
 //
-// Week 2, Day 3:
+// Week 2, Day 2:
 //   quantized_matmul_vanilla_w4a16_g128
 //   quantized_matvec_x4_fast_w4a16_g128
-// Week 2, Day 6:
+// Week 2, Day 5:
 //   quantized_matmul_simdgroup_w4a16_g128
-// Week 2, Day 7:
+// Week 2, Day 6:
 //   quantized_matmul_simdgroup_splitk_w4a16_g128
 //   quantized_matmul_splitk_reduce
 // Week 3, Day 4:

--- a/src/extensions/src/quantized_matmul.metal
+++ b/src/extensions/src/quantized_matmul.metal
@@ -1,0 +1,21 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Starter interface map. Implement the named kernels at these checkpoints;
+// their argument lists are defined by the matching C++ encoder you complete.
+//
+// Week 2, Day 3:
+//   quantized_matmul_vanilla_w4a16_g128
+//   quantized_matvec_x4_fast_w4a16_g128
+// Week 2, Day 6:
+//   quantized_matmul_simdgroup_w4a16_g128
+// Week 2, Day 7:
+//   quantized_matmul_simdgroup_splitk_w4a16_g128
+//   quantized_matmul_splitk_reduce
+// Week 3, Day 4:
+//   quantized_embedding_w4a16_g128
+//
+// The x2/x8 tuning variants in the reference extension are deliberately not
+// starter interfaces. Add an experimental variant only while running the
+// optional scheduling comparison, then keep the selected course path.

--- a/src/extensions/src/tiny_llm_ext.h
+++ b/src/extensions/src/tiny_llm_ext.h
@@ -1,12 +1,183 @@
 #pragma once
 
-#include "mlx/ops.h"
 #include "mlx/primitives.h"
+#include "mlx/utils.h"
 
 namespace mx = mlx::core;
 
 namespace tiny_llm_ext {
 
 void load_library(const char *path);
+
+// Week 2, Day 3: implement the wrapper and the initial vanilla/matvec paths.
+// Week 2, Days 6-7: extend the same interface with SIMD-matrix and Split-K scheduling.
+mx::array quantized_matmul(const mx::array &scales, const mx::array &biases, const int group_size, const int bits,
+                           const mx::array &a, const mx::array &b, const bool transpose_b,
+                           const bool use_simdgroup = true, const bool use_split_k = false, mx::StreamOrDevice s = {});
+
+class QuantizedMatmul : public mx::Primitive {
+public:
+    QuantizedMatmul(mx::Stream stream, bool use_simdgroup, bool use_split_k)
+        : mx::Primitive(stream), use_simdgroup_(use_simdgroup), use_split_k_(use_split_k) {}
+
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("QuantizedMatmul has no vmap implementation.");
+    }
+    const char *name() const override { return "QuantizedMatmul"; }
+
+private:
+    bool use_simdgroup_;
+    bool use_split_k_;
+};
+
+// Week 3, Day 4: replace the readable selected-row lookup with one extension dispatch.
+mx::array quantized_embedding(const mx::array &indices, const mx::array &scales, const mx::array &biases,
+                              const mx::array &weight, int group_size, int bits, mx::StreamOrDevice s = {});
+
+class QuantizedEmbedding : public mx::Primitive {
+public:
+    explicit QuantizedEmbedding(mx::Stream stream) : mx::Primitive(stream) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("QuantizedEmbedding has no vmap implementation.");
+    }
+    const char *name() const override { return "QuantizedEmbedding"; }
+};
+
+// Week 2, Day 4: implement the three fused model kernels in checkpoint order.
+mx::array rms_norm(const mx::array &x, const mx::array &weight, float eps, mx::StreamOrDevice s = {});
+mx::array rope(const mx::array &x, const mx::array &offsets, int dims, float base, bool traditional,
+               mx::StreamOrDevice s = {});
+mx::array swiglu(const mx::array &gate, const mx::array &up, mx::StreamOrDevice s = {});
+
+class Week2RMSNorm : public mx::Primitive {
+public:
+    Week2RMSNorm(mx::Stream stream, float eps) : mx::Primitive(stream), eps_(eps) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("Week2RMSNorm has no vmap implementation.");
+    }
+    const char *name() const override { return "Week2RMSNorm"; }
+
+private:
+    float eps_;
+};
+
+class Week2RoPE : public mx::Primitive {
+public:
+    Week2RoPE(mx::Stream stream, int dims, float base, bool traditional)
+        : mx::Primitive(stream), dims_(dims), base_(base), traditional_(traditional) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("Week2RoPE has no vmap implementation.");
+    }
+    const char *name() const override { return "Week2RoPE"; }
+
+private:
+    int dims_;
+    float base_;
+    bool traditional_;
+};
+
+class Week2SwiGLU : public mx::Primitive {
+public:
+    explicit Week2SwiGLU(mx::Stream stream) : mx::Primitive(stream) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("Week2SwiGLU has no vmap implementation.");
+    }
+    const char *name() const override { return "Week2SwiGLU"; }
+};
+
+// Week 2, Day 5: implement online-softmax decode attention.
+mx::array decode_attention(const mx::array &q, const mx::array &k, const mx::array &v, const mx::array &mask,
+                           float scale, bool is_causal, bool has_mask, int num_heads, int num_kv_heads,
+                           mx::StreamOrDevice s = {});
+
+class Week2DecodeAttention : public mx::Primitive {
+public:
+    Week2DecodeAttention(mx::Stream stream, float scale, bool is_causal, bool has_mask, int num_heads, int num_kv_heads)
+        : mx::Primitive(stream),
+          scale_(scale),
+          is_causal_(is_causal),
+          has_mask_(has_mask),
+          num_heads_(num_heads),
+          num_kv_heads_(num_kv_heads) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("Week2DecodeAttention has no vmap implementation.");
+    }
+    const char *name() const override { return "Week2DecodeAttention"; }
+
+private:
+    float scale_;
+    bool is_causal_;
+    bool has_mask_;
+    int num_heads_;
+    int num_kv_heads_;
+};
+
+// Week 3, Day 3: implement slice-sized writes into paged KV storage.
+mx::array paged_cache_update(const mx::array &pages, const mx::array &values, int page_id, int start,
+                             mx::StreamOrDevice s = {});
+
+class PagedCacheUpdate : public mx::Primitive {
+public:
+    PagedCacheUpdate(mx::Stream stream, int page_id, int start)
+        : mx::Primitive(stream), page_id_(page_id), start_(start) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("PagedCacheUpdate has no vmap implementation.");
+    }
+    const char *name() const override { return "PagedCacheUpdate"; }
+
+private:
+    int page_id_;
+    int start_;
+};
+
+// Week 3, Day 4: implement direct paged decode and correctness-first prefill.
+// Week 3, Day 5: optimize the long-query prefill schedule without changing this API.
+mx::array paged_attention(const mx::array &q, const mx::array &key_pages, const mx::array &value_pages,
+                          const mx::array &block_table, const mx::array &context_lens, const float scale,
+                          const bool is_causal, const int num_kv_heads, const int num_heads, mx::StreamOrDevice s = {});
+
+class PagedAttention : public mx::Primitive {
+public:
+    PagedAttention(mx::Stream stream, float scale, bool is_causal, int num_kv_heads, int num_heads)
+        : mx::Primitive(stream),
+          scale_(scale),
+          is_causal_(is_causal),
+          num_kv_heads_(num_kv_heads),
+          num_heads_(num_heads) {}
+    void eval_cpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    void eval_gpu(const std::vector<mx::array> &inputs, std::vector<mx::array> &outputs) override;
+    std::pair<std::vector<mx::array>, std::vector<int>> vmap(const std::vector<mx::array> &,
+                                                             const std::vector<int> &) override {
+        throw std::runtime_error("PagedAttention has no vmap implementation.");
+    }
+    const char *name() const override { return "PagedAttention"; }
+
+private:
+    float scale_;
+    bool is_causal_;
+    int num_kv_heads_;
+    int num_heads_;
+};
 
 }  // namespace tiny_llm_ext

--- a/src/extensions/src/tiny_llm_ext.h
+++ b/src/extensions/src/tiny_llm_ext.h
@@ -9,8 +9,8 @@ namespace tiny_llm_ext {
 
 void load_library(const char *path);
 
-// Week 2, Day 3: implement the wrapper and the initial vanilla/matvec paths.
-// Week 2, Days 6-7: extend the same interface with SIMD-matrix and Split-K scheduling.
+// Week 2, Day 2: implement the wrapper and the initial vanilla/matvec paths.
+// Week 2, Days 5-6: extend the same interface with SIMD-matrix and Split-K scheduling.
 mx::array quantized_matmul(const mx::array &scales, const mx::array &biases, const int group_size, const int bits,
                            const mx::array &a, const mx::array &b, const bool transpose_b,
                            const bool use_simdgroup = true, const bool use_split_k = false, mx::StreamOrDevice s = {});
@@ -49,7 +49,7 @@ public:
     const char *name() const override { return "QuantizedEmbedding"; }
 };
 
-// Week 2, Day 4: implement the three fused model kernels in checkpoint order.
+// Week 2, Day 3: implement the three fused model kernels in checkpoint order.
 mx::array rms_norm(const mx::array &x, const mx::array &weight, float eps, mx::StreamOrDevice s = {});
 mx::array rope(const mx::array &x, const mx::array &offsets, int dims, float base, bool traditional,
                mx::StreamOrDevice s = {});
@@ -100,7 +100,7 @@ public:
     const char *name() const override { return "Week2SwiGLU"; }
 };
 
-// Week 2, Day 5: implement online-softmax decode attention.
+// Week 2, Day 4: implement online-softmax decode attention.
 mx::array decode_attention(const mx::array &q, const mx::array &k, const mx::array &v, const mx::array &mask,
                            float scale, bool is_causal, bool has_mask, int num_heads, int num_kv_heads,
                            mx::StreamOrDevice s = {});

--- a/src/extensions/src/week2_kernels.cpp
+++ b/src/extensions/src/week2_kernels.cpp
@@ -1,0 +1,67 @@
+#include <stdexcept>
+#include <string>
+
+#include "tiny_llm_ext.h"
+
+namespace tiny_llm_ext {
+
+namespace {
+
+[[noreturn]] void checkpoint_todo(const char *function, const char *checkpoint) {
+    throw std::runtime_error(std::string(function) + " is a starter stub; implement it in " + checkpoint);
+}
+
+}  // namespace
+
+// Week 2, Day 4.
+mx::array rms_norm(const mx::array &, const mx::array &, float, mx::StreamOrDevice) {
+    checkpoint_todo("rms_norm", "Week 2, Day 4");
+}
+
+mx::array rope(const mx::array &, const mx::array &, int, float, bool, mx::StreamOrDevice) {
+    checkpoint_todo("rope", "Week 2, Day 4");
+}
+
+mx::array swiglu(const mx::array &, const mx::array &, mx::StreamOrDevice) {
+    checkpoint_todo("swiglu", "Week 2, Day 4");
+}
+
+void Week2RMSNorm::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2RMSNorm::eval_cpu", "Week 2, Day 4");
+}
+
+void Week2RMSNorm::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2RMSNorm::eval_gpu", "Week 2, Day 4");
+}
+
+void Week2RoPE::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2RoPE::eval_cpu", "Week 2, Day 4");
+}
+
+void Week2RoPE::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2RoPE::eval_gpu", "Week 2, Day 4");
+}
+
+void Week2SwiGLU::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2SwiGLU::eval_cpu", "Week 2, Day 4");
+}
+
+void Week2SwiGLU::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2SwiGLU::eval_gpu", "Week 2, Day 4");
+}
+
+// Week 2, Day 5.
+mx::array decode_attention(const mx::array &, const mx::array &, const mx::array &, const mx::array &, float, bool,
+                           bool, int, int, mx::StreamOrDevice) {
+    checkpoint_todo("decode_attention", "Week 2, Day 5");
+}
+
+void Week2DecodeAttention::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2DecodeAttention::eval_cpu", "Week 2, Day 5");
+}
+
+void Week2DecodeAttention::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
+    checkpoint_todo("Week2DecodeAttention::eval_gpu", "Week 2, Day 5");
+}
+
+}  // namespace tiny_llm_ext

--- a/src/extensions/src/week2_kernels.cpp
+++ b/src/extensions/src/week2_kernels.cpp
@@ -13,55 +13,55 @@ namespace {
 
 }  // namespace
 
-// Week 2, Day 4.
+// Week 2, Day 3.
 mx::array rms_norm(const mx::array &, const mx::array &, float, mx::StreamOrDevice) {
-    checkpoint_todo("rms_norm", "Week 2, Day 4");
+    checkpoint_todo("rms_norm", "Week 2, Day 3");
 }
 
 mx::array rope(const mx::array &, const mx::array &, int, float, bool, mx::StreamOrDevice) {
-    checkpoint_todo("rope", "Week 2, Day 4");
+    checkpoint_todo("rope", "Week 2, Day 3");
 }
 
 mx::array swiglu(const mx::array &, const mx::array &, mx::StreamOrDevice) {
-    checkpoint_todo("swiglu", "Week 2, Day 4");
+    checkpoint_todo("swiglu", "Week 2, Day 3");
 }
 
 void Week2RMSNorm::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2RMSNorm::eval_cpu", "Week 2, Day 4");
+    checkpoint_todo("Week2RMSNorm::eval_cpu", "Week 2, Day 3");
 }
 
 void Week2RMSNorm::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2RMSNorm::eval_gpu", "Week 2, Day 4");
+    checkpoint_todo("Week2RMSNorm::eval_gpu", "Week 2, Day 3");
 }
 
 void Week2RoPE::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2RoPE::eval_cpu", "Week 2, Day 4");
+    checkpoint_todo("Week2RoPE::eval_cpu", "Week 2, Day 3");
 }
 
 void Week2RoPE::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2RoPE::eval_gpu", "Week 2, Day 4");
+    checkpoint_todo("Week2RoPE::eval_gpu", "Week 2, Day 3");
 }
 
 void Week2SwiGLU::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2SwiGLU::eval_cpu", "Week 2, Day 4");
+    checkpoint_todo("Week2SwiGLU::eval_cpu", "Week 2, Day 3");
 }
 
 void Week2SwiGLU::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2SwiGLU::eval_gpu", "Week 2, Day 4");
+    checkpoint_todo("Week2SwiGLU::eval_gpu", "Week 2, Day 3");
 }
 
-// Week 2, Day 5.
+// Week 2, Day 4.
 mx::array decode_attention(const mx::array &, const mx::array &, const mx::array &, const mx::array &, float, bool,
                            bool, int, int, mx::StreamOrDevice) {
-    checkpoint_todo("decode_attention", "Week 2, Day 5");
+    checkpoint_todo("decode_attention", "Week 2, Day 4");
 }
 
 void Week2DecodeAttention::eval_cpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2DecodeAttention::eval_cpu", "Week 2, Day 5");
+    checkpoint_todo("Week2DecodeAttention::eval_cpu", "Week 2, Day 4");
 }
 
 void Week2DecodeAttention::eval_gpu(const std::vector<mx::array> &, std::vector<mx::array> &) {
-    checkpoint_todo("Week2DecodeAttention::eval_gpu", "Week 2, Day 5");
+    checkpoint_todo("Week2DecodeAttention::eval_gpu", "Week 2, Day 4");
 }
 
 }  // namespace tiny_llm_ext

--- a/src/extensions/src/week2_kernels.metal
+++ b/src/extensions/src/week2_kernels.metal
@@ -1,0 +1,13 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Week 2, Day 4:
+//   week2_rms_norm
+//   week2_rope
+//   week2_swiglu
+// Week 2, Day 5:
+//   week2_decode_attention
+//
+// Add each [[kernel]] function when its task asks for it. The C++ starter
+// wrapper and binding already exist, but remain fail-closed until then.

--- a/src/extensions/src/week2_kernels.metal
+++ b/src/extensions/src/week2_kernels.metal
@@ -2,11 +2,11 @@
 
 using namespace metal;
 
-// Week 2, Day 4:
+// Week 2, Day 3:
 //   week2_rms_norm
 //   week2_rope
 //   week2_swiglu
-// Week 2, Day 5:
+// Week 2, Day 4:
 //   week2_decode_attention
 //
 // Add each [[kernel]] function when its task asks for it. The C++ starter

--- a/src/extensions/test.py
+++ b/src/extensions/test.py
@@ -1,12 +1,29 @@
 # Copyright © 2023-2024 Apple Inc.
 
-from tiny_llm_ext import axpby
 import mlx.core as mx
-import numpy as np
+import tiny_llm_ext
+
+
+LEARNER_EXTENSION_INTERFACES = {
+    "quantized_matmul": "Week 2, Day 3",
+    "rms_norm": "Week 2, Day 4",
+    "rope": "Week 2, Day 4",
+    "swiglu": "Week 2, Day 4",
+    "decode_attention": "Week 2, Day 5",
+    "paged_cache_update": "Week 3, Day 3",
+    "quantized_embedding": "Week 3, Day 4",
+    "paged_attention": "Week 3, Day 4",
+}
+
+missing = sorted(
+    name for name in LEARNER_EXTENSION_INTERFACES if not hasattr(tiny_llm_ext, name)
+)
+if missing:
+    raise RuntimeError(f"starter extension is missing learner interfaces: {missing}")
 
 a = mx.ones((3, 4))
 b = mx.ones((3, 4))
-c = axpby(a, b, 4.0, 2.0, stream=mx.cpu)
+c = tiny_llm_ext.axpby(a, b, 4.0, 2.0, stream=mx.cpu)
 
 print(f"c shape: {c.shape}")
 print(f"c dtype: {c.dtype}")

--- a/src/extensions/test.py
+++ b/src/extensions/test.py
@@ -5,11 +5,11 @@ import tiny_llm_ext
 
 
 LEARNER_EXTENSION_INTERFACES = {
-    "quantized_matmul": "Week 2, Day 3",
-    "rms_norm": "Week 2, Day 4",
-    "rope": "Week 2, Day 4",
-    "swiglu": "Week 2, Day 4",
-    "decode_attention": "Week 2, Day 5",
+    "quantized_matmul": "Week 2, Day 2",
+    "rms_norm": "Week 2, Day 3",
+    "rope": "Week 2, Day 3",
+    "swiglu": "Week 2, Day 3",
+    "decode_attention": "Week 2, Day 4",
     "paged_cache_update": "Week 3, Day 3",
     "quantized_embedding": "Week 3, Day 4",
     "paged_attention": "Week 3, Day 4",

--- a/tests_refsol/test_extension_interface_sync.py
+++ b/tests_refsol/test_extension_interface_sync.py
@@ -1,6 +1,9 @@
+import importlib
 import re
+import sys
 from pathlib import Path
 
+import mlx.core as mx
 import pytest
 
 
@@ -137,6 +140,125 @@ DOC_TASK_MARKERS = {
     },
 }
 
+EXTENSION_TASK_PAIRS = {
+    "book/src/week2-03-quantized-matvec.md": {
+        "Task 2": {
+            (
+                "src/extensions/src/quantized_matmul.cpp",
+                "tiny_llm_ext::quantized_matmul",
+            ),
+            ("src/extensions/src/quantized_matmul.cpp", "QuantizedMatmul::eval_cpu"),
+        },
+        "Task 3": {
+            ("src/extensions/src/quantized_matmul.cpp", "QuantizedMatmul::eval_gpu"),
+            (
+                "src/extensions/src/quantized_matmul.metal",
+                "quantized_matmul_vanilla_w4a16_g128",
+            ),
+            (
+                "src/extensions/src/quantized_matmul.metal",
+                "quantized_matvec_x4_fast_w4a16_g128",
+            ),
+        },
+    },
+    "book/src/week2-04-fused-model-kernels.md": {
+        "Task 1": {
+            ("src/extensions/src/week2_kernels.cpp", "tiny_llm_ext::rms_norm"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2RMSNorm::eval_cpu"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2RMSNorm::eval_gpu"),
+            ("src/extensions/src/week2_kernels.metal", "week2_rms_norm"),
+        },
+        "Task 2": {
+            ("src/extensions/src/week2_kernels.cpp", "tiny_llm_ext::rope"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2RoPE::eval_cpu"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2RoPE::eval_gpu"),
+            ("src/extensions/src/week2_kernels.metal", "week2_rope"),
+        },
+        "Task 3": {
+            ("src/extensions/src/week2_kernels.cpp", "tiny_llm_ext::swiglu"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2SwiGLU::eval_cpu"),
+            ("src/extensions/src/week2_kernels.cpp", "Week2SwiGLU::eval_gpu"),
+            ("src/extensions/src/week2_kernels.metal", "week2_swiglu"),
+        },
+    },
+    "book/src/week2-05-decode-attention.md": {
+        "Task 2": {
+            (
+                "src/extensions/src/week2_kernels.cpp",
+                "tiny_llm_ext::decode_attention",
+            ),
+            (
+                "src/extensions/src/week2_kernels.cpp",
+                "Week2DecodeAttention::eval_cpu",
+            ),
+            (
+                "src/extensions/src/week2_kernels.cpp",
+                "Week2DecodeAttention::eval_gpu",
+            ),
+            (
+                "src/extensions/src/week2_kernels.metal",
+                "week2_decode_attention",
+            ),
+        },
+    },
+    "book/src/week3-03-paged-attention-part1.md": {
+        "Task 1": {
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "tiny_llm_ext::paged_cache_update",
+            ),
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "PagedCacheUpdate::eval_cpu",
+            ),
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "PagedCacheUpdate::eval_gpu",
+            ),
+            (
+                "src/extensions/src/paged_attention.metal",
+                "paged_cache_update_kernel",
+            ),
+        },
+    },
+    "book/src/week3-04-paged-attention-part2.md": {
+        "Task 2": {
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "tiny_llm_ext::paged_attention",
+            ),
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "PagedAttention::eval_cpu",
+            ),
+            (
+                "src/extensions/src/paged_attention.cpp",
+                "PagedAttention::eval_gpu",
+            ),
+            (
+                "src/extensions/src/paged_attention.metal",
+                "paged_attention_decode",
+            ),
+            (
+                "src/extensions/src/paged_attention.metal",
+                "paged_attention_scalar_f32",
+            ),
+            (
+                "src/extensions/src/quantized_matmul.cpp",
+                "tiny_llm_ext::quantized_embedding",
+            ),
+            (
+                "src/extensions/src/quantized_matmul.cpp",
+                "QuantizedEmbedding::eval_cpu",
+            ),
+            (
+                "src/extensions/src/quantized_matmul.metal",
+                "quantized_embedding_w4a16_g128",
+            ),
+        },
+    },
+}
+
 
 def _read(path: str) -> str:
     return (ROOT / path).read_text()
@@ -225,11 +347,44 @@ def _binding_functions(path: str) -> set[str]:
     return set(re.findall(r'm\.def\("([a-z][a-z0-9_]*)"', _read(path)))
 
 
-def _binding_arguments(path: str, function: str) -> list[str]:
-    source = _read(path)
+def _binding_contract(
+    source: str, function: str
+) -> tuple[str, list[tuple[str, str | None]]]:
     match = re.search(rf'm\.def\("{function}"(.*?)\);', source, re.DOTALL)
+    assert match is not None, f"missing binding for {function}"
+    target = re.search(r"&([A-Za-z_][A-Za-z0-9_:]*)", match.group(1))
+    assert target is not None, f"missing binding target for {function}"
+    arguments = re.findall(
+        r'"([a-z][a-z0-9_]*)"_a(?:\s*=\s*([A-Za-z0-9_:().+\-]+))?',
+        match.group(1),
+    )
+    return target.group(1), [(name, default or None) for name, default in arguments]
+
+
+def _assert_binding_parity(starter_source: str, reference_source: str) -> None:
+    for function in INTERFACES:
+        starter_target, starter_arguments = _binding_contract(starter_source, function)
+        reference_target, reference_arguments = _binding_contract(
+            reference_source, function
+        )
+        assert starter_target == f"tiny_llm_ext::{function}"
+        assert reference_target == f"tiny_llm_ext_ref::{function}"
+        assert starter_arguments == reference_arguments
+
+
+def _task_body(chapter: str, task: str) -> str:
+    match = re.search(
+        rf"^## {task}:.*?(?=^## Task |\Z)", chapter, re.MULTILINE | re.DOTALL
+    )
     assert match is not None
-    return re.findall(r'"([a-z][a-z0-9_]*)"_a', match.group(1))
+    return match.group(0)
+
+
+def _assert_task_pairs(chapter: str, task: str, pairs: set[tuple[str, str]]) -> None:
+    body = _task_body(chapter, task)
+    for filename, function in pairs:
+        assert filename in body, f"{task} does not name {filename} for {function}"
+        assert function in body, f"{task} does not name {function} in {filename}"
 
 
 def test_starter_and_reference_publish_the_same_learner_extension_functions():
@@ -251,9 +406,10 @@ def test_starter_and_reference_publish_the_same_learner_extension_functions():
         assert _header_declaration(
             "src/extensions/src/tiny_llm_ext.h", function
         ) == _header_declaration("src/extensions_ref/src/tiny_llm_ext.h", function)
-        assert _binding_arguments(
-            "src/extensions/bindings.cpp", function
-        ) == _binding_arguments("src/extensions_ref/bindings.cpp", function)
+    _assert_binding_parity(
+        _read("src/extensions/bindings.cpp"),
+        _read("src/extensions_ref/bindings.cpp"),
+    )
 
 
 def test_starter_cpp_stubs_are_registered_and_checkpoint_labeled():
@@ -308,12 +464,14 @@ def test_each_extension_task_names_the_exact_starter_functions_to_modify():
     for path, tasks in DOC_TASK_MARKERS.items():
         chapter = _read(path)
         for task, markers in tasks.items():
-            match = re.search(
-                rf"^## {task}:.*?(?=^## Task |\Z)", chapter, re.MULTILINE | re.DOTALL
-            )
-            assert match is not None
+            body = _task_body(chapter, task)
             for marker in markers:
-                assert marker in match.group(0)
+                assert marker in body
+
+    for path, tasks in EXTENSION_TASK_PAIRS.items():
+        chapter = _read(path)
+        for task, pairs in tasks.items():
+            _assert_task_pairs(chapter, task, pairs)
 
 
 def test_optional_grouped_moe_interface_remains_a_staged_reveal():
@@ -358,6 +516,76 @@ def test_cpp_fail_closed_guard_rejects_a_fake_success_body():
     assert fake_success != source
     with pytest.raises(AssertionError):
         _assert_checkpoint_call(fake_success, "rms_norm", "Week 2, Day 4")
+
+
+def test_built_starter_extension_fails_closed_for_every_public_operation(monkeypatch):
+    monkeypatch.syspath_prepend(str(ROOT / "src/extensions"))
+    sys.modules.pop("tiny_llm_ext", None)
+    extension = importlib.import_module("tiny_llm_ext")
+
+    scalar = mx.ones((1,), dtype=mx.float32)
+    calls = {
+        "quantized_matmul": lambda: extension.quantized_matmul(
+            scalar, scalar, 128, 4, scalar, scalar
+        ),
+        "rms_norm": lambda: extension.rms_norm(scalar, scalar, 1e-5),
+        "rope": lambda: extension.rope(scalar, scalar, 1, 10_000.0),
+        "swiglu": lambda: extension.swiglu(scalar, scalar),
+        "decode_attention": lambda: extension.decode_attention(
+            scalar, scalar, scalar, scalar, 1.0, False, False, 1, 1
+        ),
+        "paged_cache_update": lambda: extension.paged_cache_update(
+            scalar, scalar, 0, 0
+        ),
+        "quantized_embedding": lambda: extension.quantized_embedding(
+            scalar, scalar, scalar, scalar, 128, 4
+        ),
+        "paged_attention": lambda: extension.paged_attention(
+            scalar,
+            scalar,
+            scalar,
+            scalar,
+            scalar,
+            num_kv_heads=1,
+            num_heads=1,
+        ),
+    }
+    for function, (checkpoint, _) in INTERFACES.items():
+        with pytest.raises(
+            RuntimeError,
+            match=rf"^{re.escape(function)} is a starter stub; implement it in "
+            rf"{re.escape(checkpoint)}$",
+        ):
+            calls[function]()
+
+
+def test_binding_guard_rejects_a_changed_python_default():
+    source = _read("src/extensions/bindings.cpp")
+    changed_default = source.replace(
+        '"transpose_b"_a = false', '"transpose_b"_a = true', 1
+    )
+    assert changed_default != source
+    with pytest.raises(AssertionError):
+        _assert_binding_parity(
+            changed_default, _read("src/extensions_ref/bindings.cpp")
+        )
+
+
+def test_task_pair_guard_rejects_a_nonexistent_source_path():
+    path = "book/src/week2-04-fused-model-kernels.md"
+    source = _read(path)
+    wrong_path = source.replace(
+        "`Week2RMSNorm::eval_gpu` in `src/extensions/src/week2_kernels.cpp`",
+        "`Week2RMSNorm::eval_gpu` in `src/extensions/src/wrong.cpp`",
+        1,
+    )
+    assert wrong_path != source
+    with pytest.raises(AssertionError):
+        _assert_task_pairs(
+            wrong_path,
+            "Task 1",
+            EXTENSION_TASK_PAIRS[path]["Task 1"],
+        )
 
 
 def test_metal_guard_rejects_a_leaked_kernel_body():

--- a/tests_refsol/test_extension_interface_sync.py
+++ b/tests_refsol/test_extension_interface_sync.py
@@ -252,6 +252,10 @@ EXTENSION_TASK_PAIRS = {
                 "QuantizedEmbedding::eval_cpu",
             ),
             (
+                "src/extensions/src/quantized_matmul.cpp",
+                "QuantizedEmbedding::eval_gpu",
+            ),
+            (
                 "src/extensions/src/quantized_matmul.metal",
                 "quantized_embedding_w4a16_g128",
             ),
@@ -380,11 +384,61 @@ def _task_body(chapter: str, task: str) -> str:
     return match.group(0)
 
 
+def _functions_in_code_tokens(
+    tokens: list[str], expected_functions: set[str]
+) -> list[tuple[int, str]]:
+    functions = []
+    for index, token in enumerate(tokens):
+        for function in expected_functions:
+            if token == function or token.startswith(f"{function}("):
+                functions.append((index, function))
+                continue
+
+            if "::" not in function:
+                continue
+            owner, short_name = function.rsplit("::", 1)
+            if token == short_name and any(
+                previous.startswith(f"{owner}::") for previous in tokens[:index]
+            ):
+                functions.append((index, function))
+    return functions
+
+
 def _assert_task_pairs(chapter: str, task: str, pairs: set[tuple[str, str]]) -> None:
     body = _task_body(chapter, task)
-    for filename, function in pairs:
-        assert filename in body, f"{task} does not name {filename} for {function}"
-        assert function in body, f"{task} does not name {function} in {filename}"
+    expected_files = {filename for filename, _ in pairs}
+    expected_functions = {function for _, function in pairs}
+    associations: set[tuple[str, str]] = set()
+
+    blocks = re.split(r"\n\s*\n|(?=^\s*-\s)", body, flags=re.MULTILINE)
+    for block in blocks:
+        tokens = re.findall(r"`([^`\n]+)`", block)
+        files = []
+        for index, token in enumerate(tokens):
+            for filename in expected_files:
+                if token in {filename, Path(filename).name}:
+                    files.append((index, filename))
+        functions = _functions_in_code_tokens(tokens, expected_functions)
+
+        cursor = 0
+        for index, filename in files:
+            for function_index, function in functions:
+                if cursor <= function_index < index:
+                    associations.add((filename, function))
+            cursor = index + 1
+
+        if files and not any(
+            function_index < files[0][0] for function_index, _ in functions
+        ):
+            filename = files[-1][1]
+            for function_index, function in functions:
+                if function_index >= cursor:
+                    associations.add((filename, function))
+
+    missing = pairs - associations
+    assert not missing, (
+        f"{task} does not bind exact starter file/function pairs: {missing}"
+    )
 
 
 def test_starter_and_reference_publish_the_same_learner_extension_functions():
@@ -586,6 +640,40 @@ def test_task_pair_guard_rejects_a_nonexistent_source_path():
             "Task 1",
             EXTENSION_TASK_PAIRS[path]["Task 1"],
         )
+
+
+def test_task_pair_guard_rejects_cross_swapped_valid_week_3_day_4_pairs():
+    path = "book/src/week3-04-paged-attention-part2.md"
+    source = _read(path)
+    paged_swapped = source.replace(
+        "`tiny_llm_ext::paged_attention`, `PagedAttention::eval_cpu`, and\n"
+        "  `PagedAttention::eval_gpu` in `src/extensions/src/paged_attention.cpp`;",
+        "`tiny_llm_ext::paged_attention` and `PagedAttention::eval_cpu` in\n"
+        "  `src/extensions/src/paged_attention.cpp`; `PagedAttention::eval_gpu` in\n"
+        "  `src/extensions/src/quantized_matmul.cpp`;",
+        1,
+    )
+    assert paged_swapped != source
+    cross_swapped = paged_swapped.replace(
+        "`tiny_llm_ext::quantized_embedding` plus\n"
+        "`QuantizedEmbedding::eval_cpu`/`eval_gpu` in\n"
+        "`src/extensions/src/quantized_matmul.cpp`,",
+        "`tiny_llm_ext::quantized_embedding` in\n"
+        "`src/extensions/src/quantized_matmul.cpp` plus\n"
+        "`QuantizedEmbedding::eval_cpu` and `QuantizedEmbedding::eval_gpu` in\n"
+        "`src/extensions/src/paged_attention.cpp`,",
+        1,
+    )
+    assert cross_swapped != paged_swapped
+
+    pairs = EXTENSION_TASK_PAIRS[path]["Task 2"]
+    body = _task_body(cross_swapped, "Task 2")
+    for filename, function in pairs:
+        assert filename in body
+        assert function in body
+
+    with pytest.raises(AssertionError):
+        _assert_task_pairs(cross_swapped, "Task 2", pairs)
 
 
 def test_metal_guard_rejects_a_leaked_kernel_body():

--- a/tests_refsol/test_extension_interface_sync.py
+++ b/tests_refsol/test_extension_interface_sync.py
@@ -10,22 +10,22 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 
 INTERFACES = {
-    "quantized_matmul": ("Week 2, Day 3", "quantized_matmul.cpp"),
-    "rms_norm": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "rope": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "swiglu": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "decode_attention": ("Week 2, Day 5", "week2_kernels.cpp"),
+    "quantized_matmul": ("Week 2, Day 2", "quantized_matmul.cpp"),
+    "rms_norm": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "rope": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "swiglu": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "decode_attention": ("Week 2, Day 4", "week2_kernels.cpp"),
     "paged_cache_update": ("Week 3, Day 3", "paged_attention.cpp"),
     "quantized_embedding": ("Week 3, Day 4", "quantized_matmul.cpp"),
     "paged_attention": ("Week 3, Day 4", "paged_attention.cpp"),
 }
 
 PRIMITIVE_CLASSES = {
-    "QuantizedMatmul": ("Week 2, Day 3", "quantized_matmul.cpp"),
-    "Week2RMSNorm": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "Week2RoPE": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "Week2SwiGLU": ("Week 2, Day 4", "week2_kernels.cpp"),
-    "Week2DecodeAttention": ("Week 2, Day 5", "week2_kernels.cpp"),
+    "QuantizedMatmul": ("Week 2, Day 2", "quantized_matmul.cpp"),
+    "Week2RMSNorm": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "Week2RoPE": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "Week2SwiGLU": ("Week 2, Day 3", "week2_kernels.cpp"),
+    "Week2DecodeAttention": ("Week 2, Day 4", "week2_kernels.cpp"),
     "PagedCacheUpdate": ("Week 3, Day 3", "paged_attention.cpp"),
     "QuantizedEmbedding": ("Week 3, Day 4", "quantized_matmul.cpp"),
     "PagedAttention": ("Week 3, Day 4", "paged_attention.cpp"),
@@ -33,18 +33,18 @@ PRIMITIVE_CLASSES = {
 
 METAL_CHECKPOINTS = {
     "quantized_matmul.metal": {
-        "quantized_matmul_vanilla_w4a16_g128": "Week 2, Day 3",
-        "quantized_matvec_x4_fast_w4a16_g128": "Week 2, Day 3",
-        "quantized_matmul_simdgroup_w4a16_g128": "Week 2, Day 6",
-        "quantized_matmul_simdgroup_splitk_w4a16_g128": "Week 2, Day 7",
-        "quantized_matmul_splitk_reduce": "Week 2, Day 7",
+        "quantized_matmul_vanilla_w4a16_g128": "Week 2, Day 2",
+        "quantized_matvec_x4_fast_w4a16_g128": "Week 2, Day 2",
+        "quantized_matmul_simdgroup_w4a16_g128": "Week 2, Day 5",
+        "quantized_matmul_simdgroup_splitk_w4a16_g128": "Week 2, Day 6",
+        "quantized_matmul_splitk_reduce": "Week 2, Day 6",
         "quantized_embedding_w4a16_g128": "Week 3, Day 4",
     },
     "week2_kernels.metal": {
-        "week2_rms_norm": "Week 2, Day 4",
-        "week2_rope": "Week 2, Day 4",
-        "week2_swiglu": "Week 2, Day 4",
-        "week2_decode_attention": "Week 2, Day 5",
+        "week2_rms_norm": "Week 2, Day 3",
+        "week2_rope": "Week 2, Day 3",
+        "week2_swiglu": "Week 2, Day 3",
+        "week2_decode_attention": "Week 2, Day 4",
     },
     "paged_attention.metal": {
         "paged_cache_update_kernel": "Week 3, Day 3",
@@ -55,7 +55,7 @@ METAL_CHECKPOINTS = {
 }
 
 DOC_TASK_MARKERS = {
-    "book/src/week2-03-quantized-matvec.md": {
+    "book/src/week2-02-benchmark-quantize.md": {
         "Task 1": {"QuantizedWeights.from_mlx_layer", "QuantizedEmbedding.__call__"},
         "Task 2": {"tiny_llm_ext::quantized_matmul", "QuantizedMatmul::eval_cpu"},
         "Task 3": {
@@ -65,7 +65,7 @@ DOC_TASK_MARKERS = {
         },
         "Task 4": {"Qwen3ModelWeek2.__init__", "Qwen3MultiHeadAttention.__call__"},
     },
-    "book/src/week2-04-fused-model-kernels.md": {
+    "book/src/week2-03-fused-model-kernels.md": {
         "Task 1": {
             "tiny_llm_ext::rms_norm",
             "Week2RMSNorm::eval_gpu",
@@ -75,7 +75,7 @@ DOC_TASK_MARKERS = {
         "Task 3": {"tiny_llm_ext::swiglu", "Week2SwiGLU::eval_gpu", "week2_swiglu"},
         "Task 4": {"Qwen3ModelWeek2.__init__", "Qwen3MLP.__call__"},
     },
-    "book/src/week2-05-decode-attention.md": {
+    "book/src/week2-04-decode-attention.md": {
         "Task 1": {"scaled_dot_product_attention"},
         "Task 2": {
             "tiny_llm_ext::decode_attention",
@@ -84,7 +84,7 @@ DOC_TASK_MARKERS = {
         },
         "Task 3": {"Qwen3MultiHeadAttention.__call__", "decode_attention_custom"},
     },
-    "book/src/week2-06-simd-matrix-prefill.md": {
+    "book/src/week2-05-simd-matrix-prefill.md": {
         "Task 1": {
             "QuantizedMatmul::eval_gpu",
             "quantized_matmul_simdgroup_w4a16_g128",
@@ -94,7 +94,7 @@ DOC_TASK_MARKERS = {
         "Task 4": {"Qwen3ModelWeek2.__call__"},
         "Task 5": {"QuantizedMatmul::eval_gpu", "Qwen3ModelWeek2.__call__"},
     },
-    "book/src/week2-07-split-k-prefill.md": {
+    "book/src/week2-06-split-k-prefill.md": {
         "Task 1": {"quantized_matmul_simdgroup_w4a16_g128"},
         "Task 2": {"quantized_matmul_simdgroup_splitk_w4a16_g128"},
         "Task 3": {"QuantizedMatmul::eval_gpu"},
@@ -141,7 +141,7 @@ DOC_TASK_MARKERS = {
 }
 
 EXTENSION_TASK_PAIRS = {
-    "book/src/week2-03-quantized-matvec.md": {
+    "book/src/week2-02-benchmark-quantize.md": {
         "Task 2": {
             (
                 "src/extensions/src/quantized_matmul.cpp",
@@ -161,7 +161,7 @@ EXTENSION_TASK_PAIRS = {
             ),
         },
     },
-    "book/src/week2-04-fused-model-kernels.md": {
+    "book/src/week2-03-fused-model-kernels.md": {
         "Task 1": {
             ("src/extensions/src/week2_kernels.cpp", "tiny_llm_ext::rms_norm"),
             ("src/extensions/src/week2_kernels.cpp", "Week2RMSNorm::eval_cpu"),
@@ -181,7 +181,7 @@ EXTENSION_TASK_PAIRS = {
             ("src/extensions/src/week2_kernels.metal", "week2_swiglu"),
         },
     },
-    "book/src/week2-05-decode-attention.md": {
+    "book/src/week2-04-decode-attention.md": {
         "Task 2": {
             (
                 "src/extensions/src/week2_kernels.cpp",
@@ -563,13 +563,13 @@ def test_optional_grouped_moe_interface_remains_a_staged_reveal():
 def test_cpp_fail_closed_guard_rejects_a_fake_success_body():
     source = _read("src/extensions/src/week2_kernels.cpp")
     fake_success = source.replace(
-        'checkpoint_todo("rms_norm", "Week 2, Day 4");',
+        'checkpoint_todo("rms_norm", "Week 2, Day 3");',
         "return mx::zeros({1});",
         1,
     )
     assert fake_success != source
     with pytest.raises(AssertionError):
-        _assert_checkpoint_call(fake_success, "rms_norm", "Week 2, Day 4")
+        _assert_checkpoint_call(fake_success, "rms_norm", "Week 2, Day 3")
 
 
 def test_built_starter_extension_fails_closed_for_every_public_operation(monkeypatch):
@@ -626,7 +626,7 @@ def test_binding_guard_rejects_a_changed_python_default():
 
 
 def test_task_pair_guard_rejects_a_nonexistent_source_path():
-    path = "book/src/week2-04-fused-model-kernels.md"
+    path = "book/src/week2-03-fused-model-kernels.md"
     source = _read(path)
     wrong_path = source.replace(
         "`Week2RMSNorm::eval_gpu` in `src/extensions/src/week2_kernels.cpp`",

--- a/tests_refsol/test_extension_interface_sync.py
+++ b/tests_refsol/test_extension_interface_sync.py
@@ -1,6 +1,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -140,6 +142,72 @@ def _read(path: str) -> str:
     return (ROOT / path).read_text()
 
 
+def _strip_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def _cpp_function_body(source: str, symbol: str) -> str:
+    source = _strip_comments(source)
+    definitions = list(
+        re.finditer(rf"\b(?:mx::array|void)\s+{re.escape(symbol)}\s*\(", source)
+    )
+    assert len(definitions) == 1, f"expected one definition of {symbol}"
+
+    opening_brace = source.find("{", definitions[0].end())
+    assert opening_brace != -1, f"missing body for {symbol}"
+    assert ";" not in source[definitions[0].end() : opening_brace], (
+        f"found a declaration instead of a definition for {symbol}"
+    )
+
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace + 1 : index]
+    raise AssertionError(f"unterminated body for {symbol}")
+
+
+def _normalized_cpp_body(body: str) -> str:
+    return " ".join(body.split())
+
+
+def _learner_owned_cpp_definitions(source: str) -> set[str]:
+    source = _strip_comments(source)
+    wrappers = set(re.findall(r"\bmx::array\s+([a-z][a-z0-9_]*)\s*\(", source))
+    evaluators = set(
+        re.findall(r"\bvoid\s+([A-Z][A-Za-z0-9_]*::eval_(?:cpu|gpu))\s*\(", source)
+    )
+    return wrappers | evaluators
+
+
+def _assert_checkpoint_call(source: str, symbol: str, checkpoint: str) -> None:
+    assert _normalized_cpp_body(_cpp_function_body(source, symbol)) == (
+        f'checkpoint_todo("{symbol}", "{checkpoint}");'
+    )
+
+
+def _assert_checkpoint_helper_throws(source: str) -> None:
+    assert "[[noreturn]] void checkpoint_todo" in _strip_comments(source)
+    assert _normalized_cpp_body(_cpp_function_body(source, "checkpoint_todo")) == (
+        'throw std::runtime_error(std::string(function) + " is a starter stub; '
+        'implement it in " + checkpoint);'
+    )
+
+
+def _assert_metal_scaffold_only(source: str) -> None:
+    executable = _strip_comments(source)
+    assert "[[kernel]]" not in executable
+    executable = re.sub(r"^\s*#.*$", "", executable, flags=re.MULTILINE)
+    executable = re.sub(r"\busing\s+namespace\s+metal\s*;", "", executable)
+    assert not executable.strip(), (
+        "starter Metal file contains executable declarations or bodies"
+    )
+
+
 def _header_functions(path: str) -> set[str]:
     return set(re.findall(r"mx::array\s+([a-z][a-z0-9_]*)\s*\(", _read(path)))
 
@@ -191,22 +259,36 @@ def test_starter_and_reference_publish_the_same_learner_extension_functions():
 def test_starter_cpp_stubs_are_registered_and_checkpoint_labeled():
     cmake = _read("src/extensions/CMakeLists.txt")
     header = _read("src/extensions/src/tiny_llm_ext.h")
+    starter_cpp_files = {filename for _, filename in INTERFACES.values()} | {
+        filename for _, filename in PRIMITIVE_CLASSES.values()
+    }
+    actual_definitions = set()
+    for filename in starter_cpp_files:
+        actual_definitions |= _learner_owned_cpp_definitions(
+            _read(f"src/extensions/src/{filename}")
+        )
+    expected_definitions = set(INTERFACES)
+    for primitive in PRIMITIVE_CLASSES:
+        expected_definitions.add(f"{primitive}::eval_cpu")
+        expected_definitions.add(f"{primitive}::eval_gpu")
+    assert actual_definitions == expected_definitions
+
     for function, (checkpoint, filename) in INTERFACES.items():
         source = _read(f"src/extensions/src/{filename}")
-        assert function in source
+        _assert_checkpoint_call(source, function, checkpoint)
         assert checkpoint in source
         assert f"src/{filename}" in cmake
 
     for primitive, (checkpoint, filename) in PRIMITIVE_CLASSES.items():
         source = _read(f"src/extensions/src/{filename}")
         assert f"class {primitive}" in header
-        assert f"{primitive}::eval_cpu" in source
-        assert f"{primitive}::eval_gpu" in source
+        _assert_checkpoint_call(source, f"{primitive}::eval_cpu", checkpoint)
+        _assert_checkpoint_call(source, f"{primitive}::eval_gpu", checkpoint)
         assert checkpoint in source
 
     for filename in {filename for _, filename in INTERFACES.values()}:
         source = _read(f"src/extensions/src/{filename}")
-        assert "starter stub" in source
+        _assert_checkpoint_helper_throws(source)
         assert "get_kernel" not in source
         assert "dispatch_thread" not in source
 
@@ -219,6 +301,7 @@ def test_starter_metal_stubs_name_each_learner_owned_kernel_and_checkpoint():
         for kernel, checkpoint in kernels.items():
             assert kernel in source
             assert checkpoint in source
+        _assert_metal_scaffold_only(source)
 
 
 def test_each_extension_task_names_the_exact_starter_functions_to_modify():
@@ -234,13 +317,61 @@ def test_each_extension_task_names_the_exact_starter_functions_to_modify():
 
 
 def test_optional_grouped_moe_interface_remains_a_staged_reveal():
-    starter_header = _read("src/extensions/src/tiny_llm_ext.h")
     reference_header = _read("src/extensions_ref/src/tiny_llm_ext.h")
     optional_chapter = _read("book/src/week3-optional-moe.md")
-    assert "grouped_quantized_matmul" not in starter_header
+
+    starter_surfaces = [
+        "src/extensions/src/tiny_llm_ext.h",
+        "src/extensions/bindings.cpp",
+        "src/extensions/CMakeLists.txt",
+        *(
+            str(path.relative_to(ROOT))
+            for path in (ROOT / "src/extensions/src").glob("*.cpp")
+        ),
+        *(
+            str(path.relative_to(ROOT))
+            for path in (ROOT / "src/extensions/src").glob("*.metal")
+        ),
+    ]
+    withheld_symbols = {
+        "grouped_quantized_matmul",
+        "quantized_matvec_x2",
+        "quantized_matvec_x8",
+    }
+    for path in starter_surfaces:
+        source = _read(path)
+        for symbol in withheld_symbols:
+            assert symbol not in source, f"{symbol} leaked into {path}"
+
     assert "grouped_quantized_matmul" not in reference_header
     assert "intentionally not predeclared" in optional_chapter
     assert "`grouped_quantized_matmul` Metal kernel" in optional_chapter
+
+
+def test_cpp_fail_closed_guard_rejects_a_fake_success_body():
+    source = _read("src/extensions/src/week2_kernels.cpp")
+    fake_success = source.replace(
+        'checkpoint_todo("rms_norm", "Week 2, Day 4");',
+        "return mx::zeros({1});",
+        1,
+    )
+    assert fake_success != source
+    with pytest.raises(AssertionError):
+        _assert_checkpoint_call(fake_success, "rms_norm", "Week 2, Day 4")
+
+
+def test_metal_guard_rejects_a_leaked_kernel_body():
+    source = _read("src/extensions/src/week2_kernels.metal")
+    leaked_kernel = (
+        source
+        + """
+    [[kernel]] void week2_rms_norm(device float *output [[buffer(0)]]) {
+        output[0] = 0.0f;
+    }
+    """
+    )
+    with pytest.raises(AssertionError):
+        _assert_metal_scaffold_only(leaked_kernel)
 
 
 def test_setup_distinguishes_the_runnable_demo_from_future_stubs():

--- a/tests_refsol/test_extension_interface_sync.py
+++ b/tests_refsol/test_extension_interface_sync.py
@@ -1,0 +1,249 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INTERFACES = {
+    "quantized_matmul": ("Week 2, Day 3", "quantized_matmul.cpp"),
+    "rms_norm": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "rope": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "swiglu": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "decode_attention": ("Week 2, Day 5", "week2_kernels.cpp"),
+    "paged_cache_update": ("Week 3, Day 3", "paged_attention.cpp"),
+    "quantized_embedding": ("Week 3, Day 4", "quantized_matmul.cpp"),
+    "paged_attention": ("Week 3, Day 4", "paged_attention.cpp"),
+}
+
+PRIMITIVE_CLASSES = {
+    "QuantizedMatmul": ("Week 2, Day 3", "quantized_matmul.cpp"),
+    "Week2RMSNorm": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "Week2RoPE": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "Week2SwiGLU": ("Week 2, Day 4", "week2_kernels.cpp"),
+    "Week2DecodeAttention": ("Week 2, Day 5", "week2_kernels.cpp"),
+    "PagedCacheUpdate": ("Week 3, Day 3", "paged_attention.cpp"),
+    "QuantizedEmbedding": ("Week 3, Day 4", "quantized_matmul.cpp"),
+    "PagedAttention": ("Week 3, Day 4", "paged_attention.cpp"),
+}
+
+METAL_CHECKPOINTS = {
+    "quantized_matmul.metal": {
+        "quantized_matmul_vanilla_w4a16_g128": "Week 2, Day 3",
+        "quantized_matvec_x4_fast_w4a16_g128": "Week 2, Day 3",
+        "quantized_matmul_simdgroup_w4a16_g128": "Week 2, Day 6",
+        "quantized_matmul_simdgroup_splitk_w4a16_g128": "Week 2, Day 7",
+        "quantized_matmul_splitk_reduce": "Week 2, Day 7",
+        "quantized_embedding_w4a16_g128": "Week 3, Day 4",
+    },
+    "week2_kernels.metal": {
+        "week2_rms_norm": "Week 2, Day 4",
+        "week2_rope": "Week 2, Day 4",
+        "week2_swiglu": "Week 2, Day 4",
+        "week2_decode_attention": "Week 2, Day 5",
+    },
+    "paged_attention.metal": {
+        "paged_cache_update_kernel": "Week 3, Day 3",
+        "paged_attention_decode": "Week 3, Day 4",
+        "paged_attention_scalar_f32": "Week 3, Day 4",
+        "paged_attention_mma_bf16_d128": "Week 3, Day 5",
+    },
+}
+
+DOC_TASK_MARKERS = {
+    "book/src/week2-03-quantized-matvec.md": {
+        "Task 1": {"QuantizedWeights.from_mlx_layer", "QuantizedEmbedding.__call__"},
+        "Task 2": {"tiny_llm_ext::quantized_matmul", "QuantizedMatmul::eval_cpu"},
+        "Task 3": {
+            "QuantizedMatmul::eval_gpu",
+            "quantized_matmul_vanilla_w4a16_g128",
+            "quantized_matvec_x4_fast_w4a16_g128",
+        },
+        "Task 4": {"Qwen3ModelWeek2.__init__", "Qwen3MultiHeadAttention.__call__"},
+    },
+    "book/src/week2-04-fused-model-kernels.md": {
+        "Task 1": {
+            "tiny_llm_ext::rms_norm",
+            "Week2RMSNorm::eval_gpu",
+            "week2_rms_norm",
+        },
+        "Task 2": {"tiny_llm_ext::rope", "Week2RoPE::eval_gpu", "week2_rope"},
+        "Task 3": {"tiny_llm_ext::swiglu", "Week2SwiGLU::eval_gpu", "week2_swiglu"},
+        "Task 4": {"Qwen3ModelWeek2.__init__", "Qwen3MLP.__call__"},
+    },
+    "book/src/week2-05-decode-attention.md": {
+        "Task 1": {"scaled_dot_product_attention"},
+        "Task 2": {
+            "tiny_llm_ext::decode_attention",
+            "Week2DecodeAttention::eval_gpu",
+            "week2_decode_attention",
+        },
+        "Task 3": {"Qwen3MultiHeadAttention.__call__", "decode_attention_custom"},
+    },
+    "book/src/week2-06-simd-matrix-prefill.md": {
+        "Task 1": {
+            "QuantizedMatmul::eval_gpu",
+            "quantized_matmul_simdgroup_w4a16_g128",
+        },
+        "Task 2": {"quantized_matmul_simdgroup_w4a16_g128"},
+        "Task 3": {"quantized_matmul_simdgroup_w4a16_g128"},
+        "Task 4": {"Qwen3ModelWeek2.__call__"},
+        "Task 5": {"QuantizedMatmul::eval_gpu", "Qwen3ModelWeek2.__call__"},
+    },
+    "book/src/week2-07-split-k-prefill.md": {
+        "Task 1": {"quantized_matmul_simdgroup_w4a16_g128"},
+        "Task 2": {"quantized_matmul_simdgroup_splitk_w4a16_g128"},
+        "Task 3": {"QuantizedMatmul::eval_gpu"},
+        "Task 4": {"quantized_matmul_splitk_reduce", "QuantizedMatmul::eval_gpu"},
+    },
+    "book/src/week3-03-paged-attention-part1.md": {
+        "Task 1": {
+            "TinyKvPagedPool.__init__",
+            "tiny_llm_ext::paged_cache_update",
+            "paged_cache_update_kernel",
+        },
+        "Task 2": {"TinyKvPagedCache.__init__", "update_and_fetch"},
+        "Task 3": {"TinyKvPagedCache.gather_dense", "Qwen3ModelWeek3.create_kv_cache"},
+    },
+    "book/src/week3-04-paged-attention-part2.md": {
+        "Task 1": {"TinyKvPagedCache.block_table", "Request.try_prefill"},
+        "Task 2": {
+            "tiny_llm_ext::paged_attention",
+            "PagedAttention::eval_gpu",
+            "paged_attention_decode",
+            "paged_attention_scalar_f32",
+            "tiny_llm_ext::quantized_embedding",
+            "quantized_embedding_w4a16_g128",
+        },
+        "Task 3": {"Qwen3MultiHeadAttention.__call__", "Qwen3ModelWeek3.__call__"},
+        "Task 4": {"Request.try_prefill", "batch_generate"},
+    },
+    "book/src/week3-05-flash-attention.md": {
+        "Task 1": {"paged_attention_mma_bf16_d128"},
+        "Task 2": {"paged_attention_mma_bf16_d128"},
+        "Task 3": {"PagedAttention::eval_gpu", "paged_attention_mma_bf16_d128"},
+        "Task 4": {"Qwen3MultiHeadAttention.__call__", "PagedAttention::eval_gpu"},
+    },
+    "book/src/week3-optional-moe.md": {
+        "Task 1": {"tiny_llm_ext::grouped_quantized_matmul", "grouped_expert_linear"},
+        "Task 2": {"route_topk"},
+        "Task 3": {"Moe.__init__", "Moe.__call__"},
+        "Task 4": {
+            "is_qwen3_moe_sparse_layer",
+            "Qwen3ModelWeek3.__init__",
+            "dispatch_model",
+        },
+    },
+}
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def _header_functions(path: str) -> set[str]:
+    return set(re.findall(r"mx::array\s+([a-z][a-z0-9_]*)\s*\(", _read(path)))
+
+
+def _header_declaration(path: str, function: str) -> str:
+    source = _read(path)
+    match = re.search(rf"mx::array\s+{function}\s*\(.*?\);", source, re.DOTALL)
+    assert match is not None
+    declaration = re.sub(r"//.*", "", match.group(0))
+    declaration = re.sub(r"\s+", " ", declaration).strip()
+    return re.sub(r"\s+([);,])", r"\1", declaration)
+
+
+def _binding_functions(path: str) -> set[str]:
+    return set(re.findall(r'm\.def\("([a-z][a-z0-9_]*)"', _read(path)))
+
+
+def _binding_arguments(path: str, function: str) -> list[str]:
+    source = _read(path)
+    match = re.search(rf'm\.def\("{function}"(.*?)\);', source, re.DOTALL)
+    assert match is not None
+    return re.findall(r'"([a-z][a-z0-9_]*)"_a', match.group(1))
+
+
+def test_starter_and_reference_publish_the_same_learner_extension_functions():
+    expected = set(INTERFACES)
+    assert _header_functions("src/extensions_ref/src/tiny_llm_ext.h") == expected
+    assert _header_functions("src/extensions/src/tiny_llm_ext.h") == expected
+
+    reference_bindings = _binding_functions("src/extensions_ref/bindings.cpp") - {
+        "load_library"
+    }
+    starter_bindings = _binding_functions("src/extensions/bindings.cpp") - {
+        "load_library",
+        "axpby",
+    }
+    assert reference_bindings == expected
+    assert starter_bindings == expected
+
+    for function in expected:
+        assert _header_declaration(
+            "src/extensions/src/tiny_llm_ext.h", function
+        ) == _header_declaration("src/extensions_ref/src/tiny_llm_ext.h", function)
+        assert _binding_arguments(
+            "src/extensions/bindings.cpp", function
+        ) == _binding_arguments("src/extensions_ref/bindings.cpp", function)
+
+
+def test_starter_cpp_stubs_are_registered_and_checkpoint_labeled():
+    cmake = _read("src/extensions/CMakeLists.txt")
+    header = _read("src/extensions/src/tiny_llm_ext.h")
+    for function, (checkpoint, filename) in INTERFACES.items():
+        source = _read(f"src/extensions/src/{filename}")
+        assert function in source
+        assert checkpoint in source
+        assert f"src/{filename}" in cmake
+
+    for primitive, (checkpoint, filename) in PRIMITIVE_CLASSES.items():
+        source = _read(f"src/extensions/src/{filename}")
+        assert f"class {primitive}" in header
+        assert f"{primitive}::eval_cpu" in source
+        assert f"{primitive}::eval_gpu" in source
+        assert checkpoint in source
+
+    for filename in {filename for _, filename in INTERFACES.values()}:
+        source = _read(f"src/extensions/src/{filename}")
+        assert "starter stub" in source
+        assert "get_kernel" not in source
+        assert "dispatch_thread" not in source
+
+
+def test_starter_metal_stubs_name_each_learner_owned_kernel_and_checkpoint():
+    cmake = _read("src/extensions/CMakeLists.txt")
+    for filename, kernels in METAL_CHECKPOINTS.items():
+        source = _read(f"src/extensions/src/{filename}")
+        assert f"src/{filename}" in cmake
+        for kernel, checkpoint in kernels.items():
+            assert kernel in source
+            assert checkpoint in source
+
+
+def test_each_extension_task_names_the_exact_starter_functions_to_modify():
+    for path, tasks in DOC_TASK_MARKERS.items():
+        chapter = _read(path)
+        for task, markers in tasks.items():
+            match = re.search(
+                rf"^## {task}:.*?(?=^## Task |\Z)", chapter, re.MULTILINE | re.DOTALL
+            )
+            assert match is not None
+            for marker in markers:
+                assert marker in match.group(0)
+
+
+def test_optional_grouped_moe_interface_remains_a_staged_reveal():
+    starter_header = _read("src/extensions/src/tiny_llm_ext.h")
+    reference_header = _read("src/extensions_ref/src/tiny_llm_ext.h")
+    optional_chapter = _read("book/src/week3-optional-moe.md")
+    assert "grouped_quantized_matmul" not in starter_header
+    assert "grouped_quantized_matmul" not in reference_header
+    assert "intentionally not predeclared" in optional_chapter
+    assert "`grouped_quantized_matmul` Metal kernel" in optional_chapter
+
+
+def test_setup_distinguishes_the_runnable_demo_from_future_stubs():
+    setup = _read("book/src/week1-07-sampling-prepare.md")
+    assert "fail-closed starter stubs" in setup
+    assert "this setup check calls\nonly `axpby`" in setup


### PR DESCRIPTION
## Why

Published learner tasks depended on extension interfaces that existed only in the reference tree. The starter could therefore compile while silently drifting from the functions learners were expected to implement.

## What changed

- Added compile-safe, fail-closed starter declarations, bindings, C++ stubs, Metal scaffolds, and build registration for the required interface map: Week 2 Day 2 `quantized_matmul`; Day 3 `rms_norm`/`rope`/`swiglu`; Day 4 `decode_attention`; Week 3 Day 3 `paged_cache_update`; and Day 4 `quantized_embedding`/`paged_attention`. Week 2 Days 5–6 and Week 3 Day 5 extend the existing matmul/attention schedules without adding public APIs.
- Updated every affected learner task to name the exact starter functions and files it modifies. Optional `grouped_quantized_matmul` and the experimental x2/x8 matvec variants remain intentionally withheld at their staged reveals.
- Added a regression that checks all public wrappers and evaluators, checkpoint-specific fail-closed behavior through the built starter, binding parity/defaults, exact learner file/function pairs, Metal scaffolds, withheld interfaces, and five mutation controls including a valid-pair cross-swap.

## Review note

This is a new current-main port of the reviewed `7b59ee0` contract; stale PR #218 and its branch were not modified. The assigned base advanced `00dbf5c` → `10e96db` → `5e9e67d`; both intervening commits are preserved, and runtime/reference/benchmark/artifact/config bytes match `5e9e67d` except the starter-only CMake registration in scope. Historical test-selector numbers remain unchanged even where live chapter names shifted.

Please focus on exact interface parity, checkpoint ownership, fail-closed drift guards, and whether any starter scaffold reveals solution logic.

AI-Assisted: GPT-5.6 Sol + Forge
