### PR TITLE
Normalize the Week 4 overview and learner-day structure

### DIFF
--- a/book/src/week4-01-agent-loop.md
+++ b/book/src/week4-01-agent-loop.md
@@ -1,73 +1,58 @@
 # Day 1: A Validated Agent Loop
 
-> **Day 1 scope:** This chapter teaches a bounded loop and a JSON action
-> protocol. The supplied test uses a fake read-only workspace. File mutation
-> and command execution are not Day 1 capabilities.
+Weeks 1 through 3 built a function that turns a conversation into model text.
+A coding agent needs a small control loop around that function: ask for one
+response, decide whether it is a final answer or an action, record what
+happened, and continue when an action produces an observation.
 
-A text generator returns one response and stops. A coding agent needs a small
-control loop: it asks for one response, decides whether that response is a
-final answer or an action, records what happened, and repeats when an action
-produces an observation.
+The model never edits a file directly. It emits text. Ordinary Python validates
+that text before handing a parsed action to a workspace object. This separation
+makes the loop deterministic to test even when no model weights are loaded.
 
-The model never edits a file directly. It emits text. Ordinary Python code
-validates that text before handing a parsed action to the workspace object.
-That separation is what makes the loop testable without a model.
+## The Teaching Boundary
 
-## Files and Commands
+Day 1 teaches only a bounded loop and one JSON action protocol. The supplied
+test uses a fake workspace with one enabled read-only action. Real project
+inspection arrives on Day 2; file mutation, command execution, approval, and
+durable receipts arrive later.
 
-Implement these Day 1 starter functions:
+The loop validates and records a model response, but it does not prove that the
+model solved the task. It is also not a sandbox, background worker, persistent
+session, or production scheduler.
 
-| File | Function or type | Your responsibility |
+## Files and Public Surface
+
+Implement the TODO bodies in these Day 1 starter files:
+
+| File | Public names | Responsibility |
 | --- | --- | --- |
-| `src/tiny_llm/agent/generation.py` | `initial_messages()`, `generate_response()` | Reject a blank task, create the first messages, and decode one response with a fresh cache. |
-| `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `parse_action()`, `build_system_prompt()` | Define the exact action vocabulary, validate one JSON object, and describe only enabled actions. |
-| `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `run_agent()` | Bound the loop, append observations, and return an auditable result. |
+| `src/tiny_llm/agent/generation.py` | `initial_messages`, `generate_response` | Begin a conversation and keep one model-response boundary explicit. |
+| `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `parse_action`, `build_system_prompt` | Represent and validate one final answer or one enabled tool request. |
+| `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `run_agent` | Bound a run, propagate observations, and retain an inspectable trace. |
 
-Run the focused learner check:
+`generate_response()` remains part of the public Day 1 surface even though the
+focused test uses scripted strings. It renders the messages with the course
+tokenizer, decodes at most `max_tokens` with a fresh cache, stops at EOS, and
+releases every cache in a `finally` block.
+
+Run the cumulative learner checkpoint from the repository root:
 
 ```bash
 pdm run test --week 4 --day 1
 ```
 
-It should pass without loading a model. For the supplied reference check:
+This command copies the supplied Day 1 test into `tests/` before running it.
+Before you implement the TODOs, the implementation-dependent cases across nine
+task groups are expected to fail. No model download is required.
+
+Course maintainers can check the supplied implementation without copying the
+learner test:
 
 ```bash
 pdm run test-refsol --week 4 --day 1
 ```
 
-`generate_response()` is still a Day 1 public boundary even though the focused
-test deliberately avoids model weights. Render the messages with the tokenizer,
-decode at most the requested token count using a fresh cache, stop at EOS, and
-release every cache in a finally block. The scripted loop tests are the fast
-way to verify the control flow; a real model is not required for this checkpoint.
-
-## One Response, One Structured Decision
-
-Use JSON because it makes the protocol visible in a trace. A response is
-either a final answer:
-
-```json
-{"final":"I inspected README.md."}
-```
-
-or a tool request:
-
-```json
-{"tool":"read_file","path":"README.md"}
-```
-
-`parse_action()` must accept exactly one JSON object. It rejects malformed
-JSON, non-object values, an empty final answer, an unknown tool, disabled
-tools, missing required fields, unexpected fields, and fields with the wrong
-shape. Do not quietly ignore trailing or extra data.
-
-`TOOL_FIELDS` names the complete future vocabulary:
-`list_files`, `read_file`, `write_file`, `edit_file`, and `run_command`.
-Day 1 does not implement those effects. Its fake workspace enables only
-`read_file`, which is enough to prove that the loop validates availability
-before dispatching an action.
-
-## Start a Conversation Deliberately
+## Task 1: Start the Conversation Deliberately
 
 `initial_messages(task, system_prompt)` creates the first two messages:
 
@@ -78,69 +63,121 @@ before dispatching an action.
 ]
 ```
 
-Reject an empty or whitespace-only task. A clear first message lets later turns
-grow from a known history instead of assembling prompt fragments ad hoc.
+Reject an empty or whitespace-only task. `build_system_prompt(workspace)`
+describes only the actions enabled for this run. The prompt is guidance, not
+enforcement: the protocol and workspace boundary must still reject anything
+the policy does not allow.
 
-`build_system_prompt(workspace)` describes the enabled action set for this
-run. The prompt is guidance, not enforcement: `parse_action()` and the
-workspace boundary must independently reject anything the policy does not
-allow.
+## Task 2: Execute One Tool and Finish
 
-## The Bounded Loop
+`run_agent(task, generate, workspace, limits=None)` starts from those messages.
+The test injects a `generate` callable that returns predetermined strings, so
+the control flow stays deterministic.
 
-`run_agent()` receives a task, a `generate` callable, and a workspace. The
-tests substitute a callable that returns predetermined strings, so the loop's
-behavior stays deterministic.
+For a valid tool action, call `workspace.execute(action)`, record the action and
+result, and append both the assistant response and a user observation. When a
+later response is a valid `FinalAction`, return a completed `AgentRun` with the
+final text.
 
-```python
-messages = initial_messages(task, build_system_prompt(workspace))
-for step in range(1, limits.max_steps + 1):
-    response = generate(messages)
-    action = parse_action(response, workspace.available_tools)
+## Task 3: Validate One Structured Decision
 
-    if action is a final answer:
-        record it and stop
+A model response is exactly one JSON object. It is either a final answer:
 
-    result = workspace.execute(action)
-    record the action and result
-    messages = append the assistant response and tool observation
+```json
+{"final":"I inspected README.md."}
 ```
 
-The real implementation also turns a parse failure into an observation such
-as `error: response is not valid JSON: ...`, then lets the model try again.
-This is more useful than crashing the agent for one malformed answer.
+or one tool request:
 
-Every interaction becomes an `AgentEvent` containing the step number, raw
-response, parsed action when one exists, and result or validation error. The
-returned `AgentRun` records whether a valid final answer completed the
-protocol. It does **not** prove that a task was solved; task grading is a later
-course concern.
+```json
+{"tool":"read_file","path":"README.md"}
+```
 
-## Stop Conditions Are Part of Correctness
+`parse_action()` rejects malformed JSON, non-object values, blank final text,
+unknown or disabled tools, missing fields, unexpected fields, and fields with
+the wrong shape. Do not ignore trailing or extra data.
 
-`AgentLimits` requires positive values. Implement all of these terminal cases:
+`TOOL_FIELDS` names the cumulative vocabulary: `list_files`, `read_file`,
+`write_file`, `edit_file`, and `run_command`. Day 1 implements none of those
+effects. Its fake workspace enables only `read_file`, which is enough to prove
+that availability is checked before dispatch.
 
-- a valid final answer returns `completed`;
-- reaching `max_steps` returns `step_limit`;
-- too many invalid actions returns `invalid_action_limit`;
-- an overlong conversation returns `context_limit`; and
-- too many identical tool requests returns `repeated_action_limit`.
+Malformed or unavailable actions become ordinary `error:` observations. The
+model can see the failure and choose another response instead of crashing the
+Python loop.
 
-The repeated-action check matters even when a tool succeeds. Repeating the
-same request can burn the whole budget while adding no new information.
+## Task 4: Stop at the Step Budget
 
-## Exercise Checklist
+`AgentLimits.max_steps` bounds how many model decisions one run may attempt.
+When the loop consumes that budget without a valid final answer, return an
+incomplete run whose reason is `step_limit`. The events show exactly how the
+budget was spent.
 
-Before considering Day 1 complete, make the focused test demonstrate all of
-these behaviors:
+## Task 5: Return an Inspectable Run
 
-1. A task starts with a system message and a user message.
-2. A `read_file` request reaches the fake workspace, its result becomes an
-   observation, and a later final answer stops the run.
-3. Invalid JSON and an unavailable tool become recoverable error observations.
-4. The loop stops at the step budget.
-5. Repeated identical actions stop before the general step budget is spent.
+Every interaction becomes an `AgentEvent` with the step number, raw response,
+parsed action when one exists, and result or validation error. `AgentRun`
+records the completion flag, stop reason, optional final answer, and immutable
+event tuple.
 
-Keep the solution inside the Day 1 starter files.
+A run marked `completed` means only that the model returned a valid final
+action. Later days add receipts and outcome evaluation; Day 1 keeps the trace
+small and in memory.
+
+## Task 6: Recover from Invalid JSON
+
+After an invalid response, append the raw assistant response and its exact
+validation error as the next user observation. Reset the identical-action
+counter, then let the model try again while the invalid-action budget remains.
+
+The focused case sends invalid JSON followed by a valid final response. The
+first event must retain the recoverable error, and the second must complete the
+run.
+
+## Task 7: Stop Repeated Actions
+
+Serialize each parsed tool name and normalized argument object into a stable
+signature. Count consecutive identical requests and stop with
+`repeated_action_limit` when the count exceeds the configured budget.
+
+This guard matters even when a tool succeeds: repeating the same request can
+consume the whole run without adding new information.
+
+## Task 8: Preserve the Exact Observation
+
+The next model call must receive the complete tool result, not only a marker:
+
+```python
+{
+    "role": "user",
+    "content": "Tool result:\nREADME contents",
+}
+```
+
+The normal guard fails if that payload is changed or dropped. It also proves
+that a known-but-disabled tool such as `write_file` becomes an error
+observation and never reaches the fake workspace.
+
+## Task 9: Make Every Limit Fail Closed
+
+Require positive values for `max_steps`, `max_context_chars`,
+`max_invalid_actions`, and `max_identical_actions`. Zero or negative budgets
+would disable the intended stopping guarantee and must be rejected.
+
+Before each model call, bound the total message-content characters and stop
+with `context_limit` when it is too large. Count invalid actions and stop with
+`invalid_action_limit` when that budget is exhausted. Together with the step
+and repeated-action limits, every run has an explicit terminal reason.
+
+## Checkpoint
+
+When Day 1 is green, inspect the focused test rather than only its final pass:
+confirm the initial system/user pair, one dispatched `read_file`, the exact
+observation in the next model input, the completed final event, and each
+budgeted stop reason.
+
+You now have a validated, bounded model → action → observation loop. Continue
+with [Day 2: Inspect a Workspace](week4-02-tools.md) to replace the fake tool
+boundary with real contained directory listing and UTF-8 file reads.
 
 {{#include copyright.md}}

--- a/book/src/week4-02-tools.md
+++ b/book/src/week4-02-tools.md
@@ -168,8 +168,9 @@ pdm run test --week 4 --day 2
 ```
 
 This copies the cumulative Day 2 learner test into `tests/` and runs it against
-`tiny_llm`. During course development, check the supplied implementation
-without copying the learner test:
+`tiny_llm`. Before you implement the TODOs, the implementation-dependent cases
+across six task groups are expected to fail. During course development, check
+the supplied implementation without copying the learner test:
 
 ```bash
 pdm run test-refsol --week 4 --day 2
@@ -219,6 +220,12 @@ the final answer with the actual disposable files:
 find "$INSPECT_ROOT" -type f -print
 cat "$INSPECT_ROOT/README.md" "$INSPECT_ROOT/src/weather.py"
 ```
+
+## Checkpoint
+
+Confirm that the deterministic run listed a directory, read exact UTF-8 file
+contents, returned recoverable path errors to the model, and completed without
+enabling any effect tool.
 
 When this checkpoint is green, continue to [Day 3: Edit, Validate, and
 Record](week4-03-safe-editing.md).

--- a/book/src/week4-04-sessions.md
+++ b/book/src/week4-04-sessions.md
@@ -15,7 +15,7 @@ This is a teaching checkpoint for one process and the course's fake model. It
 is not a session tree, rewind feature, persistent KV store, transaction log, or
 exactly-once effect system.
 
-## Check the Chapter
+## Files and Public Surface
 
 Implement the TODO-only surfaces in:
 

--- a/book/src/week4-05-compaction.md
+++ b/book/src/week4-05-compaction.md
@@ -170,6 +170,8 @@ receipt lookup by summary text, K/V cache editing, session trees, rewind,
 steering, or exactly-once execution. It compacts only completed effects backed
 by the receipts the caller supplies.
 
+## Checkpoint
+
 You can now make an older validation interaction visibly smaller, inspect the
 receipt that retains its complete result, and feed the compact view to the next
 model call. Continue with [Day 6: Inspect and Steer a Paused

--- a/book/src/week4-09-bound-tool-evidence.md
+++ b/book/src/week4-09-bound-tool-evidence.md
@@ -35,6 +35,12 @@ pdm run test --week 4 --day 9
 Before you implement the TODOs, the implementation-dependent cases across six
 tasks are expected to fail; the shared constructor-validation cases already pass.
 
+Use this command for the supplied implementation:
+
+```bash
+pdm run test-refsol --week 4 --day 9
+```
+
 ## Task 1: Give Exact Bytes an Identity
 
 `ArtifactStore.put(result)` encodes the complete result as UTF-8, writes those

--- a/book/src/week4-overview.md
+++ b/book/src/week4-overview.md
@@ -4,139 +4,92 @@
 > through 9 are ready to learn and review. Additional capabilities will appear
 > only after their implementation, starter, and reviews are ready.
 
-Weeks 1 through 3 turn tokens into text and make serving that text efficient.
-Week 4 starts a different kind of program: an agent repeatedly asks the model
-for one structured action, records the result, and gives that result back to
-the model. Day 1 builds the bounded deterministic loop. Day 2 gives that loop a
-small read-only workspace for listing and reading project files. Day 3 adds an
-approval boundary for edits, one exact validation command, and simple receipts.
-Day 4 saves a complete conversation boundary and the fake model's cache
-metadata, then restores both into a fresh model without replaying effects.
-Day 5 derives a smaller model-visible transcript from older completed effects
-while their exact receipts remain unchanged. Day 6 inspects one safe checkpoint,
-adds one visible operator steering message, and resumes a fresh model without
-replaying the completed effect. Day 7 evaluates one completed run from declared
-final, file, result, and receipt facts without grading hidden reasoning or exact
-transcript shape.
-Day 8 reconnects the agent to the inference system from Weeks 1–3: it saves one
-real tokenizer/KV prefix, forks two isolated steered continuations without
-rewinding completed effects, evaluates both, and makes one explicit selection.
-Day 9 keeps oversized tool-result bytes in a local artifact store while the
-model sees a bounded identity, digest, preview, and explicit range-retrieval
-path through the unchanged agent loop.
+Weeks 1 through 3 built the inference path: tokenize a conversation, run the
+model, and manage the key/value cache that makes later decoding efficient.
+Week 4 puts that path inside a small coding-agent harness. The model proposes
+one structured action at a time; ordinary Python validates it, executes it
+through an explicit workspace boundary, returns the observation, and decides
+when the run must stop.
 
-## What Day 1 Builds
+The goal is not broad autonomy. Each day adds one visible mechanism that you
+can inspect and test: bounded control flow, read-only tools, approved effects,
+receipts, checkpoints, context selection, steering, evaluation, prefix reuse,
+and bounded evidence retrieval.
 
-Day 1 establishes the protocol and control flow that later checkpoints will
-extend:
+## The Nine-Day Progression
 
-```text
-task + system instruction
-          |
-          v
-     model response
-          |
-          v
-  validate one JSON action
-      |             |
-      | tool        | final answer
-      v             v
- execute through  stop the run
- a supplied workspace
-      |
-      v
- append an observation and continue
-```
-
-The workspace in the Day 1 tests is a small fake object with one enabled
-read-only action. This keeps the learning target focused: validate the model's
-text, bound the loop, and preserve the conversation. Day 2 replaces the fake
-with real read-only tools without changing the Day 1 loop contract.
-
-## Day 1 Checkpoint
-
-The Day 1 starter exposes exactly these public names:
-
-| File | Public names | Why they are here |
+| Day | Question | Visible mechanism |
 | --- | --- | --- |
-| `src/tiny_llm/agent/generation.py` | `initial_messages`, `generate_response` | Begin a conversation and keep the one-response model boundary explicit. |
-| `src/tiny_llm/agent/protocol.py` | `AgentError`, `FinalAction`, `ToolAction`, `parse_action`, `build_system_prompt` | Represent and validate one final answer or one tool request. |
-| `src/tiny_llm/agent/loop.py` | `AgentLimits`, `AgentEvent`, `AgentRun`, `run_agent` | Bound the run and retain an inspectable trace. |
+| [1](week4-01-agent-loop.md) | How does model text become one safe next step? | A validated JSON action protocol and bounded loop. |
+| [2](week4-02-tools.md) | How can the agent inspect a project? | A contained read-only workspace with listing and file reads. |
+| [3](week4-03-safe-editing.md) | How can it change and validate code deliberately? | Operator approval, exact edits and commands, and effect receipts. |
+| [4](week4-04-sessions.md) | Where can a run pause and resume? | One complete-observation checkpoint with model cache metadata. |
+| [5](week4-05-compaction.md) | How can older completed work use less context? | Receipt-backed deterministic compaction of completed interactions. |
+| [6](week4-06-steering.md) | How can an operator inspect and redirect a paused run? | A public status view and one visible steering message. |
+| [7](week4-07-evaluation.md) | How do we judge a run without grading hidden reasoning? | A deterministic report over declared observable outcomes. |
+| [8](week4-08-fork-steer-select.md) | How can two continuations reuse one inference prefix? | Dense tokenizer/KV-prefix reuse, isolated effects, and explicit selection. |
+| [9](week4-09-bound-tool-evidence.md) | How can a large tool result remain available without filling the prompt? | Content-addressed external bytes, bounded previews, and explicit range retrieval. |
 
-Implement the Day 1 exercise, then run:
+The sequence is cumulative. Later starters keep the earlier public surface, and
+later tests rely on the boundaries established before them. Work through the
+days in order even when one later mechanism is your main interest.
 
-```bash
-pdm run test --week 4 --day 1
-```
+## Prerequisites and Environment
 
-The learner test uses scripted responses and a fake workspace, so it does not
-download or load a model. To check the supplied implementation without copying
-the learner test, run:
+Complete the repository setup and Weeks 1 through 3 first. Day 8 directly uses
+the course tokenizer, model, and dense KV cache; the earlier Week 4 days also
+assume you recognize the model-generation boundary those weeks established.
 
-```bash
-pdm run test-refsol --week 4 --day 1
-```
+The supported environment is macOS on Apple Silicon with the project
+dependencies installed. The deterministic Week 4 learner tests use scripted
+models and temporary workspaces, so they do not need model downloads. The
+chapters that include real-model walkthroughs label them as manual and
+nondeterministic; uncached runs additionally need network access, disk space,
+and enough Apple unified memory for the selected MLX weights.
 
-## Publication Boundary
+Use only disposable workspaces with no secrets. Read observations become model
+input, and later days can enable file changes and an exact allowlisted command.
 
-After Day 1 passes, continue with [Day 2: Inspect a
-Workspace](week4-02-tools.md). The cumulative Day 2 command is:
+## How to Use This Week
 
-```bash
-pdm run test --week 4 --day 2
-```
+For each day:
 
-After Day 2 passes, continue with [Day 3: Edit, Validate, and
-Record](week4-03-safe-editing.md). Its cumulative command is:
+1. Read its teaching boundary and public starter surface.
+2. Run the day-specific learner command to see the expected failures.
+3. Implement only that day's numbered tasks in `src/tiny_llm/agent/`.
+4. Rerun the same cumulative checkpoint until it is green.
+5. Inspect the recorded events, files, receipts, reports, or cache facts named
+   by the chapter instead of trusting a final model sentence alone.
 
-```bash
-pdm run test --week 4 --day 3
-```
+The day chapters contain the exact commands and checkpoints. Course maintainers
+can use the corresponding reference command without copying a learner test.
+Optional real-model walkthroughs come after the deterministic checkpoint; they
+are exploration, not a replacement for reproducible course-code evidence.
 
-After Day 3 passes, continue with [Day 4: Checkpoint and
-Resume](week4-04-sessions.md). Its cumulative command is:
+## The Cumulative Learning Arc
 
-```bash
-pdm run test --week 4 --day 4
-```
+Days 1 through 3 establish the ordinary agent cycle: propose, validate,
+observe, approve effects, and record evidence. Days 4 through 6 show how the
+harness can pause, reduce older context, and add an operator instruction while
+preserving completed work. Day 7 evaluates observable outcomes. Day 8 reconnects
+that control path to the tokenizer and KV cache from Weeks 1 through 3. Day 9
+keeps oversized results verifiable while exposing only a bounded view to the
+model.
 
-After Day 4 passes, continue with [Day 5: Compact Completed
-Work](week4-05-compaction.md). Its cumulative command is:
+By the end, you can explain both sides of the boundary: what the model sees and
+proposes, and what the harness validates, executes, retains, or refuses.
 
-```bash
-pdm run test --week 4 --day 5
-```
+## Week Boundary
 
-After Day 5 passes, continue with [Day 6: Inspect and Steer a Paused
-Agent](week4-06-steering.md). Its cumulative command is:
+This is a teaching agent for a trusted operator and disposable local projects.
+It is not a sandbox, hostile-filesystem defense, process jail, durable
+transaction system, distributed scheduler, session tree, hidden grader,
+semantic-perfect memory, network artifact service, or production serving
+framework. Completed effects are never presented as rewound, and a model's
+final prose is never treated as proof by itself.
 
-```bash
-pdm run test --week 4 --day 6
-```
-
-After Day 6 passes, continue with [Day 7: Evaluate Observable
-Outcomes](week4-07-evaluation.md). Its cumulative command is:
-
-```bash
-pdm run test --week 4 --day 7
-```
-
-After Day 7 passes, continue with [Day 8: Fork, Steer, and
-Select](week4-08-fork-steer-select.md). Its cumulative command is:
-
-```bash
-pdm run test --week 4 --day 8
-```
-
-After Day 8 passes, continue with [Day 9: Bound Tool
-Evidence](week4-09-bound-tool-evidence.md). Its cumulative command is:
-
-```bash
-pdm run test --week 4 --day 9
-```
-
-Only the Day 1 through Day 9 starter modules are published. Do not add session
-trees, effect rewind, reconciliation, an LLM judge, semantic summarization,
-radix serving, or other later public APIs to your solution.
+Each day states its narrower limits where they matter. Keep later or
+production-scale APIs out of the starter unless a chapter explicitly teaches
+them.
 
 {{#include copyright.md}}


### PR DESCRIPTION
## Summary

- separate the Week 4 overview from Day 1 implementation details and replace the repeated day commands with a concise nine-day learning map
- restructure Day 1 around the same learner grammar as Days 2–9: teaching boundary, public surface, Tasks 1–9, commands, expected failures, checkpoint, and Day 2 handoff
- add only the necessary consistency cues to Days 2, 4, 5, and 9; preserve Days 3, 6, 7, and 8 byte-for-byte

This is a prose-only normalization on exact main `2bd3baf79e647f8c2dfb4dc4b539244da612f5d9`. It changes no Python, starter, tests, navigation, publication metadata, theme, sitemap, technical scope, readiness state, release, or deploy surface.

## Evidence

- cumulative Week 4 learner/reference course-code preservation: 146/146 passed
- Day 1 learner checkpoint: 13 expected TODO failures and 2 shared mutation-guard passes, confirming the nine visible task groups and expected-red wording
- manual mdBook build and complete changed-chapter read-through passed
- `git diff --check` passed; generated learner test and book output cleaned

AI-Assisted: GPT-5.6 Sol + Sentinel

Reviewed-by: GPT-5.6 Terra + Oracle (consistency)

Reviewed-by: GPT-5.6 Terra + Scholar (learner)
