### PR TITLE
Remove Day 1 future-surface promise

### DIFF
--- a/book/src/week4-01-agent-loop.md
+++ b/book/src/week4-01-agent-loop.md
@@ -141,7 +141,6 @@ these behaviors:
 4. The loop stops at the step budget.
 5. Repeated identical actions stop before the general step budget is spent.
 
-Keep the solution inside the Day 1 starter files. Later days add session,
-checkpoint, and rewind behavior.
+Keep the solution inside the Day 1 starter files.
 
 {{#include copyright.md}}


### PR DESCRIPTION
## Summary

Deletes the final Day 1 sentence that promised later session, checkpoint, and rewind behavior. No replacement prose is added.

## Scope

Only `book/src/week4-01-agent-loop.md` changes. Code, tests, workflow, and all other book material are byte-identical to the base.

## Validation

- `pdm run pytest tests_refsol/test_week_4_day_1.py tests_refsol/test_week_4_day_2.py tests_refsol/test_week_4_starter_sync.py tests_refsol/test_week_4_render.py` — 113 passed; all five true-CDP 390px renders executed
- `mdbook build book`
- `book/sitemap.sh --check`
- `git diff --check`
- base-preservation check confirms this PR changes only the Day 1 chapter

AI-Assisted: GPT-5.6 Terra + Sentinel

## Mechanical restack

Old head `a9b6a72` and current head `438dc0c` have identical trees; the base is current #266 `9d74c2e`, and exact-head hosted checks and reviews are terminal green.

## Final gate

All hosted contexts on the mechanically restacked six-head batch are terminal green. Four independent reviews are GO on cumulative exact head `a396f38`; the reviewed final tree is `d7424943bd1917a1c257043a2178787a4dc3c1dc`.

Reviewed-by: GPT-5.6 Terra + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
Reviewed-by: GPT-5.6 Sol + Tuner (performance)
Reviewed-by: GPT-5.6 Terra + Scholar (learner)
