### PR TITLE
Finalize Tiny-LLM publication metadata

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -3,7 +3,7 @@ authors = ["Alex Chi", "Connor Zhang"]
 language = "en"
 src = "src"
 title = "Tiny-LLM — Build an LLM Serving System with MLX"
-description = "A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, Metal kernels, KV caching, batching, and paged attention."
+description = "A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, then connect its inference state and context budget to a coding agent."
 
 [preprocessor.toc]
 command = "mdbook-toc"

--- a/book/src/sitemap.txt
+++ b/book/src/sitemap.txt
@@ -30,4 +30,12 @@ https://skyzh.github.io/tiny-llm/week3-optional-moe
 https://skyzh.github.io/tiny-llm/week3-optional-speculative-decoding
 https://skyzh.github.io/tiny-llm/week3-overview
 https://skyzh.github.io/tiny-llm/week4-01-agent-loop
+https://skyzh.github.io/tiny-llm/week4-02-tools
+https://skyzh.github.io/tiny-llm/week4-03-safe-editing
+https://skyzh.github.io/tiny-llm/week4-04-sessions
+https://skyzh.github.io/tiny-llm/week4-05-compaction
+https://skyzh.github.io/tiny-llm/week4-06-steering
+https://skyzh.github.io/tiny-llm/week4-07-evaluation
+https://skyzh.github.io/tiny-llm/week4-08-fork-steer-select
+https://skyzh.github.io/tiny-llm/week4-09-bound-tool-evidence
 https://skyzh.github.io/tiny-llm/week4-overview

--- a/book/src/sitemap.xml
+++ b/book/src/sitemap.xml
@@ -97,6 +97,30 @@
         <loc>https://skyzh.github.io/tiny-llm/week4-01-agent-loop</loc>
     </url>
     <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-02-tools</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-03-safe-editing</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-04-sessions</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-05-compaction</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-06-steering</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-07-evaluation</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-08-fork-steer-select</loc>
+    </url>
+    <url>
+        <loc>https://skyzh.github.io/tiny-llm/week4-09-bound-tool-evidence</loc>
+    </url>
+    <url>
         <loc>https://skyzh.github.io/tiny-llm/week4-overview</loc>
     </url>
 </urlset>

--- a/book/theme/head.hbs
+++ b/book/theme/head.hbs
@@ -5,7 +5,7 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Tiny-LLM">
 <meta property="og:title" content="{{#if chapter_title}}{{ chapter_title }} — Tiny-LLM{{else}}{{ title }}{{/if}}">
-<meta property="og:description" content="A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, Metal kernels, KV caching, batching, and paged attention.">
+<meta property="og:description" content="A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, then connect its inference state and context budget to a coding agent.">
 <meta property="og:image" content="https://skyzh.github.io/tiny-llm/tiny-llm-social.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
@@ -15,6 +15,26 @@
 <meta name="twitter:site" content="@iskyzh">
 <meta name="twitter:creator" content="@iskyzh">
 <meta name="twitter:title" content="{{#if chapter_title}}{{ chapter_title }} — Tiny-LLM{{else}}{{ title }}{{/if}}">
-<meta name="twitter:description" content="A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, Metal kernels, KV caching, batching, and paged attention.">
+<meta name="twitter:description" content="A hands-on course for systems engineers. Build and optimize an LLM serving system with MLX, then connect its inference state and context budget to a coding agent.">
 <meta name="twitter:image" content="https://skyzh.github.io/tiny-llm/tiny-llm-social.png">
 <meta name="twitter:image:alt" content="Tiny-LLM — Build an LLM Serving System with MLX">
+
+<script>
+  (function () {
+    var pageUrl = "https://skyzh.github.io" + window.location.pathname.replace(/\/index\.html$/, "/");
+    var canonical = document.createElement("link");
+    canonical.rel = "canonical";
+    canonical.href = pageUrl;
+    document.head.appendChild(canonical);
+
+    var openGraphUrl = document.createElement("meta");
+    openGraphUrl.setAttribute("property", "og:url");
+    openGraphUrl.content = pageUrl;
+    document.head.appendChild(openGraphUrl);
+
+    var twitterUrl = document.createElement("meta");
+    twitterUrl.name = "twitter:url";
+    twitterUrl.content = pageUrl;
+    document.head.appendChild(twitterUrl);
+  }());
+</script>


### PR DESCRIPTION
## Why

The frozen Week 4 book has no page-aware canonical or social URL metadata, its generated sitemap stops after Day 1, and its shared description does not reflect the coding-agent/inference integration taught in Week 4.

## What changed

- add page-aware canonical, `og:url`, and `twitter:url` metadata using the deployed pathname
- refresh the shared description to include the Week 4 coding-agent connection
- regenerate both source sitemaps so Week 4 Days 2–9 are discoverable

The learner, reference, starter, and course-code bytes are unchanged. Existing 🚧 / early-review wording is preserved.

## Manual validation

- clean `mdbook build book`
- `book/sitemap.sh --check`
- inspected landing, Week 4 overview, and Days 1–9 at representative desktop/mobile widths and light/dark presentation
- verified root, Day 1, and Day 9 canonical/OG/Twitter URLs in rendered DOM
- verified all 41 sitemap entries and visible local/external links
- confirmed navigation, keyboard controls, semantic structure, tables, and code-block overflow remain usable

AI-Assisted: gpt-5.6-sol + Herald
