### PR TITLE
Week 4: Try the Agent with a Real Model

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,560 +1,186 @@
+"""Run the Week 4 agent loop with a real local MLX model."""
+
+from __future__ import annotations
+
 import argparse
 import importlib
 import json
 import shlex
 import sys
-from itertools import cycle
 from pathlib import Path
-from threading import Event, Thread
 
 from model_names import shortcut_name_to_full_name
 
 
-def run_with_spinner(label, function, *args):
-    """CLI support for Week 4: show progress without changing agent behavior."""
-
-    if not sys.stdout.isatty():
-        return function(*args)
-    stopped = Event()
-
-    def animate():
-        """CLI support for Week 4: redraw a spinner until generation finishes."""
-
-        for frame in cycle("|/-\\"):
-            print(f"\r{frame} {label}", end="", flush=True)
-            if stopped.wait(0.1):
-                break
-
-    thread = Thread(target=animate, daemon=True)
-    thread.start()
-    try:
-        return function(*args)
-    finally:
-        stopped.set()
-        thread.join()
-        print(f"\r{' ' * (len(label) + 2)}\r", end="", flush=True)
-
-
 def build_parser() -> argparse.ArgumentParser:
-    """CLI support for Week 4: define model, budget, and safety policy flags."""
-
-    parser = argparse.ArgumentParser(description="A tiny Week 4 coding agent.")
-    parser.add_argument("task", nargs="*", help="coding task for a new session")
+    parser = argparse.ArgumentParser(
+        description="Explore the current Week 4 agent with a real local model."
+    )
+    parser.add_argument("task", nargs="+", help="one natural-language goal")
     parser.add_argument(
-        "--interactive",
-        action="store_true",
-        help="accept follow-up messages after each bounded run",
-    )
-    resume = parser.add_mutually_exclusive_group()
-    resume.add_argument(
-        "--continue",
-        dest="continue_session",
-        action="store_true",
-        help="resume the newest session for this workspace and model",
-    )
-    resume.add_argument(
-        "--session",
-        metavar="SESSION_ID",
-        help="resume a selected session for this workspace and model",
-    )
-    parser.add_argument(
-        "--no-session",
-        action="store_true",
-        help="do not write a persistent session transcript",
+        "--root",
+        required=True,
+        type=Path,
+        help="pre-created disposable workspace containing no secrets",
     )
     parser.add_argument("--model", default="qwen3-4b")
     parser.add_argument(
         "--solution",
-        choices=["tiny_llm", "tiny_llm_ref", "ref", "mlx"],
-        default="tiny_llm_ref",
+        choices=["tiny_llm", "tiny_llm_ref", "ref"],
+        default="tiny_llm",
+        help="course workspace implementation (the model uses local MLX-LM)",
     )
-    parser.add_argument("--loader", choices=["week2", "week3"], default="week2")
     parser.add_argument("--device", choices=["cpu", "gpu"], default="gpu")
     parser.add_argument("--enable-thinking", action="store_true")
     parser.add_argument("--max-steps", type=int, default=8)
     parser.add_argument("--max-tokens", type=int, default=256)
-    parser.add_argument("--max-context-tokens", type=int, default=32_768)
-    parser.add_argument("--reserve-tokens", type=int, default=8_192)
-    parser.add_argument("--summary-max-tokens", type=int, default=1_024)
-    parser.add_argument("--max-tool-result-tokens", type=int, default=4_096)
-    parser.add_argument("--min-recent-turns", type=int, default=2)
-    parser.add_argument(
-        "--root",
-        type=Path,
-        default=Path.cwd(),
-        help="workspace boundary (defaults to the current directory)",
-    )
     parser.add_argument(
         "--allow-writes",
         action="store_true",
-        help="allow file writes; existing files still must be read first",
+        help="enable approved write_file and edit_file calls",
     )
     parser.add_argument(
         "--allow-command",
         action="append",
         default=[],
         metavar="COMMAND",
-        help="allow one exact command; repeat the flag to add another",
+        help="allow one exact command; repeat to allow another",
+    )
+    parser.add_argument(
+        "--receipt-log",
+        type=Path,
+        metavar="RELATIVE_PATH",
+        help="append effect receipts to this workspace-relative JSONL path",
     )
     return parser
 
 
 def parse_allowed_commands(values: list[str]) -> tuple[tuple[str, ...], ...]:
-    """Week 4, Day 5: convert operator-approved commands into exact argv tuples."""
-
     commands = []
     for value in values:
-        argv = tuple(shlex.split(value))
-        if not argv:
+        command = tuple(shlex.split(value))
+        if not command:
             raise ValueError("--allow-command must not be empty")
-        commands.append(argv)
+        commands.append(command)
     return tuple(commands)
 
 
-def validate_session_arguments(
-    parser: argparse.ArgumentParser, args: argparse.Namespace
-) -> None:
-    """Reject ambiguous session lifecycles before loading a model."""
-
-    if not args.task and not (args.continue_session or args.session):
-        parser.error("TASK is required unless --continue or --session is used")
-    if args.task and not " ".join(args.task).strip():
-        parser.error("TASK must not be empty")
-    if args.task and (args.continue_session or args.session):
-        parser.error("TASK cannot be combined with --continue or --session")
-    if args.no_session and (args.continue_session or args.session):
-        parser.error("--no-session cannot be combined with a resume option")
-    if args.interactive and not getattr(sys.stdin, "isatty", lambda: False)():
-        parser.error("--interactive requires a TTY")
+def receipt_path(root: Path, raw: Path | None) -> Path | None:
+    if raw is None:
+        return None
+    if raw.is_absolute() or ".." in raw.parts or not raw.name:
+        raise ValueError("--receipt-log must be a workspace-relative file path")
+    path = root.joinpath(raw)
+    if not path.parent.is_dir():
+        raise ValueError("--receipt-log parent directory must exist")
+    return path
 
 
-def validate_budget_arguments(
-    parser: argparse.ArgumentParser, args: argparse.Namespace
-) -> None:
-    """Reject generation settings that can exceed the advertised context limit."""
-
-    if args.max_tokens <= 0:
-        parser.error("--max-tokens must be positive")
-    if args.max_steps <= 0:
-        parser.error("--max-steps must be positive")
-    if args.max_tokens > args.reserve_tokens:
-        parser.error("--max-tokens must not exceed --reserve-tokens")
-    if args.summary_max_tokens >= args.max_context_tokens:
-        parser.error("--summary-max-tokens must be below --max-context-tokens")
-
-
-def confirm_tool_call(action, root: Path) -> bool:
-    """Ask a human to approve one side effect, defaulting safely to no."""
-
+def confirm_tool(action) -> bool:
     payload = {"tool": action.tool, **action.arguments}
-    print("\nHuman approval required before this tool call:")
-    print(f"workspace> {json.dumps(str(root), ensure_ascii=True)}")
-    print("tool call> " + json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    print("\napproval requested> " + json.dumps(payload, sort_keys=True))
     if action.tool == "run_command":
-        print("Warning: commands are not confined by the workspace path boundary.")
-    if not getattr(sys.stdin, "isatty", lambda: False)():
-        print("Denied: interactive confirmation requires a TTY.")
+        print("warning> an allowed command is not confined by the workspace boundary")
+    if not sys.stdin.isatty():
+        print("approval denied> interactive confirmation requires a TTY")
         return False
     try:
-        response = input("Execute this tool call? [y/N] ")
+        answer = input("approve this effect? [y/N] ")
     except EOFError:
-        print("\nDenied: no confirmation was received.")
+        print("\napproval denied> no answer received")
         return False
-    approved = response.strip().casefold() in {"y", "yes"}
-    if not approved:
-        print("Denied.")
+    approved = answer.strip().casefold() in {"y", "yes"}
+    print("approval> " + ("yes" if approved else "no"))
     return approved
 
 
-def show_run_result(result) -> None:
-    """Render protocol completion separately from independently validated success."""
-
-    if result.completed:
-        final = json.dumps(result.final, ensure_ascii=True)
-        print("\nModel finished (task success not independently validated): " + final)
-    else:
-        print(f"\nStopped: {result.reason}")
-    show_side_effect_summary(
-        result.modified_files,
-        result.command_side_effects_untracked,
-        result.uncertain_modified_files,
-        result.retained_recovery_files,
-        result.command_cleanup_incomplete,
-    )
+def show_event(agent, event) -> None:
+    print(f"\n[{event.step}] model> {event.response}")
+    if isinstance(event.action, agent.ToolAction):
+        payload = {"tool": event.action.tool, **event.action.arguments}
+        print("action> " + json.dumps(payload, sort_keys=True))
+    if event.result is not None:
+        print(f"observation> {event.result}")
 
 
-def show_side_effect_summary(
-    modified_files,
-    command_side_effects_untracked: bool,
-    uncertain_modified_files=(),
-    retained_recovery_files=(),
-    command_cleanup_incomplete: bool = False,
-) -> None:
-    """Report tracked file mutations and the command-tracking boundary."""
-
-    if modified_files:
-        modified = json.dumps(list(modified_files), ensure_ascii=True)
-        print("Tracked file-tool changes: " + modified)
-    if uncertain_modified_files:
-        uncertain = json.dumps(list(uncertain_modified_files), ensure_ascii=True)
-        print("Warning: file-tool mutation outcome is uncertain; inspect: " + uncertain)
-    if retained_recovery_files:
-        retained = json.dumps(list(retained_recovery_files), ensure_ascii=True)
-        print("Safety copies retained for manual inspection: " + retained)
-    if command_side_effects_untracked:
-        print(
-            "Warning: one or more commands ran; their side effects are not "
-            "included in the tracked file-tool changes."
-        )
-    if command_cleanup_incomplete:
-        print(
-            "Warning: command cleanup or output collection was incomplete; "
-            "inspect the host for a surviving process."
-        )
-
-
-def show_interrupted_run(workspace) -> None:
-    """Disclose known side effects when Ctrl-C prevents an AgentRun result."""
-
-    show_stopped_run(workspace, "interrupted")
-
-
-def show_stopped_run(workspace, reason: str) -> None:
-    """Disclose known side effects when no AgentRun result is available."""
-
-    modified = tuple(
-        sorted(
-            str(path.relative_to(workspace.policy.root))
-            for path in workspace.modified_files
-        )
-    )
-    uncertain = tuple(
-        sorted(
-            str(path.relative_to(workspace.policy.root))
-            for path in workspace.uncertain_modified_files
-        )
-    )
-    retained = tuple(
-        sorted(
-            str(path.relative_to(workspace.policy.root))
-            for path in workspace.retained_recovery_files
-        )
-    )
-    print(f"\nStopped: {reason}")
-    show_side_effect_summary(
-        modified,
-        workspace.command_side_effects_untracked,
-        uncertain,
-        retained,
-        workspace.command_cleanup_incomplete,
-    )
-
-
-def run_and_report(function, workspace):
-    """Run the agent and always disclose known side effects before exiting."""
-
-    try:
-        result = function()
-    except KeyboardInterrupt:
-        show_stopped_run(workspace, "interrupted")
-        raise SystemExit(130) from None
-    except Exception:
-        show_stopped_run(workspace, "unexpected error")
-        raise
-    show_run_result(result)
-    if result.reason == "interrupted":
-        raise SystemExit(130)
-    return result
-
-
-def main():
-    """CLI support for Week 4: load a backend and invoke the bounded agent loop."""
-
+def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    validate_session_arguments(parser, args)
-    validate_budget_arguments(parser, args)
-    if args.solution != "mlx" and args.device != "gpu":
-        parser.error("The completed Week 2 and Week 3 models require --device gpu")
+    task = " ".join(args.task).strip()
+    if not task:
+        parser.error("task must not be empty")
+    if args.max_steps <= 0 or args.max_tokens <= 0:
+        parser.error("generation limits must be positive")
+    if not args.root.is_dir():
+        parser.error("--root must be a pre-created directory")
     try:
-        allowed_commands = parse_allowed_commands(args.allow_command)
-    except ValueError as error:
-        parser.error(str(error))
-    if not args.root.exists() or not args.root.is_dir():
-        parser.error("--root must be an existing directory")
-    import mlx.core as mx
-    from mlx_lm import load
-
-    package = (
-        "tiny_llm_ref"
-        if args.solution in {"tiny_llm_ref", "ref", "mlx"}
-        else "tiny_llm"
-    )
-    agent = importlib.import_module(f"{package}.agent")
-    models = None
-    if args.solution != "mlx":
-        models = importlib.import_module(f"{package}.models")
-    try:
+        commands = parse_allowed_commands(args.allow_command)
+        package = (
+            "tiny_llm_ref" if args.solution in {"tiny_llm_ref", "ref"} else "tiny_llm"
+        )
+        agent = importlib.import_module(f"{package}.agent")
         policy = agent.ToolPolicy(
-            root=args.root,
+            args.root,
             allow_writes=args.allow_writes,
-            allowed_commands=allowed_commands,
+            allowed_commands=commands,
         )
-        context_policy = agent.ContextPolicy(
-            max_tokens=args.max_context_tokens,
-            reserve_tokens=args.reserve_tokens,
-            summary_max_tokens=args.summary_max_tokens,
-            max_tool_result_tokens=args.max_tool_result_tokens,
-            min_recent_turns=args.min_recent_turns,
-        )
-    except ValueError as error:
+        log_path = receipt_path(policy.root, args.receipt_log)
+        store = agent.ReceiptStore(log_path)
+    except (ImportError, ValueError) as error:
         parser.error(str(error))
+
+    workspace = agent.Workspace(policy, confirm_tool, store)
     limits = agent.AgentLimits(max_steps=args.max_steps)
-
-    if not args.allow_writes:
-        print(
-            "Safety: workspace tools are read-only; pass --allow-writes to "
-            "permit file changes"
-        )
-    if allowed_commands:
-        print("Safety: only the exact --allow-command values may be executed")
-    else:
-        print("Safety: command execution is disabled")
-    if args.allow_writes or allowed_commands:
-        print("Safety: each write, edit, and command requires y/N approval")
-
     model_name = shortcut_name_to_full_name(args.model)
-    mlx_model, tokenizer = load(model_name)
-    if args.solution == "mlx":
-        model = mlx_model
-        print(f"Using the MLX executor on {args.device}; --loader is ignored")
-    else:
-        assert models is not None
-        dispatch_args = {}
-        model = models.dispatch_model(
-            model_name, mlx_model, week=int(args.loader[-1]), **dispatch_args
-        )
-        print(f"Using {package} with the {args.loader} loader on {args.device}")
-
-    backend_id = "|".join(
-        (
-            model_name,
-            f"solution={'mlx' if args.solution == 'mlx' else package}",
-            f"loader={'mlx' if args.solution == 'mlx' else args.loader}",
-            f"thinking={args.enable_thinking}",
-        )
-    )
-    try:
-        if args.no_session:
-            session_log = agent.memory_session(policy.root, backend_id)
-        else:
-            session_store = agent.SessionStore(policy.root, backend_id)
-            if args.continue_session:
-                session_log = session_store.latest()
-            elif args.session:
-                session_log = session_store.load(args.session)
-            else:
-                session_log = session_store.create()
-    except ValueError as error:
-        parser.error(str(error))
-    if session_log.path is None:
-        print("Session: ephemeral (--no-session)")
-    else:
-        print(f"Session transcript: {session_log.session_id} (sensitive local data)")
-    cancellation = agent.CancellationToken()
-    workspace = agent.Workspace(
-        policy,
-        confirm_tool=lambda action: confirm_tool_call(action, policy.root),
-        session_log=session_log,
-        cancellation=cancellation,
-    )
-    for recovery in workspace.recovery_results:
-        if recovery.status == "conflict":
-            print(
-                "Warning: interrupted mutation conflicts with current bytes: "
-                + json.dumps(recovery.path, ensure_ascii=True)
-            )
-
-    completed_session = next(
-        (
-            event.data.get("completed") is True
-            for event in reversed(session_log.events)
-            if event.type == "run_finished"
-        ),
-        False,
-    )
-    pending_steering = bool(session_log.pending_steering())
-    if (
-        completed_session
-        and not pending_steering
-        and not args.task
-        and not args.interactive
-    ):
-        parser.error(
-            "the selected session completed; provide a follow-up interactively"
-        )
-
-    generation_session = None
-    if args.solution == "mlx":
-
-        def generate(messages):
-            """Adapt the stateless MLX-LM compatibility backend."""
-
-            from mlx_lm import generate as mlx_generate
-
-            prompt = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-                enable_thinking=args.enable_thinking,
-            )
-
-            def generate_mlx():
-                """Week 4, Day 1: decode with the optimized MLX-LM backend."""
-
-                return mlx_generate(
-                    model,
-                    tokenizer,
-                    prompt,
-                    max_tokens=args.max_tokens,
-                    verbose=False,
-                )
-
-            return run_with_spinner("Model is working...", generate_mlx)
-
-    else:
-        if args.loader == "week2":
-            cache_type = importlib.import_module(f"{package}.kv_cache").TinyKvFullCache
-
-            def cache_factory():
-                """Week 4, Day 1: allocate one full cache per decoder layer."""
-
-                return [cache_type() for _ in range(model.num_hidden_layers)]
-
-        else:
-            cache_factory = model.create_kv_cache
-        generation_session = agent.GenerationSession(
-            model,
-            tokenizer,
-            cache_factory,
-            args.max_tokens,
-            args.enable_thinking,
-            cancellation=cancellation,
-        )
-
-        def generate(messages):
-            """Generate with Day 4's reusable course-model cache."""
-
-            assert generation_session is not None
-            response = run_with_spinner(
-                "Model is working...", generation_session, messages
-            )
-            generate.last_stats = generation_session.last_stats
-            return response
-
-    if generation_session is None:
-
-        def encode_messages(messages):
-            prompt = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-                enable_thinking=args.enable_thinking,
-            )
-            return tuple(tokenizer.encode(prompt, add_special_tokens=False))
-
-    else:
-        encode_messages = generation_session.encode_messages
-
-    context_manager = agent.ContextManager(encode_messages, context_policy)
-
-    def summarize(messages):
-        """Generate one summary with state separate from the primary cache."""
-
-        if args.solution == "mlx":
-            from mlx_lm import generate as mlx_generate
-
-            prompt = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-                enable_thinking=args.enable_thinking,
-            )
-
-            return run_with_spinner(
-                "Compacting context...",
-                lambda: mlx_generate(
-                    model,
-                    tokenizer,
-                    prompt,
-                    max_tokens=args.summary_max_tokens,
-                    verbose=False,
-                ),
-            )
-        summary_session = agent.GenerationSession(
-            model,
-            tokenizer,
-            cache_factory,
-            args.summary_max_tokens,
-            args.enable_thinking,
-            cancellation=cancellation,
-        )
-        try:
-            return run_with_spinner("Compacting context...", summary_session, messages)
-        finally:
-            summary_session.close()
-
-    def show_event(event):
-        """Week 4, Day 7: print the same trace represented by AgentEvent."""
-
-        print(
-            f"\n[{event.step}] model> " + json.dumps(event.response, ensure_ascii=True)
-        )
-        if isinstance(event.action, agent.ToolAction):
-            action = {"tool": event.action.tool, **event.action.arguments}
-            print(f"tool call> {json.dumps(action, ensure_ascii=True)}")
-        if event.result is not None:
-            print(f"tool> {json.dumps(event.result, ensure_ascii=True)}")
-
-    def execute_agent(task):
-        """Run generation within the requested MLX stream."""
-
-        with mx.stream(mx.gpu if args.device == "gpu" else mx.cpu):
-            return agent.run_agent(
-                task,
-                generate,
-                workspace,
-                limits,
-                show_event,
-                session=session_log,
-                context_manager=context_manager,
-                summarize=summarize,
-                cancellation=cancellation,
-            )
 
     try:
-        pending_task = " ".join(args.task).strip() if args.task else None
-        if pending_task is None and completed_session and not pending_steering:
-            try:
-                pending_task = input("\nfollow-up (blank to exit)> ").strip()
-            except EOFError:
-                return None
-            if not pending_task:
-                return None
-        result = run_and_report(lambda: execute_agent(pending_task), workspace)
-        while args.interactive:
-            try:
-                follow_up = input("\nfollow-up (blank to exit)> ").strip()
-            except EOFError:
-                break
-            if not follow_up:
-                break
-            result = run_and_report(lambda: execute_agent(follow_up), workspace)
-        return result
-    finally:
-        if generation_session is not None:
-            generation_session.close()
+        import mlx.core as mx
+        from mlx_lm import load
+
+        mlx_model, tokenizer = load(model_name)
+    except Exception as error:
+        parser.exit(1, f"error: could not load local model {model_name}: {error}\n")
+
+    def generate(messages):
+        from mlx_lm import generate as mlx_generate
+
+        prompt = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=args.enable_thinking,
+        )
+        return mlx_generate(
+            mlx_model,
+            tokenizer,
+            prompt,
+            max_tokens=args.max_tokens,
+            verbose=False,
+        )
+
+    print("model> " + model_name)
+    print("workspace> " + str(policy.root))
+    print("goal> " + task)
+    print("tools> " + ", ".join(sorted(workspace.available_tools)))
+    if log_path is not None:
+        print("receipt log> " + str(log_path))
+
+    with mx.stream(mx.gpu if args.device == "gpu" else mx.cpu):
+        result = agent.run_agent(
+            task,
+            generate,
+            workspace,
+            limits,
+            lambda event: show_event(agent, event),
+        )
+
+    if result.completed:
+        print("\nfinished> " + (result.final or ""))
+    else:
+        print("\nstopped> " + result.reason)
+    print("modified files> " + json.dumps(list(workspace.modified_files)))
+    return 0 if result.completed else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/agent.py
+++ b/agent.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import argparse
-import importlib
 import json
 import shlex
 import sys
 from pathlib import Path
 
 from model_names import shortcut_name_to_full_name
+from tiny_llm import agent
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -24,12 +24,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="pre-created disposable workspace containing no secrets",
     )
     parser.add_argument("--model", default="qwen3-4b")
-    parser.add_argument(
-        "--solution",
-        choices=["tiny_llm", "tiny_llm_ref", "ref"],
-        default="tiny_llm",
-        help="course workspace implementation (the model uses local MLX-LM)",
-    )
     parser.add_argument("--device", choices=["cpu", "gpu"], default="gpu")
     parser.add_argument("--enable-thinking", action="store_true")
     parser.add_argument("--max-steps", type=int, default=8)
@@ -115,10 +109,6 @@ def main() -> int:
         parser.error("--root must be a pre-created directory")
     try:
         commands = parse_allowed_commands(args.allow_command)
-        package = (
-            "tiny_llm_ref" if args.solution in {"tiny_llm_ref", "ref"} else "tiny_llm"
-        )
-        agent = importlib.import_module(f"{package}.agent")
         policy = agent.ToolPolicy(
             args.root,
             allow_writes=args.allow_writes,
@@ -126,7 +116,7 @@ def main() -> int:
         )
         log_path = receipt_path(policy.root, args.receipt_log)
         store = agent.ReceiptStore(log_path)
-    except (ImportError, ValueError) as error:
+    except ValueError as error:
         parser.error(str(error))
 
     workspace = agent.Workspace(policy, confirm_tool, store)

--- a/agent.py
+++ b/agent.py
@@ -75,6 +75,11 @@ def confirm_tool(action) -> bool:
     print("\napproval requested> " + json.dumps(payload, sort_keys=True))
     if action.tool == "run_command":
         print("warning> an allowed command is not confined by the workspace boundary")
+        print(
+            "warning> approved commands may create or change additional filesystem "
+            "paths; command receipts record the command and result, not a complete "
+            "filesystem diff"
+        )
     if not sys.stdin.isatty():
         print("approval denied> interactive confirmation requires a TTY")
         return False
@@ -95,6 +100,10 @@ def show_event(agent, event) -> None:
         print("action> " + json.dumps(payload, sort_keys=True))
     if event.result is not None:
         print(f"observation> {event.result}")
+
+
+def show_file_tool_changes(paths) -> None:
+    print("file-tool changes> " + json.dumps(list(paths)))
 
 
 def main() -> int:
@@ -168,7 +177,7 @@ def main() -> int:
         print("\nfinished> " + (result.final or ""))
     else:
         print("\nstopped> " + result.reason)
-    print("modified files> " + json.dumps(list(workspace.modified_files)))
+    show_file_tool_changes(workspace.modified_files)
     return 0 if result.completed else 1
 
 

--- a/book/src/week4-02-tools.md
+++ b/book/src/week4-02-tools.md
@@ -185,14 +185,17 @@ separate manual run is exploratory: a real model chooses the tools, so its
 wording and exact tool order may vary. Use only a disposable directory that
 contains no secrets or private source.
 
-The CLI defaults to `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`). The command below
-selects the stronger `mlx-community/Qwen3-30B-A3B-4bit` model for more reliable
-tool use. Both use the local MLX model path already used by this repository.
-You need macOS on Apple Silicon and the installed MLX dependencies. The first
-run downloads the selected weights from Hugging Face when they are not cached,
-so it also needs network access and several gigabytes of free disk. If MLX is
-unavailable or the weights cannot be loaded, the command exits before the
-agent calls a workspace tool; it does not substitute scripted output.
+The CLI defaults to `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`), whose cached weights
+use about 2 GiB; use that lower-resource option when needed. The recorded
+exploratory run below used `mlx-community/Qwen3-30B-A3B-4bit`, whose cached
+weights use about 16 GiB and require sufficient Apple unified memory. Model
+behavior and tool order vary with either choice. Both use the local MLX model
+path already used by this repository. You need macOS on Apple Silicon and the
+installed MLX dependencies. The first run downloads the selected weights from
+Hugging Face when they are not cached, so it also needs network access and the
+corresponding free disk space. If MLX is unavailable or the weights cannot be
+loaded, the command exits before the agent calls a workspace tool; it does not
+substitute scripted output.
 
 Create a tiny read-only workspace, then give the model one goal:
 

--- a/book/src/week4-02-tools.md
+++ b/book/src/week4-02-tools.md
@@ -178,6 +178,45 @@ pdm run test-refsol --week 4 --day 2
 The cumulative course-code guard compares the starter and reference public
 signatures, dataclass fields, package exports, and solution-free method bodies.
 
+## Explore with a Real Model
+
+The scripted checkpoint above is the reproducible mechanics proof. This
+separate manual run is exploratory: a real model chooses the tools, so its
+wording and exact tool order may vary. Use only a disposable directory that
+contains no secrets or private source.
+
+The CLI defaults to `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`). The command below
+selects the stronger `mlx-community/Qwen3-30B-A3B-4bit` model for more reliable
+tool use. Both use the local MLX model path already used by this repository.
+You need macOS on Apple Silicon and the installed MLX dependencies. The first
+run downloads the selected weights from Hugging Face when they are not cached,
+so it also needs network access and several gigabytes of free disk. If MLX is
+unavailable or the weights cannot be loaded, the command exits before the
+agent calls a workspace tool; it does not substitute scripted output.
+
+Create a tiny read-only workspace, then give the model one goal:
+
+```bash
+INSPECT_ROOT="$(mktemp -d)"
+mkdir "$INSPECT_ROOT/src"
+printf '%s\n' '# Pocket Weather' 'A tiny terminal forecast project.' > "$INSPECT_ROOT/README.md"
+printf '%s\n' 'def forecast(city):' '    return f"Sunny in {city}"' > "$INSPECT_ROOT/src/weather.py"
+
+pdm run agent -- --model mlx-community/Qwen3-30B-A3B-4bit --root "$INSPECT_ROOT" \
+  "Inspect this workspace and explain its purpose and the behavior implemented in its source file. Use the available workspace tools to gather evidence from both the project overview and the source file. Your first response must be one tool request, every response must contain exactly one JSON object, and you must not finish until you have read the source file."
+```
+
+Watch the printed goal, model responses, parsed actions, and tool observations.
+There is no predefined action list: the model decides what to list and read
+before returning a final answer.
+The policy is read-only, so no approval prompt or receipt is expected. Compare
+the final answer with the actual disposable files:
+
+```bash
+find "$INSPECT_ROOT" -type f -print
+cat "$INSPECT_ROOT/README.md" "$INSPECT_ROOT/src/weather.py"
+```
+
 When this checkpoint is green, continue to [Day 3: Edit, Validate, and
 Record](week4-03-safe-editing.md).
 

--- a/book/src/week4-03-safe-editing.md
+++ b/book/src/week4-03-safe-editing.md
@@ -207,13 +207,16 @@ lets a real model plan the same Day 3 cycle from one natural-language goal.
 Its wording and tool order can vary, and completion is not an automated test.
 Use a fresh disposable directory with no secrets.
 
-The CLI default is `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`); this example selects
-`mlx-community/Qwen3-30B-A3B-4bit` for more reliable multi-step tool use. It
-requires macOS on Apple Silicon and the installed MLX dependencies. An
-uncached first run downloads the selected weights from Hugging Face and needs
-network access plus several gigabytes of free disk. If MLX, network access,
-disk space, or the weights are unavailable, model loading fails before any
-tool call; do not treat a scripted checkpoint as evidence that this live run
+The CLI default is `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`), whose cached weights
+use about 2 GiB; use that lower-resource option when needed. The recorded
+exploratory run below used `mlx-community/Qwen3-30B-A3B-4bit`, whose cached
+weights use about 16 GiB and require sufficient Apple unified memory. Model
+behavior and tool order vary with either choice. Both require macOS on Apple
+Silicon and the installed MLX dependencies. An uncached first run downloads
+the selected weights from Hugging Face and needs network access plus the
+corresponding free disk space. If MLX, network access, disk space, unified
+memory, or the weights are unavailable, model loading fails before any tool
+call; do not treat a scripted checkpoint as evidence that this live run
 occurred.
 
 Pre-create the workspace, an existing file, and one focused validation fixture:

--- a/book/src/week4-03-safe-editing.md
+++ b/book/src/week4-03-safe-editing.md
@@ -200,6 +200,65 @@ pdm run test-refsol --week 4 --day 3
 The cumulative course-code guard checks exact public signatures, dataclass
 fields, package exports, TODO-only starter bodies, and absence of future APIs.
 
+## Explore the Full Cycle with a Real Model
+
+Keep the scripted checkpoint as the deterministic proof. This manual exercise
+lets a real model plan the same Day 3 cycle from one natural-language goal.
+Its wording and tool order can vary, and completion is not an automated test.
+Use a fresh disposable directory with no secrets.
+
+The CLI default is `qwen3-4b` (`Qwen/Qwen3-4B-MLX-4bit`); this example selects
+`mlx-community/Qwen3-30B-A3B-4bit` for more reliable multi-step tool use. It
+requires macOS on Apple Silicon and the installed MLX dependencies. An
+uncached first run downloads the selected weights from Hugging Face and needs
+network access plus several gigabytes of free disk. If MLX, network access,
+disk space, or the weights are unavailable, model loading fails before any
+tool call; do not treat a scripted checkpoint as evidence that this live run
+occurred.
+
+Pre-create the workspace, an existing file, and one focused validation fixture:
+
+```bash
+EDIT_ROOT="$(mktemp -d)"
+printf '%s\n' \
+  'def greeting(name):' \
+  '    return f"Hello, {name}!"' > "$EDIT_ROOT/app.py"
+cat > "$EDIT_ROOT/validate.py" <<'PY'
+from pathlib import Path
+from app import greeting
+
+assert greeting("Ada") == "Welcome, Ada!"
+assert Path("NOTES.md").read_text() == "Greeting now says Welcome.\n"
+print("validation passed")
+PY
+```
+
+Now give the real model one goal. `--allow-command` names the only command it
+may run, including its exact arguments. Each proposed write, edit, or command
+still pauses at a default-No learner approval prompt:
+
+```bash
+pdm run agent -- --model mlx-community/Qwen3-30B-A3B-4bit --root "$EDIT_ROOT" \
+  --allow-writes \
+  --allow-command "python validate.py" \
+  --receipt-log .agent-receipts.jsonl \
+  "Inspect the workspace. Create NOTES.md containing exactly 'Greeting now says Welcome.' followed by a newline, precisely change app.py so greeting says Welcome instead of Hello, run the allowed validation, react to its evidence, and finish with a brief summary. Use workspace tools to gather evidence before any effect. Your first response must be one tool request, every response must contain exactly one JSON object, and do not finish until the requested files and validation evidence have been inspected."
+```
+
+Read every approval payload before answering `y`. The live trace shows the
+model response, parsed action, tool observation, validation status/output, and
+final answer. Afterward, inspect the changed bytes and the durable effect
+receipts rather than trusting the final prose alone:
+
+```bash
+cat "$EDIT_ROOT/app.py" "$EDIT_ROOT/NOTES.md"
+cat "$EDIT_ROOT/.agent-receipts.jsonl"
+```
+
+The receipt records preserve the approved `write_file`, `edit_file`, and
+`run_command` arguments and outcomes. The status and captured output in the
+validation receipt are the evidence to compare with the changed bytes.
+
 ## Checkpoint
 
 You now have a small end-to-end coding loop: inspect real bytes, propose one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ bench-chunked-prefill.cmd = "python -m benches.bench_chunked_prefill"
 bench-week3-attention.cmd = "python -m benches.bench_week3_attention"
 bench-long-context-attention.cmd = "python -m benches.bench_long_context_attention"
 batch-main.cmd = "python batch-main.py"
-agent.cmd = "python agent.py"
+agent = { cmd = "python agent.py", env = { PYTHONPATH = "src" } }
 evaluate-agent.cmd = "python evaluate-agent.py"
 test.cmd = "python scripts/dev-tools.py test"
 check-installation.cmd = "python scripts/check-installation.py"

--- a/tests_refsol/test_week_4_starter_sync.py
+++ b/tests_refsol/test_week_4_starter_sync.py
@@ -3,6 +3,8 @@
 """Course-code guards for the cumulative Week 4 Day 1--4 starter."""
 
 import ast
+import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -13,6 +15,7 @@ sys.path.insert(0, str(ROOT / "src"))
 
 STARTER = ROOT / "src" / "tiny_llm" / "agent"
 REFSOL = ROOT / "src" / "tiny_llm_ref" / "agent"
+REAL_MODEL_CLI = ROOT / "agent.py"
 MODULES = (
     "checkpoint",
     "generation",
@@ -206,3 +209,31 @@ def test_starter_does_not_import_the_reference_solution():
     for path in STARTER.glob("*.py"):
         source = path.read_text(encoding="utf-8")
         assert "tiny_llm_ref" not in source
+
+
+def test_real_model_cli_exposes_only_the_learner_package():
+    source = REAL_MODEL_CLI.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assert "tiny_llm_ref" not in source
+    assert "importlib" not in source
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "tiny_llm"
+        and any(alias.name == "agent" for alias in node.names)
+        for node in tree.body
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "week4_real_model_cli", REAL_MODEL_CLI
+    )
+    assert spec is not None and spec.loader is not None
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+    parser = cli.build_parser()
+    help_text = parser.format_help()
+    assert "--solution" not in help_text
+    assert "tiny_llm_ref" not in help_text
+    assert re.search(r"\bref\b", help_text) is None
+    assert all(action.dest != "solution" for action in parser._actions)
+    args = parser.parse_args(["--root", str(ROOT), "inspect", "this", "workspace"])
+    assert not hasattr(args, "solution")

--- a/tests_refsol/test_week_4_starter_sync.py
+++ b/tests_refsol/test_week_4_starter_sync.py
@@ -4,8 +4,10 @@
 
 import ast
 import importlib.util
+import io
 import re
 import sys
+from contextlib import redirect_stdout
 from pathlib import Path
 
 import pytest
@@ -237,3 +239,38 @@ def test_real_model_cli_exposes_only_the_learner_package():
     assert all(action.dest != "solution" for action in parser._actions)
     args = parser.parse_args(["--root", str(ROOT), "inspect", "this", "workspace"])
     assert not hasattr(args, "solution")
+
+
+def test_real_model_cli_discloses_command_side_effect_scope(tmp_path, monkeypatch):
+    import tiny_llm_ref.agent as ref_agent
+
+    spec = importlib.util.spec_from_file_location(
+        "week4_real_model_cli", REAL_MODEL_CLI
+    )
+    assert spec is not None and spec.loader is not None
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+
+    command = (sys.executable, "-c", "from pathlib import Path; Path('extra').touch()")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("y\n"))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        workspace = ref_agent.Workspace(
+            ref_agent.ToolPolicy(tmp_path, allowed_commands=(command,)),
+            cli.confirm_tool,
+        )
+        result = workspace.execute(
+            ref_agent.ToolAction("run_command", {"argv": list(command)})
+        )
+        cli.show_file_tool_changes(workspace.modified_files)
+
+    assert (tmp_path / "extra").is_file()
+    assert result.startswith("status: 0")
+    text = output.getvalue()
+    assert "file-tool changes> []" in text
+    assert "approved commands may create or change additional filesystem paths" in text
+    assert (
+        "command receipts record the command and result, not a complete filesystem diff"
+        in text
+    )


### PR DESCRIPTION
## Why

The deterministic Week 4 tests prove the loop mechanics, but learners cannot yet give the real local model a goal and watch it choose tools. The advertised `pdm run agent` command also targeted unreleased Day 5–7 APIs and could not run on the merged Day 4 surface.

## Change

- replace the stale driver with a thin local MLX-LM adapter over the existing public `tiny_llm.agent` APIs
- bind the learner CLI unconditionally to the solution-free starter, with no reference selector, alias, dynamic import, or hidden switch
- keep the default read-only and every write, edit, or exact-argv command behind a default-No TTY approval
- print the real model response, parsed action, observation, final answer, scoped `file-tool changes`, and receipt path
- warn before approved commands that they may affect additional filesystem paths and that command receipts are not a complete filesystem diff
- add exploratory Day 2 inspection and Day 3 edit/validate/receipt exercises with disposable setup, factual model/cache requirements, and post-run inspection commands
- add proportional course-code guards for the public parser/help/import boundary and command-side-effect disclosure

All Day 1–4 course/starter modules and deterministic day tests are byte-identical to main. Exact identity: base `cd33f7e0a419eba0f7bfa78668f50652b977cde1`; head `9be80179cf707e8900e1fe026e881a825fc0bf70`; tree `608c4dc64c568246ad28f94f8e85d0749cc2e627`; five paths, 281 additions / 484 deletions.

## Review note

The learner-CLI guard was introduced before the repair and failed on prior head `9e5b4e5` at the exposed `tiny_llm_ref` path. It now proves `--help` and the parser expose no `--solution`, `ref`, or reference package and that the committed driver statically imports only `tiny_llm.agent`.

The command-side-effect regression was introduced before its repair and failed on prior head `f4db8e4`. It runs an actually allowed file-creating command, proves the extra path exists while file-tool changes remain empty, and requires both the scoped label and disclosure; independent label-removal and warning-removal mutations each fail this test.

Live cached `mlx-community/Qwen3-30B-A3B-4bit` evidence was real, not scripted. A one-off uncommitted maintainer harness redirected the public-package import to the reference package without altering learner wiring. Read-only chose list root → read README → list `src` → read `weather.py` → evidence-based final, with `file-tool changes> []`. Edit chose list → read `app.py` → separately approved `NOTES.md` write → separately approved exact edit → separately approved `python validate.py`; validation returned status 0 / `validation passed`, final bytes matched, and the JSONL log contained three receipts. The command also created an unlisted `__pycache__/app.cpython-312.pyc`, visibly demonstrating why the trace reports only file-tool changes and why the command warning is required. No credentials or environment dump were printed or retained.

The learner sections make no comparative reliability claim: they identify the recorded 30B run as roughly 16 GiB cached plus sufficient Apple unified memory, point lower-resource learners to the default 4B model at roughly 2 GiB cached, and state behavior/tool order vary with either choice.

Final exact-head gates: Week 4 59/59; full reference 394 passed / 8 intentional skips; Ruff, format, diff, and public solution-free CLI help clean; manual Day 4 copy byte-identical and expected-red 7/7 before cleanup; manual mdBook build passed. Hosted macOS run 31583381459 / job 94071446901 is terminal success. Sentinel task 261 was a zero-edit editorial review on the exact head.

AI-Assisted: GPT-5.6 Sol + Forge
Editorial: Sentinel
