### PR TITLE
Remove reference guidance from Day 1 starter

### DIFF
--- a/src/tiny_llm/agent/generation.py
+++ b/src/tiny_llm/agent/generation.py
@@ -5,8 +5,8 @@
 Day 1 needs only the message types, the initial conversation messages, and
 a single-shot ``generate_response`` helper.
 
-Implement the bodies yourself; the reference solution lives in
-``tiny_llm_ref``.
+Implement the bodies yourself; use the Day 1 chapter and public tests as the
+learner contract.
 """
 
 from collections.abc import Callable, Sequence

--- a/src/tiny_llm/agent/loop.py
+++ b/src/tiny_llm/agent/loop.py
@@ -7,8 +7,8 @@ response.  It stops by budget, returns invalid actions to the model, and
 guards against repeated identical actions.  This file keeps only the
 validated Day 1 core.
 
-Implement the bodies yourself; the reference solution lives in
-``tiny_llm_ref``.
+Implement the bodies yourself; use the Day 1 chapter and public tests as the
+learner contract.
 """
 
 from collections.abc import Callable

--- a/tests_refsol/test_week_4_starter_sync.py
+++ b/tests_refsol/test_week_4_starter_sync.py
@@ -316,10 +316,26 @@ def _assert_no_reference_imports(starter_dir: Path) -> None:
                     )
 
 
+def _assert_no_reference_guidance(starter_dir: Path) -> None:
+    """Reject learner-facing package or path guidance to the reference tree."""
+
+    for path in starter_dir.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        assert "tiny_llm_ref" not in source, (
+            f"starter {path.name} guides learners to the reference solution"
+        )
+
+
 def test_starter_package_does_not_import_reference():
     """The normal CI guard scans the complete real starter tree."""
 
     _assert_no_reference_imports(STARTER)
+
+
+def test_starter_does_not_guide_learners_to_reference():
+    """Public starter source must not point learners at reference code."""
+
+    _assert_no_reference_guidance(STARTER)
 
 
 def test_day1_loop_has_no_session_contract():
@@ -773,6 +789,23 @@ def test_real_tree_dynamic_import_mutations_fail_normal_guard(tmp_path, form, pa
     path.write_text(path.read_text(encoding="utf-8") + payload, encoding="utf-8")
     with pytest.raises(AssertionError, match="dynamically imports"):
         _assert_no_reference_imports(starter)
+
+
+@pytest.mark.parametrize(
+    ("form", "payload"),
+    (
+        ("package", "\n# Copy the answer from tiny_llm_ref.\n"),
+        ("path", "\n# See src/tiny_llm_ref/agent/generation.py.\n"),
+    ),
+)
+def test_real_tree_reference_guidance_mutations_fail_normal_guard(
+    tmp_path, form, payload
+):
+    starter = _copy_starter_tree(tmp_path)
+    path = starter / "generation.py"
+    path.write_text(path.read_text(encoding="utf-8") + payload, encoding="utf-8")
+    with pytest.raises(AssertionError, match="guides learners"):
+        _assert_no_reference_guidance(starter)
 
 
 def test_real_tree_starter_only_session_id_fails_normal_guard(tmp_path):


### PR DESCRIPTION
## Why

Two Day 1 starter docstrings directed learners to the private reference package. That guidance leaks the answer location even though the starter itself remains solution-free.

## Change

- Replace the two reference-package pointers with guidance to use the Day 1 chapter and public tests as the learner contract.
- Add a fail-closed whole-starter guard that rejects direct `tiny_llm_ref` package or path guidance.
- Prove the normal guard kills real temporary-tree package-name and source-path mutations.

## Review note

Stacked on exact PR #267 head `438dc0c`. The diff is limited to the two starter docstrings and the sync/anti-leakage guard; reference code, README safety guidance, book, workflow, configuration, and all other base bytes are unchanged.

Local gates: 64 sync/anti-leakage tests; 116 focused Day 1/Day 2/sync/render tests with all five renders executed; cumulative reference suite 451 passed with 8 intentional model/course skips; learner command remains expected-red at 13 failed and 2 mutation-control passes; scoped Ruff/format, mdBook, sitemap, and diff/preservation checks pass.

AI-Assisted: GPT-5.6 Sol + Forge

## Mechanical restack

Old reviewed head `90d0d4` and current head `a396f38` have identical trees. Exact-head hosted checks and all four independent reviews are terminal green; no old-head verdict transfers.

## Final gate

All hosted contexts on the mechanically restacked six-head batch are terminal green. Four independent reviews are GO on cumulative exact head `a396f38`; the reviewed final tree is `d7424943bd1917a1c257043a2178787a4dc3c1dc`.

Reviewed-by: GPT-5.6 Terra + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
Reviewed-by: GPT-5.6 Sol + Tuner (performance)
Reviewed-by: GPT-5.6 Terra + Scholar (learner)
