### PR TITLE
Correct Week 4 Day 1 API map

### DIFF
--- a/book/src/week4-01-agent-loop.md
+++ b/book/src/week4-01-agent-loop.md
@@ -1,9 +1,8 @@
 # Day 1: A Validated Agent Loop
 
 > **Day 1 scope:** This chapter teaches a bounded loop and a JSON action
-> protocol. The supplied test uses a fake read-only workspace. File mutation,
-> command execution, durable receipts, sessions, and evaluation are not Day 1
-> capabilities.
+> protocol. The supplied test uses a fake read-only workspace. File mutation
+> and command execution are not Day 1 capabilities.
 
 A text generator returns one response and stops. A coding agent needs a small
 control loop: it asks for one response, decides whether that response is a
@@ -14,15 +13,15 @@ The model never edits a file directly. It emits text. Ordinary Python code
 validates that text before handing a parsed action to the workspace object.
 That separation is what makes the loop testable without a model.
 
-## Checkpoint and Commands
+## Files and Commands
 
 Implement these Day 1 starter functions:
 
 | File | Function or type | Your responsibility |
 | --- | --- | --- |
-| `src/tiny_llm/agent/generation.py` | `GenerationStats`, `initial_messages()`, `generate_response()` | Reject a blank task, create the first messages, and decode one response with a fresh cache. |
-| `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `TOOL_FIELDS`, `tool_catalog_hash()`, `parse_action()`, `build_system_prompt()` | Define the exact action vocabulary, validate one JSON object, and describe only enabled actions. |
-| `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `_append_tool_result()`, `run_agent()` | Bound the loop, append observations, and return an auditable result. |
+| `src/tiny_llm/agent/generation.py` | `initial_messages()`, `generate_response()` | Reject a blank task, create the first messages, and decode one response with a fresh cache. |
+| `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `TOOL_CATALOG_HASH`, `tool_catalog_hash()`, `parse_action()`, `build_system_prompt()` | Define the exact action vocabulary, validate one JSON object, and describe only enabled actions. |
+| `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `run_agent()` | Bound the loop, append observations, and return an auditable result. |
 
 Run the focused learner check:
 
@@ -38,9 +37,9 @@ pdm run test-refsol --week 4 --day 1
 
 `generate_response()` is still a Day 1 public boundary even though the focused
 test deliberately avoids model weights. Render the messages with the tokenizer,
-decode at most `max_tokens` using a fresh cache, stop at EOS, and release every
-cache in a `finally` block. The scripted loop tests are the fast way to verify
-the control flow; a real model is not required for this checkpoint.
+decode at most the requested token count using a fresh cache, stop at EOS, and
+release every cache in a finally block. The scripted loop tests are the fast
+way to verify the control flow; a real model is not required for this checkpoint.
 
 ## One Response, One Structured Decision
 
@@ -142,8 +141,7 @@ these behaviors:
 4. The loop stops at the step budget.
 5. Repeated identical actions stop before the general step budget is spent.
 
-Keep the solution inside the Day 1 starter files. Do not create session,
-workspace, receipt, checkpoint, or evaluation modules yet; those files arrive
-with their own checkpoints.
+Keep the solution inside the Day 1 starter files. Later days add session,
+checkpoint, and rewind behavior.
 
 {{#include copyright.md}}

--- a/book/src/week4-overview.md
+++ b/book/src/week4-overview.md
@@ -45,7 +45,7 @@ The Day 1 starter exposes exactly these public names:
 
 | File | Public names | Why they are here |
 | --- | --- | --- |
-| `src/tiny_llm/agent/generation.py` | `GenerationStats`, `initial_messages`, `generate_response` | Begin a conversation and keep the one-response model boundary explicit. |
+| `src/tiny_llm/agent/generation.py` | `initial_messages`, `generate_response` | Begin a conversation and keep the one-response model boundary explicit. |
 | `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `TOOL_CATALOG_HASH`, `tool_catalog_hash`, `parse_action`, `build_system_prompt` | Represent and validate one final answer or one tool request. |
 | `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `run_agent` | Bound the run and retain an inspectable trace. |
 
@@ -63,23 +63,10 @@ the learner test, run:
 pdm run test-refsol --week 4 --day 1
 ```
 
-## Seven-Day Shape
+## Publication Boundary
 
-The course will keep this seven-day structure. Only the first row is available
-today; the rest is a map, not an invitation to implement ahead.
-
-| Day | Theme | Availability |
-| --- | --- | --- |
-| 1 | Validated agent loop and tool protocol | Available now |
-| 2 | Effect receipts | Published after its own reviewed merge |
-| 3 | Session tree | Published after its own reviewed merge |
-| 4 | KV checkpoint and rewind | Published after its own reviewed merge |
-| 5 | Receipt-backed compaction | Published after its own reviewed merge |
-| 6 | Steering, status, and reconciliation | Published after its own reviewed merge |
-| 7 | Equivalence harness | Published after its own reviewed merge |
-
-Do not add modules for a later day to your Day 1 solution. The starter's small
-surface is intentional: it lets the tests catch accidental solution leakage
-and makes each new capability easy to review.
+Only Day 1 is available today. Do not add modules for later days to your
+solution; each later capability will be published with its own reviewed
+checkpoint.
 
 {{#include copyright.md}}


### PR DESCRIPTION
## Summary

Corrects the Week 4 Day 1 learner material after the repaired public starter:

- removes the unavailable `GenerationStats` requirement;
- lists only exported Day 1 APIs in the required API map; and
- removes future KV/checkpoint/rewind material from required work while retaining one concise later-days boundary.

This is documentation-only. Runtime, starter, reference-solution, and test files are unchanged.

## Why

Day 1 produces text only. The book must not require a later-day statistics or checkpoint surface that the Day 1 public starter does not export.

## Validation

- `pdm run pytest tests_refsol/test_week_4_day_1.py tests_refsol/test_week_4_day_2.py tests_refsol/test_week_4_starter_sync.py tests_refsol/test_week_4_render.py` — 107 passed, zero skips/expected failures
- `mdbook build book`
- `book/sitemap.sh --check`
- `git diff --check`

The focused/sync/render collection is currently 107 tests (not the 106 in the handoff); all passed on this head.
