### PR TITLE
Week 4 feat3: minimal event-level session tree

### DIFF
--- a/src/tiny_llm_ref/agent/session.py
+++ b/src/tiny_llm_ref/agent/session.py
@@ -175,6 +175,23 @@ class SessionLog:
             return ()
         return tuple(item for item in snapshot if isinstance(item, dict))
 
+    def active_path_events(self) -> tuple[SessionEvent, ...]:
+        """Deterministically reconstruct the model-visible active path.
+
+        The append-only ``id``/``parentId`` tree keeps every branch's full
+        history, so the active path is exactly this session's own event
+        sequence: events after ``branch_completed`` are the leaf's private
+        tail, and the copied prefix before it is the inherited path.  This is
+        the Pi-inspired deterministic reconstruction: the same session always
+        yields the same path, and a branch never rewrites its ancestors.
+        """
+
+        events = self.events
+        completed = [event for event in events if event.type == "branch_completed"]
+        if len(completed) > 1:
+            raise ValueError("session contains multiple branch completion markers")
+        return events
+
     def append(
         self, event_type: str, *, parent_id: str | None = None, **data: Any
     ) -> SessionEvent:
@@ -1085,6 +1102,52 @@ class SessionStore:
             copied_event_count=len(copied_ids),
         )
         return branch
+
+    def parent_of(self, session_id: str) -> tuple[str, str] | None:
+        """Return ``(parent_session_id, at_event_id)`` for one branch session.
+
+        The root session of the tree returns ``None``.  The answer is derived
+        only from the durable ``session_started`` metadata, so reconstruction
+        never depends on in-memory state.
+        """
+
+        log = self.load(session_id, recover=False)
+        first = log.events[0]
+        parent_session = first.data.get("branch_parent_session_id")
+        parent_event = first.data.get("branch_parent_event_id")
+        if parent_session is None or parent_event is None:
+            return None
+        if (
+            not isinstance(parent_session, str)
+            or not _SESSION_ID.fullmatch(parent_session)
+            or not isinstance(parent_event, str)
+            or not _SESSION_ID.fullmatch(parent_event)
+        ):
+            raise ValueError("session branch metadata is invalid")
+        return (parent_session, parent_event)
+
+    def active_path(self, session_id: str) -> tuple[str, ...]:
+        """Reconstruct the deterministic root-to-leaf session path.
+
+        Walk ``parent_of`` from the given leaf back to the root, then return
+        the path root-first.  Any cycle or dangling parent fails closed; this
+        is the Pi-inspired ``id``/``parentId`` tree navigation used by
+        deterministic active-path reconstruction.
+        """
+
+        path: list[str] = []
+        seen: set[str] = set()
+        current: str | None = session_id
+        while current is not None:
+            if not _SESSION_ID.fullmatch(current):
+                raise ValueError("invalid session ID in active path")
+            if current in seen:
+                raise ValueError("session tree contains a cycle")
+            seen.add(current)
+            path.append(current)
+            parent = self.parent_of(current)
+            current = parent[0] if parent is not None else None
+        return tuple(reversed(path))
 
     @staticmethod
     def _validate_branch_side_effect_state(

--- a/tests_refsol/test_week_4_day_4.py
+++ b/tests_refsol/test_week_4_day_4.py
@@ -600,3 +600,76 @@ def test_task_4_model_failure_releases_the_live_cache(monkeypatch):
 
     assert generation.cached_token_ids == ()
     assert all(cache.released == 1 for cache in caches)
+
+
+def test_task_5_active_path_of_root_session_is_just_the_root(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+    root = store.create()
+
+    assert store.active_path(root.session_id) == (root.session_id,)
+    assert store.parent_of(root.session_id) is None
+
+
+def test_task_5_branch_builds_a_two_level_active_path(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+    root = store.create()
+    root.append("user_message", content="task one")
+    branch = store.branch(root.session_id, at_event_id=root.events[-1].id)
+
+    path = store.active_path(branch.session_id)
+    assert path == (root.session_id, branch.session_id)
+    assert store.parent_of(branch.session_id) == (
+        root.session_id,
+        root.events[-1].id,
+    )
+
+
+def test_task_5_active_path_events_are_deterministic(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+    root = store.create()
+    root.append("user_message", content="task one")
+    branch = store.branch(root.session_id, at_event_id=root.events[-1].id)
+    branch.append("user_message", content="branch follow-up")
+
+    first = branch.active_path_events()
+    second = branch.active_path_events()
+
+    assert [event.id for event in first] == [event.id for event in second]
+    assert first[-1].data.get("content") == "branch follow-up"
+    assert [event.type for event in first].count("user_message") == 2
+
+
+def test_task_5_branch_keeps_the_full_inherited_prefix(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+    root = store.create()
+    root.append("user_message", content="task one")
+    branch = store.branch(root.session_id, at_event_id=root.events[-1].id)
+
+    events = branch.active_path_events()
+    types = [event.type for event in events]
+    assert "session_started" in types
+    assert "branch_created" in types
+    assert "branch_completed" in types
+    assert [event.type for event in events].count("user_message") == 1
+
+
+def test_task_5_active_path_rejects_an_unknown_session(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+
+    with pytest.raises(ValueError):
+        store.active_path("0" * 32)
+
+
+def test_task_5_grandchild_path_orders_root_first(tmp_path):
+    store = SessionStore(tmp_path, "test-model")
+    root = store.create()
+    root.append("user_message", content="task one")
+    branch = store.branch(root.session_id, at_event_id=root.events[-1].id)
+    branch.append("user_message", content="branch follow-up")
+    child = store.branch(branch.session_id, at_event_id=branch.events[-1].id)
+
+    assert store.active_path(child.session_id) == (
+        root.session_id,
+        branch.session_id,
+        child.session_id,
+    )


### PR DESCRIPTION
## Why

Feature 3 of the approved feature-split Week 4 reference-solution stack (minimal event-level session tree). Stacked on feat2 ([#232](https://github.com/skyzh/tiny-llm/pull/232)); base branch `agent/week4-feat2-effect-receipts` @ `fcba689`. Days undecided; no book/starter/README/benchmark changes.

## What changed

- `session.py` — `SessionStore.parent_of` / `active_path`: deterministic root-to-leaf path derived only from durable `session_started` branch metadata; cycles and dangling parents fail closed. `SessionLog.active_path_events`: deterministic model-visible path reconstruction (inherited copied prefix + private leaf tail).
- Pi-inspired `id`/`parentId` append-only tree per `badlogic/pi-mono@936aff0` session-format.md — event-level only; no KV sharing, no COW (branch summaries work on this tree alone).
- `test_week_4_day_4.py` — six tree tests.

## Review note

- 345/345 week-4 refsol tests pass; ruff check + format clean.
- Kept minimal per design review: no navigation API beyond active-path; the tree is the durable-evidence prerequisite for branch summaries.

AI-Assisted: DeepSeek V4 Flash + Forge
