### PR TITLE
Week 4 feat1: agent loop + tool protocol (tool catalog hash)

### DIFF
--- a/src/tiny_llm_ref/agent/__init__.py
+++ b/src/tiny_llm_ref/agent/__init__.py
@@ -35,9 +35,11 @@ from .loop import AgentEvent, AgentLimits, AgentRun, run_agent
 from .protocol import (
     AgentError,
     FinalAction,
+    TOOL_CATALOG_HASH,
     ToolAction,
     build_system_prompt,
     parse_action,
+    tool_catalog_hash,
 )
 from .recovery import (
     Checkpoint,
@@ -82,6 +84,7 @@ __all__ = [
     "SessionLog",
     "SessionStore",
     "StaticHeldOutGrader",
+    "TOOL_CATALOG_HASH",
     "StagedTask",
     "SteeringHandle",
     "ToolAction",
@@ -98,6 +101,7 @@ __all__ = [
     "compact_messages",
     "generate_response",
     "evaluate_task",
+    "tool_catalog_hash",
     "initial_messages",
     "memory_session",
     "parse_action",

--- a/src/tiny_llm_ref/agent/protocol.py
+++ b/src/tiny_llm_ref/agent/protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -32,6 +33,28 @@ class ToolAction:
 AgentAction = FinalAction | ToolAction
 
 
+def tool_catalog_hash(available_tools: frozenset[str] | None) -> str:
+    """Stable content hash of the enabled tool schema catalog.
+
+    The checkpoint validity rule binds a KV checkpoint to the exact schema
+    set the model saw.  Changing the tool set changes the hash, which
+    invalidates every continuation that assumed the old schema set.
+    """
+
+    if available_tools is None:
+        return hashlib.sha256(b"all-tools").hexdigest()
+    catalog = {
+        tool: {
+            "required": sorted(TOOL_FIELDS[tool][0]),
+            "optional": sorted(TOOL_FIELDS[tool][1]),
+        }
+        for tool in sorted(available_tools)
+        if tool in TOOL_FIELDS
+    }
+    payload = json.dumps(catalog, ensure_ascii=True, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 TOOL_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
     "list_files": (frozenset(), frozenset({"path"})),
     "read_file": (frozenset({"path"}), frozenset()),
@@ -39,6 +62,9 @@ TOOL_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
     "edit_file": (frozenset({"path", "old", "new"}), frozenset()),
     "run_command": (frozenset({"argv"}), frozenset()),
 }
+
+
+TOOL_CATALOG_HASH = tool_catalog_hash(frozenset(TOOL_FIELDS))
 
 
 def parse_action(
@@ -115,8 +141,7 @@ def build_system_prompt(workspace: Workspace) -> str:
     if workspace.policy.allowed_commands:
         lines.append("The operator allowed only these exact command arrays:")
         lines += [
-            json.dumps(list(command))
-            for command in workspace.policy.allowed_commands
+            json.dumps(list(command)) for command in workspace.policy.allowed_commands
         ]
         lines.append('Use: {"tool":"run_command","argv":["exact","arguments"]}')
     else:

--- a/tests_refsol/test_week_4_day_1.py
+++ b/tests_refsol/test_week_4_day_1.py
@@ -172,3 +172,57 @@ def test_task_4_stops_at_the_step_budget(tmp_path, monkeypatch):
     assert result.reason == "step_limit"
     assert len(result.events) == 2
     assert len(workspace.executed) == 2
+
+
+def responses(*items):
+    """Return scripted model responses for loop behavior tests."""
+
+    queue = iter(items)
+    return lambda messages: next(queue)
+
+
+def test_task_5_agent_observes_then_finishes(tmp_path):
+    from .tiny_llm_base import ToolPolicy, Workspace
+
+    (tmp_path / "README.md").write_text("hello", encoding="utf-8")
+    workspace = Workspace(ToolPolicy(tmp_path))
+    generate = responses(
+        '{"tool":"read_file","path":"README.md"}',
+        '{"final":"inspected README"}',
+    )
+
+    result = run_agent("inspect the project", generate, workspace)
+
+    assert result.completed
+    assert result.final == "inspected README"
+    assert result.reason == "completed"
+    assert len(result.events) == 2
+
+
+def test_task_6_agent_recovers_from_invalid_json(tmp_path):
+    from .tiny_llm_base import ToolPolicy, Workspace
+
+    workspace = Workspace(ToolPolicy(tmp_path))
+    generate = responses("not json", '{"final":"recovered"}')
+
+    result = run_agent("inspect the project", generate, workspace)
+
+    assert result.completed
+    assert result.events[0].result.startswith("error:")
+
+
+def test_task_7_agent_stops_repeated_actions(tmp_path):
+    from .tiny_llm_base import ToolPolicy, Workspace
+
+    workspace = Workspace(ToolPolicy(tmp_path))
+    generate = responses(*['{"tool":"list_files"}'] * 3)
+
+    result = run_agent(
+        "inspect the project",
+        generate,
+        workspace,
+        AgentLimits(max_steps=5, max_identical_actions=2),
+    )
+
+    assert not result.completed
+    assert result.reason == "repeated_action_limit"

--- a/tests_refsol/test_week_4_day_2.py
+++ b/tests_refsol/test_week_4_day_2.py
@@ -125,3 +125,30 @@ def test_task_2_rejects_a_known_but_disabled_tool():
             '{"tool":"write_file","path":"x","content":"y"}',
             read_only.available_tools,
         )
+
+
+def test_task_3_tool_catalog_hash_is_stable_and_schema_bound():
+    from .tiny_llm_base import tool_catalog_hash
+
+    same = tool_catalog_hash(frozenset({"read_file", "list_files"}))
+    assert same == tool_catalog_hash(frozenset({"read_file", "list_files"}))
+    assert tool_catalog_hash(frozenset({"read_file"})) != same
+    assert tool_catalog_hash(frozenset({"read_file", "write_file"})) != same
+
+
+def test_task_3_enabled_tools_change_the_catalog_hash():
+    from .tiny_llm_base import tool_catalog_hash
+
+    read_only = tool_catalog_hash(frozenset({"read_file"}))
+    writable = tool_catalog_hash(frozenset({"read_file", "write_file"}))
+    assert read_only != writable
+
+
+def test_task_3_catalog_hash_covers_field_contracts():
+    from .tiny_llm_base import TOOL_CATALOG_HASH, tool_catalog_hash
+
+    all_tools = frozenset(
+        {"list_files", "read_file", "write_file", "edit_file", "run_command"}
+    )
+    assert TOOL_CATALOG_HASH == tool_catalog_hash(all_tools)
+    assert len(TOOL_CATALOG_HASH) == 64


### PR DESCRIPTION
## Why

Feature 1 of the approved feature-split Week 4 reference-solution stack (agent loop + tool protocol). The stack is feature-based per Chi's direction; curriculum day allocation is explicitly undecided. Reference-solution/tests only; no book, starter, README/SUMMARY, or benchmark artifacts.

## What changed

- `protocol.py` — `tool_catalog_hash()` + `TOOL_CATALOG_HASH`: stable content hash of the enabled tool schema catalog; a changed tool set changes the hash (feeds the checkpoint validity rule in a later feature).
- `test_week_4_day_1.py` — loop behavior tests appended: observe-then-finish, invalid-JSON recovery, repeated-action stop.
- `test_week_4_day_2.py` — catalog-hash tests: stability, schema-bound change, field contracts.

## Review note

- 333/333 week-4 refsol tests pass; ruff check + format clean.
- Loop + tool protocol were already implemented on main; this feature formalizes the schema identity and carries the loop tests forward.

AI-Assisted: DeepSeek V4 Flash + Forge
