### PR TITLE
Add a course roadmap and entry paths

### DIFF
--- a/book/src/course-roadmap.svg
+++ b/book/src/course-roadmap.svg
@@ -125,27 +125,24 @@
   <text class="detail" x="500" y="682" text-anchor="middle">paging / batching / scheduler</text>
   <path class="arrow" d="M 450 482 L 450 556 L 500 556 L 500 590" />
 
-  <text class="title" x="720" y="568">Week 4 scripted-model lessons</text>
-  <rect class="box week4" x="720" y="590" width="220" height="104" rx="10" />
-  <text class="label" x="830" y="620" text-anchor="middle">Days 1–7</text>
-  <text class="detail" x="830" y="644" text-anchor="middle">scripted-model</text>
-  <text class="detail" x="830" y="663" text-anchor="middle">coding-agent mechanics</text>
-  <text class="detail" x="830" y="682" text-anchor="middle">can start after setup</text>
+  <text class="title" x="740" y="568">Week 4 scripted-model lessons</text>
+  <rect class="box week4" x="740" y="590" width="270" height="104" rx="10" />
+  <text class="label" x="875" y="620" text-anchor="middle">Days 1–7</text>
+  <text class="detail" x="875" y="644" text-anchor="middle">scripted-model</text>
+  <text class="detail" x="875" y="663" text-anchor="middle">coding-agent mechanics</text>
+  <text class="detail" x="875" y="682" text-anchor="middle">independent entry after setup</text>
 
-  <rect class="box week4" x="980" y="590" width="172" height="104" rx="10" />
-  <text class="label" x="1066" y="620" text-anchor="middle">Day 8</text>
-  <text class="detail" x="1066" y="644" text-anchor="middle">real tokenizer +</text>
-  <text class="detail" x="1066" y="663" text-anchor="middle">KV-prefix bridge</text>
-  <path class="arrow" d="M 940 642 L 980 642" />
-  <path class="arrow" d="M 640 642 L 690 642 L 690 724 L 1020 724 L 1020 694" />
-  <text class="small" x="777" y="719">Week 3 serving bridge</text>
+  <rect class="box week4" x="600" y="735" width="220" height="92" rx="10" />
+  <text class="label" x="710" y="764" text-anchor="middle">Day 8 · Join</text>
+  <text class="detail" x="710" y="788" text-anchor="middle">real tokenizer +</text>
+  <text class="detail" x="710" y="807" text-anchor="middle">KV-prefix bridge</text>
+  <path class="arrow" d="M 500 694 L 500 710 L 660 710 L 660 735" />
+  <path class="arrow" d="M 875 694 L 875 710 L 760 710 L 760 735" />
 
-  <rect class="box week4" x="980" y="750" width="172" height="82" rx="10" />
-  <text class="label" x="1066" y="780" text-anchor="middle">Day 9</text>
-  <text class="detail" x="1066" y="804" text-anchor="middle">bound tool evidence</text>
-  <path class="arrow" d="M 1105 694 L 1105 750" />
-  <path class="arrow" d="M 70 168 L 24 168 L 24 760 L 830 760 L 830 694" />
-  <text class="small" x="48" y="753">scripted path from setup</text>
+  <rect class="box week4" x="900" y="735" width="220" height="92" rx="10" />
+  <text class="label" x="1010" y="764" text-anchor="middle">Day 9</text>
+  <text class="detail" x="1010" y="788" text-anchor="middle">bound tool evidence</text>
+  <path class="arrow" d="M 820 781 L 900 781" />
 
   <text class="title" x="48" y="870">Run or inspect without completing earlier exercises</text>
   <rect class="box reference" x="48" y="894" width="500" height="104" rx="10" />

--- a/book/src/course-roadmap.svg
+++ b/book/src/course-roadmap.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1040" role="img" aria-labelledby="title description">
   <title id="title">Tiny-LLM course roadmap, Week 2 operator off-ramps, and entry paths</title>
-  <desc id="description">The course implementation proceeds from setup and Week 1 through seven Week 2 days into Week 3. Week 2 Days 1 and 2 establish required state and measurement. Days 3 through 7 preserve course interfaces but allow manual substitution of corresponding MLX operators instead of custom kernels. This per-operator path is different from the full-MLX solution, which bypasses the course stack. Week 4 scripted-model lessons can begin after setup; Day 8 reconnects them to the Week 3 tokenizer and KV cache.</desc>
+  <desc id="description">The cumulative course implementation proceeds from setup and Week 1 through seven Week 2 days and Week 3 into Week 4. Week 2 Days 1 and 2 establish required state and measurement. Days 3 through 7 preserve course interfaces but allow manual substitution of corresponding MLX operators instead of custom kernels. This per-operator path is different from the full-MLX solution, which bypasses the course stack. Week 4 keeps setup plus Weeks 1 through 3 as course prerequisites, while the deterministic scripted-model tests for Days 1 through 7 can run after setup without a working serving implementation. Day 8 reconnects the scripted sequence to the Week 3 tokenizer and KV cache.</desc>
   <style>
     :root {
       color-scheme: light dark;
@@ -97,9 +97,10 @@
   <text class="title" x="900" y="478">Week 4 scripted-model lessons</text>
   <rect class="box week4" x="900" y="500" width="260" height="104" rx="10" />
   <text class="label" x="1030" y="530" text-anchor="middle">Days 1–7</text>
-  <text class="detail" x="1030" y="554" text-anchor="middle">scripted-model</text>
-  <text class="detail" x="1030" y="573" text-anchor="middle">coding-agent mechanics</text>
-  <text class="detail" x="1030" y="592" text-anchor="middle">independent entry after setup</text>
+  <text class="detail" x="1030" y="554" text-anchor="middle">course follows Week 3</text>
+  <text class="detail" x="1030" y="573" text-anchor="middle">scripted-model mechanics</text>
+  <text class="detail" x="1030" y="592" text-anchor="middle">tests runnable after setup</text>
+  <path class="arrow" d="M 880 552 L 900 552" />
 
   <rect class="box week4" x="700" y="645" width="220" height="92" rx="10" />
   <text class="label" x="810" y="674" text-anchor="middle">Day 8 · Join</text>

--- a/book/src/course-roadmap.svg
+++ b/book/src/course-roadmap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1120" role="img" aria-labelledby="title description">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1040" role="img" aria-labelledby="title description">
   <title id="title">Tiny-LLM course roadmap, Week 2 operator off-ramps, and entry paths</title>
   <desc id="description">The course implementation proceeds from setup and Week 1 through seven Week 2 days into Week 3. Week 2 Days 1 and 2 establish required state and measurement. Days 3 through 7 preserve course interfaces but allow manual substitution of corresponding MLX operators instead of custom kernels. This per-operator path is different from the full-MLX solution, which bypasses the course stack. Week 4 scripted-model lessons can begin after setup; Day 8 reconnects them to the Week 3 tokenizer and KV cache.</desc>
   <style>
@@ -56,7 +56,7 @@
     </marker>
   </defs>
 
-  <rect class="background" width="1200" height="1120" />
+  <rect class="background" width="1200" height="1040" />
   <text class="title" x="48" y="38">Cumulative course interfaces and state</text>
   <text class="detail" x="48" y="59">Keep the course boundary; choose a custom kernel or an explicit MLX operator at optimization seams.</text>
 
@@ -71,93 +71,62 @@
   <text class="detail" x="386" y="154" text-anchor="middle">model interfaces</text>
   <path class="arrow" d="M 218 125 L 286 125" />
 
-  <rect class="panel" x="48" y="210" width="1104" height="318" rx="12" />
+  <rect class="panel" x="48" y="210" width="1104" height="220" rx="12" />
   <text class="title" x="72" y="242">Week 2 · keep the model/state boundary; optimize or substitute each operator</text>
 
-  <rect class="box week2" x="72" y="265" width="230" height="92" rx="10" />
-  <text class="label" x="187" y="294" text-anchor="middle">Day 1 · KV cache</text>
-  <text class="detail" x="187" y="318" text-anchor="middle">required state +</text>
-  <text class="detail" x="187" y="337" text-anchor="middle">Week 2 model shell</text>
+  <rect class="box week2" x="96" y="275" width="350" height="105" rx="10" />
+  <text class="label" x="271" y="307" text-anchor="middle">Days 1–2 · Foundation</text>
+  <text class="detail" x="271" y="333" text-anchor="middle">Week 2 model + dense KV-cache state</text>
+  <text class="detail" x="271" y="354" text-anchor="middle">matched measurement method</text>
 
-  <rect class="box week2" x="335" y="265" width="230" height="92" rx="10" />
-  <text class="label" x="450" y="294" text-anchor="middle">Day 2 · Measure</text>
-  <text class="detail" x="450" y="318" text-anchor="middle">matched benchmark</text>
-  <text class="detail" x="450" y="337" text-anchor="middle">not an operator seam</text>
+  <rect class="box week2 optional" x="570" y="275" width="534" height="105" rx="10" />
+  <text class="label" x="837" y="307" text-anchor="middle">Days 3–7 · Operator optimizations</text>
+  <text class="detail" x="837" y="333" text-anchor="middle">keep packed-weight, model, cache, shape, and dispatch interfaces</text>
+  <text class="detail" x="837" y="354" text-anchor="middle">manual MLX off-ramp at each optimization seam</text>
 
-  <rect class="box week2 optional" x="598" y="265" width="230" height="92" rx="10" />
-  <text class="label" x="713" y="294" text-anchor="middle">Day 3 · Quantize</text>
-  <text class="detail" x="713" y="318" text-anchor="middle">keep packing + model wiring</text>
-  <text class="detail" x="713" y="337" text-anchor="middle">MLX off-ramp: projections</text>
+  <path class="arrow" d="M 446 327 L 570 327" />
+  <path class="arrow" d="M 386 168 L 386 190 L 271 190 L 271 275" />
 
-  <rect class="box week2 optional" x="861" y="265" width="230" height="92" rx="10" />
-  <text class="label" x="976" y="294" text-anchor="middle">Day 4 · Fused ops</text>
-  <text class="detail" x="976" y="318" text-anchor="middle">keep model call sites</text>
-  <text class="detail" x="976" y="337" text-anchor="middle">MLX: norm / RoPE / SiLU</text>
+  <rect class="box week3" x="600" y="500" width="280" height="104" rx="10" />
+  <text class="label" x="740" y="530" text-anchor="middle">Week 3</text>
+  <text class="detail" x="740" y="554" text-anchor="middle">MLX quantized projections</text>
+  <text class="detail" x="740" y="573" text-anchor="middle">course cache / attention /</text>
+  <text class="detail" x="740" y="592" text-anchor="middle">paging / batching / scheduler</text>
+  <path class="arrow" d="M 837 380 L 837 465 L 740 465 L 740 500" />
 
-  <path class="arrow" d="M 302 311 L 335 311" />
-  <path class="arrow" d="M 565 311 L 598 311" />
-  <path class="arrow" d="M 828 311 L 861 311" />
+  <text class="title" x="900" y="478">Week 4 scripted-model lessons</text>
+  <rect class="box week4" x="900" y="500" width="260" height="104" rx="10" />
+  <text class="label" x="1030" y="530" text-anchor="middle">Days 1–7</text>
+  <text class="detail" x="1030" y="554" text-anchor="middle">scripted-model</text>
+  <text class="detail" x="1030" y="573" text-anchor="middle">coding-agent mechanics</text>
+  <text class="detail" x="1030" y="592" text-anchor="middle">independent entry after setup</text>
 
-  <rect class="box week2 optional" x="861" y="390" width="230" height="92" rx="10" />
-  <text class="label" x="976" y="419" text-anchor="middle">Day 5 · Decode attention</text>
-  <text class="detail" x="976" y="443" text-anchor="middle">keep cache + shape adapter</text>
-  <text class="detail" x="976" y="462" text-anchor="middle">MLX off-ramp: SDPA</text>
+  <rect class="box week4" x="700" y="645" width="220" height="92" rx="10" />
+  <text class="label" x="810" y="674" text-anchor="middle">Day 8 · Join</text>
+  <text class="detail" x="810" y="698" text-anchor="middle">real tokenizer +</text>
+  <text class="detail" x="810" y="717" text-anchor="middle">KV-prefix bridge</text>
+  <path class="arrow" d="M 740 604 L 740 625 L 780 625 L 780 645" />
+  <path class="arrow" d="M 1030 604 L 1030 625 L 840 625 L 840 645" />
 
-  <rect class="box week2 optional" x="598" y="390" width="230" height="92" rx="10" />
-  <text class="label" x="713" y="419" text-anchor="middle">Day 6 · Tiled prefill</text>
-  <text class="detail" x="713" y="443" text-anchor="middle">keep projection API</text>
-  <text class="detail" x="713" y="462" text-anchor="middle">MLX off-ramp: projections</text>
+  <rect class="box week4" x="980" y="645" width="180" height="92" rx="10" />
+  <text class="label" x="1070" y="674" text-anchor="middle">Day 9</text>
+  <text class="detail" x="1070" y="698" text-anchor="middle">bound tool evidence</text>
+  <path class="arrow" d="M 920 691 L 980 691" />
 
-  <rect class="box week2 optional" x="335" y="390" width="230" height="92" rx="10" />
-  <text class="label" x="450" y="419" text-anchor="middle">Day 7 · Split-K</text>
-  <text class="detail" x="450" y="443" text-anchor="middle">keep dispatch boundary</text>
-  <text class="detail" x="450" y="462" text-anchor="middle">MLX off-ramp: projections</text>
+  <text class="title" x="48" y="790">Run or inspect without completing earlier exercises</text>
+  <rect class="box reference" x="48" y="814" width="500" height="104" rx="10" />
+  <text class="label" x="72" y="845">Supplied reference solution</text>
+  <text class="detail" x="72" y="870">Run completed checkpoints with test-refsol or --solution ref.</text>
+  <text class="detail" x="72" y="890">It demonstrates the checkpoint; it does not fill learner TODOs.</text>
 
-  <path class="arrow" d="M 1091 311 L 1120 311 L 1120 436 L 1091 436" />
-  <path class="arrow" d="M 861 436 L 828 436" />
-  <path class="arrow" d="M 598 436 L 565 436" />
-  <path class="arrow" d="M 386 168 L 386 188 L 187 188 L 187 265" />
+  <rect class="box baseline" x="590" y="814" width="562" height="104" rx="10" />
+  <text class="label" x="614" y="845">Full MLX baseline</text>
+  <text class="detail" x="614" y="870">--solution mlx replaces the whole model and bypasses course code.</text>
+  <text class="detail" x="614" y="890">It is not the manual per-operator path shown in Week 2.</text>
 
-  <rect class="box week3" x="360" y="590" width="280" height="104" rx="10" />
-  <text class="label" x="500" y="620" text-anchor="middle">Week 3</text>
-  <text class="detail" x="500" y="644" text-anchor="middle">MLX quantized projections</text>
-  <text class="detail" x="500" y="663" text-anchor="middle">course cache / attention /</text>
-  <text class="detail" x="500" y="682" text-anchor="middle">paging / batching / scheduler</text>
-  <path class="arrow" d="M 450 482 L 450 556 L 500 556 L 500 590" />
-
-  <text class="title" x="740" y="568">Week 4 scripted-model lessons</text>
-  <rect class="box week4" x="740" y="590" width="270" height="104" rx="10" />
-  <text class="label" x="875" y="620" text-anchor="middle">Days 1–7</text>
-  <text class="detail" x="875" y="644" text-anchor="middle">scripted-model</text>
-  <text class="detail" x="875" y="663" text-anchor="middle">coding-agent mechanics</text>
-  <text class="detail" x="875" y="682" text-anchor="middle">independent entry after setup</text>
-
-  <rect class="box week4" x="600" y="735" width="220" height="92" rx="10" />
-  <text class="label" x="710" y="764" text-anchor="middle">Day 8 · Join</text>
-  <text class="detail" x="710" y="788" text-anchor="middle">real tokenizer +</text>
-  <text class="detail" x="710" y="807" text-anchor="middle">KV-prefix bridge</text>
-  <path class="arrow" d="M 500 694 L 500 710 L 660 710 L 660 735" />
-  <path class="arrow" d="M 875 694 L 875 710 L 760 710 L 760 735" />
-
-  <rect class="box week4" x="900" y="735" width="220" height="92" rx="10" />
-  <text class="label" x="1010" y="764" text-anchor="middle">Day 9</text>
-  <text class="detail" x="1010" y="788" text-anchor="middle">bound tool evidence</text>
-  <path class="arrow" d="M 820 781 L 900 781" />
-
-  <text class="title" x="48" y="870">Run or inspect without completing earlier exercises</text>
-  <rect class="box reference" x="48" y="894" width="500" height="104" rx="10" />
-  <text class="label" x="72" y="925">Supplied reference solution</text>
-  <text class="detail" x="72" y="950">Run completed checkpoints with test-refsol or --solution ref.</text>
-  <text class="detail" x="72" y="970">It demonstrates the checkpoint; it does not fill learner TODOs.</text>
-
-  <rect class="box baseline" x="590" y="894" width="562" height="104" rx="10" />
-  <text class="label" x="614" y="925">Full MLX baseline</text>
-  <text class="detail" x="614" y="950">--solution mlx replaces the whole model and bypasses course code.</text>
-  <text class="detail" x="614" y="970">It is not the manual per-operator path shown in Week 2.</text>
-
-  <line x1="48" y1="1047" x2="111" y2="1047" class="arrow" />
-  <text class="detail" x="128" y="1052">interface / state prerequisite</text>
-  <rect class="box week2 optional" x="390" y="1029" width="64" height="35" rx="7" />
-  <text class="detail" x="470" y="1052">custom operator may be replaced manually at the same interface</text>
-  <text class="small" x="48" y="1097">An off-ramp continues the course but does not complete that day's custom-kernel tests or performance claim.</text>
+  <line x1="48" y1="967" x2="111" y2="967" class="arrow" />
+  <text class="detail" x="128" y="972">interface / state prerequisite</text>
+  <rect class="box week2 optional" x="390" y="949" width="64" height="35" rx="7" />
+  <text class="detail" x="470" y="972">custom operator may be replaced manually at the same interface</text>
+  <text class="small" x="48" y="1017">An off-ramp continues the course but does not complete that day's custom-kernel tests or performance claim.</text>
 </svg>

--- a/book/src/course-roadmap.svg
+++ b/book/src/course-roadmap.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 690" role="img" aria-labelledby="title description">
-  <title id="title">Tiny-LLM course roadmap and entry paths</title>
-  <desc id="description">The cumulative learner implementation proceeds from setup to Week 1, Week 2, and Week 3. A separate Week 4 scripted-agent sequence can begin after setup. Week 4 Day 8 joins both paths because it connects the agent to the real tokenizer and KV cache, then Day 9 continues. A supplied reference solution can run any completed checkpoint. Full MLX is a comparison baseline and does not supply learner prerequisites.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1120" role="img" aria-labelledby="title description">
+  <title id="title">Tiny-LLM course roadmap, Week 2 operator off-ramps, and entry paths</title>
+  <desc id="description">The course implementation proceeds from setup and Week 1 through seven Week 2 days into Week 3. Week 2 Days 1 and 2 establish required state and measurement. Days 3 through 7 preserve course interfaces but allow manual substitution of corresponding MLX operators instead of custom kernels. This per-operator path is different from the full-MLX solution, which bypasses the course stack. Week 4 scripted-model lessons can begin after setup; Day 8 reconnects them to the Week 3 tokenizer and KV cache.</desc>
   <style>
     :root {
       color-scheme: light dark;
@@ -35,6 +35,7 @@
     }
     .background { fill: var(--background); }
     .box { stroke: var(--border); stroke-width: 1.5; }
+    .panel { fill: none; stroke: var(--border); stroke-width: 1.5; }
     .setup { fill: var(--setup); }
     .week1 { fill: var(--week1); }
     .week2 { fill: var(--week2); }
@@ -42,13 +43,12 @@
     .week4 { fill: var(--week4); }
     .reference { fill: var(--reference); }
     .baseline { fill: var(--baseline); }
-    .optional { stroke-dasharray: 7 6; }
+    .optional { stroke-dasharray: 7 5; stroke-width: 2; }
     .title { fill: var(--foreground); font: 700 18px system-ui, sans-serif; }
-    .label { fill: var(--foreground); font: 650 16px system-ui, sans-serif; }
+    .label { fill: var(--foreground); font: 650 15px system-ui, sans-serif; }
     .detail { fill: var(--muted); font: 13px system-ui, sans-serif; }
     .small { fill: var(--muted); font: 12px system-ui, sans-serif; }
     .arrow { fill: none; stroke: var(--arrow); stroke-width: 2.5; marker-end: url(#arrowhead); }
-    .dash { fill: none; stroke: var(--arrow); stroke-width: 2; stroke-dasharray: 7 6; marker-end: url(#arrowhead); }
   </style>
   <defs>
     <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
@@ -56,71 +56,111 @@
     </marker>
   </defs>
 
-  <rect class="background" width="1200" height="690" />
-  <text class="title" x="48" y="40">Cumulative learner implementation</text>
+  <rect class="background" width="1200" height="1120" />
+  <text class="title" x="48" y="38">Cumulative course interfaces and state</text>
+  <text class="detail" x="48" y="59">Keep the course boundary; choose a custom kernel or an explicit MLX operator at optimization seams.</text>
 
-  <rect class="box setup" x="48" y="64" width="150" height="92" rx="10" />
-  <text class="label" x="123" y="98" text-anchor="middle">Setup</text>
-  <text class="detail" x="123" y="122" text-anchor="middle">MLX + model files</text>
-  <text class="detail" x="123" y="141" text-anchor="middle">reference checks</text>
+  <rect class="box setup" x="48" y="82" width="170" height="86" rx="10" />
+  <text class="label" x="133" y="113" text-anchor="middle">Setup</text>
+  <text class="detail" x="133" y="136" text-anchor="middle">MLX + model files</text>
+  <text class="detail" x="133" y="154" text-anchor="middle">reference checks</text>
 
-  <rect class="box week1" x="258" y="64" width="190" height="92" rx="10" />
-  <text class="label" x="353" y="96" text-anchor="middle">Week 1</text>
-  <text class="detail" x="353" y="120" text-anchor="middle">Readable Qwen3</text>
-  <text class="detail" x="353" y="139" text-anchor="middle">matmul → text</text>
+  <rect class="box week1" x="286" y="82" width="200" height="86" rx="10" />
+  <text class="label" x="386" y="113" text-anchor="middle">Week 1</text>
+  <text class="detail" x="386" y="136" text-anchor="middle">Readable Qwen3</text>
+  <text class="detail" x="386" y="154" text-anchor="middle">model interfaces</text>
+  <path class="arrow" d="M 218 125 L 286 125" />
 
-  <rect class="box week2" x="508" y="64" width="190" height="92" rx="10" />
-  <text class="label" x="603" y="96" text-anchor="middle">Week 2</text>
-  <text class="detail" x="603" y="120" text-anchor="middle">Dense KV cache</text>
-  <text class="detail" x="603" y="139" text-anchor="middle">course-owned kernels</text>
+  <rect class="panel" x="48" y="210" width="1104" height="318" rx="12" />
+  <text class="title" x="72" y="242">Week 2 · keep the model/state boundary; optimize or substitute each operator</text>
 
-  <rect class="box week3" x="758" y="64" width="190" height="92" rx="10" />
-  <text class="label" x="853" y="96" text-anchor="middle">Week 3</text>
-  <text class="detail" x="853" y="120" text-anchor="middle">Batching + paged KV</text>
-  <text class="detail" x="853" y="139" text-anchor="middle">MLX projection seam</text>
+  <rect class="box week2" x="72" y="265" width="230" height="92" rx="10" />
+  <text class="label" x="187" y="294" text-anchor="middle">Day 1 · KV cache</text>
+  <text class="detail" x="187" y="318" text-anchor="middle">required state +</text>
+  <text class="detail" x="187" y="337" text-anchor="middle">Week 2 model shell</text>
 
-  <path class="arrow" d="M 198 110 L 258 110" />
-  <path class="arrow" d="M 448 110 L 508 110" />
-  <path class="arrow" d="M 698 110 L 758 110" />
+  <rect class="box week2" x="335" y="265" width="230" height="92" rx="10" />
+  <text class="label" x="450" y="294" text-anchor="middle">Day 2 · Measure</text>
+  <text class="detail" x="450" y="318" text-anchor="middle">matched benchmark</text>
+  <text class="detail" x="450" y="337" text-anchor="middle">not an operator seam</text>
 
-  <text class="title" x="258" y="222">Agent track</text>
+  <rect class="box week2 optional" x="598" y="265" width="230" height="92" rx="10" />
+  <text class="label" x="713" y="294" text-anchor="middle">Day 3 · Quantize</text>
+  <text class="detail" x="713" y="318" text-anchor="middle">keep packing + model wiring</text>
+  <text class="detail" x="713" y="337" text-anchor="middle">MLX off-ramp: projections</text>
 
-  <rect class="box week4" x="258" y="246" width="250" height="102" rx="10" />
-  <text class="label" x="383" y="278" text-anchor="middle">Week 4 · Days 1–7</text>
-  <text class="detail" x="383" y="303" text-anchor="middle">Scripted-model agent mechanics</text>
-  <text class="detail" x="383" y="323" text-anchor="middle">can start after setup</text>
+  <rect class="box week2 optional" x="861" y="265" width="230" height="92" rx="10" />
+  <text class="label" x="976" y="294" text-anchor="middle">Day 4 · Fused ops</text>
+  <text class="detail" x="976" y="318" text-anchor="middle">keep model call sites</text>
+  <text class="detail" x="976" y="337" text-anchor="middle">MLX: norm / RoPE / SiLU</text>
 
-  <rect class="box week4" x="758" y="246" width="190" height="102" rx="10" />
-  <text class="label" x="853" y="278" text-anchor="middle">Week 4 · Day 8</text>
-  <text class="detail" x="853" y="303" text-anchor="middle">Real tokenizer +</text>
-  <text class="detail" x="853" y="323" text-anchor="middle">KV-prefix bridge</text>
+  <path class="arrow" d="M 302 311 L 335 311" />
+  <path class="arrow" d="M 565 311 L 598 311" />
+  <path class="arrow" d="M 828 311 L 861 311" />
 
-  <rect class="box week4" x="1008" y="246" width="144" height="102" rx="10" />
-  <text class="label" x="1080" y="278" text-anchor="middle">Day 9</text>
-  <text class="detail" x="1080" y="303" text-anchor="middle">Bound tool</text>
-  <text class="detail" x="1080" y="323" text-anchor="middle">evidence</text>
+  <rect class="box week2 optional" x="861" y="390" width="230" height="92" rx="10" />
+  <text class="label" x="976" y="419" text-anchor="middle">Day 5 · Decode attention</text>
+  <text class="detail" x="976" y="443" text-anchor="middle">keep cache + shape adapter</text>
+  <text class="detail" x="976" y="462" text-anchor="middle">MLX off-ramp: SDPA</text>
 
-  <path class="arrow" d="M 123 156 L 123 297 L 258 297" />
-  <path class="arrow" d="M 508 297 L 758 297" />
-  <path class="arrow" d="M 948 297 L 1008 297" />
-  <path class="arrow" d="M 853 156 L 853 246" />
-  <text class="small" x="866" y="203">serving bridge</text>
+  <rect class="box week2 optional" x="598" y="390" width="230" height="92" rx="10" />
+  <text class="label" x="713" y="419" text-anchor="middle">Day 6 · Tiled prefill</text>
+  <text class="detail" x="713" y="443" text-anchor="middle">keep projection API</text>
+  <text class="detail" x="713" y="462" text-anchor="middle">MLX off-ramp: projections</text>
 
-  <text class="title" x="48" y="421">Run or inspect without completing earlier exercises</text>
+  <rect class="box week2 optional" x="335" y="390" width="230" height="92" rx="10" />
+  <text class="label" x="450" y="419" text-anchor="middle">Day 7 · Split-K</text>
+  <text class="detail" x="450" y="443" text-anchor="middle">keep dispatch boundary</text>
+  <text class="detail" x="450" y="462" text-anchor="middle">MLX off-ramp: projections</text>
 
-  <rect class="box reference optional" x="48" y="447" width="700" height="88" rx="10" />
-  <text class="label" x="74" y="478">Supplied reference solution</text>
-  <text class="detail" x="74" y="502">Run any completed checkpoint with test-refsol or --solution ref.</text>
-  <text class="detail" x="74" y="522">This demonstrates the checkpoint; it does not complete TODOs in src/tiny_llm.</text>
+  <path class="arrow" d="M 1091 311 L 1120 311 L 1120 436 L 1091 436" />
+  <path class="arrow" d="M 861 436 L 828 436" />
+  <path class="arrow" d="M 598 436 L 565 436" />
+  <path class="arrow" d="M 386 168 L 386 188 L 187 188 L 187 265" />
 
-  <rect class="box baseline optional" x="798" y="447" width="354" height="88" rx="10" />
-  <text class="label" x="824" y="478">Full MLX baseline</text>
-  <text class="detail" x="824" y="502">--solution mlx bypasses course code.</text>
-  <text class="detail" x="824" y="522">Use it for comparison, not composition.</text>
+  <rect class="box week3" x="360" y="590" width="280" height="104" rx="10" />
+  <text class="label" x="500" y="620" text-anchor="middle">Week 3</text>
+  <text class="detail" x="500" y="644" text-anchor="middle">MLX quantized projections</text>
+  <text class="detail" x="500" y="663" text-anchor="middle">course cache / attention /</text>
+  <text class="detail" x="500" y="682" text-anchor="middle">paging / batching / scheduler</text>
+  <path class="arrow" d="M 450 482 L 450 556 L 500 556 L 500 590" />
 
-  <line x1="48" y1="592" x2="111" y2="592" class="arrow" />
-  <text class="detail" x="128" y="597">learner-code prerequisite</text>
-  <line x1="390" y1="592" x2="453" y2="592" class="dash" />
-  <text class="detail" x="470" y="597">run/compare path; does not fill learner TODOs</text>
-  <text class="small" x="48" y="644">Within each week, later days are cumulative. Optional Week 3 chapters branch after the required Week 3 path.</text>
+  <text class="title" x="720" y="568">Week 4 scripted-model lessons</text>
+  <rect class="box week4" x="720" y="590" width="220" height="104" rx="10" />
+  <text class="label" x="830" y="620" text-anchor="middle">Days 1–7</text>
+  <text class="detail" x="830" y="644" text-anchor="middle">scripted-model</text>
+  <text class="detail" x="830" y="663" text-anchor="middle">coding-agent mechanics</text>
+  <text class="detail" x="830" y="682" text-anchor="middle">can start after setup</text>
+
+  <rect class="box week4" x="980" y="590" width="172" height="104" rx="10" />
+  <text class="label" x="1066" y="620" text-anchor="middle">Day 8</text>
+  <text class="detail" x="1066" y="644" text-anchor="middle">real tokenizer +</text>
+  <text class="detail" x="1066" y="663" text-anchor="middle">KV-prefix bridge</text>
+  <path class="arrow" d="M 940 642 L 980 642" />
+  <path class="arrow" d="M 640 642 L 690 642 L 690 724 L 1020 724 L 1020 694" />
+  <text class="small" x="777" y="719">Week 3 serving bridge</text>
+
+  <rect class="box week4" x="980" y="750" width="172" height="82" rx="10" />
+  <text class="label" x="1066" y="780" text-anchor="middle">Day 9</text>
+  <text class="detail" x="1066" y="804" text-anchor="middle">bound tool evidence</text>
+  <path class="arrow" d="M 1105 694 L 1105 750" />
+  <path class="arrow" d="M 70 168 L 24 168 L 24 760 L 830 760 L 830 694" />
+  <text class="small" x="48" y="753">scripted path from setup</text>
+
+  <text class="title" x="48" y="870">Run or inspect without completing earlier exercises</text>
+  <rect class="box reference" x="48" y="894" width="500" height="104" rx="10" />
+  <text class="label" x="72" y="925">Supplied reference solution</text>
+  <text class="detail" x="72" y="950">Run completed checkpoints with test-refsol or --solution ref.</text>
+  <text class="detail" x="72" y="970">It demonstrates the checkpoint; it does not fill learner TODOs.</text>
+
+  <rect class="box baseline" x="590" y="894" width="562" height="104" rx="10" />
+  <text class="label" x="614" y="925">Full MLX baseline</text>
+  <text class="detail" x="614" y="950">--solution mlx replaces the whole model and bypasses course code.</text>
+  <text class="detail" x="614" y="970">It is not the manual per-operator path shown in Week 2.</text>
+
+  <line x1="48" y1="1047" x2="111" y2="1047" class="arrow" />
+  <text class="detail" x="128" y="1052">interface / state prerequisite</text>
+  <rect class="box week2 optional" x="390" y="1029" width="64" height="35" rx="7" />
+  <text class="detail" x="470" y="1052">custom operator may be replaced manually at the same interface</text>
+  <text class="small" x="48" y="1097">An off-ramp continues the course but does not complete that day's custom-kernel tests or performance claim.</text>
 </svg>

--- a/book/src/course-roadmap.svg
+++ b/book/src/course-roadmap.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 690" role="img" aria-labelledby="title description">
+  <title id="title">Tiny-LLM course roadmap and entry paths</title>
+  <desc id="description">The cumulative learner implementation proceeds from setup to Week 1, Week 2, and Week 3. A separate Week 4 scripted-agent sequence can begin after setup. Week 4 Day 8 joins both paths because it connects the agent to the real tokenizer and KV cache, then Day 9 continues. A supplied reference solution can run any completed checkpoint. Full MLX is a comparison baseline and does not supply learner prerequisites.</desc>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --background: #ffffff;
+      --foreground: #1f2328;
+      --muted: #59636e;
+      --border: #8c959f;
+      --arrow: #57606a;
+      --setup: #ddf4ff;
+      --week1: #dafbe1;
+      --week2: #fff8c5;
+      --week3: #ffebe9;
+      --week4: #fbefff;
+      --reference: #f6f8fa;
+      --baseline: #fff1e5;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: #0d1117;
+        --foreground: #f0f6fc;
+        --muted: #9ba7b4;
+        --border: #6e7681;
+        --arrow: #8c959f;
+        --setup: #0c2d3f;
+        --week1: #123820;
+        --week2: #3b3200;
+        --week3: #4b1f24;
+        --week4: #3b2148;
+        --reference: #21262d;
+        --baseline: #472a13;
+      }
+    }
+    .background { fill: var(--background); }
+    .box { stroke: var(--border); stroke-width: 1.5; }
+    .setup { fill: var(--setup); }
+    .week1 { fill: var(--week1); }
+    .week2 { fill: var(--week2); }
+    .week3 { fill: var(--week3); }
+    .week4 { fill: var(--week4); }
+    .reference { fill: var(--reference); }
+    .baseline { fill: var(--baseline); }
+    .optional { stroke-dasharray: 7 6; }
+    .title { fill: var(--foreground); font: 700 18px system-ui, sans-serif; }
+    .label { fill: var(--foreground); font: 650 16px system-ui, sans-serif; }
+    .detail { fill: var(--muted); font: 13px system-ui, sans-serif; }
+    .small { fill: var(--muted); font: 12px system-ui, sans-serif; }
+    .arrow { fill: none; stroke: var(--arrow); stroke-width: 2.5; marker-end: url(#arrowhead); }
+    .dash { fill: none; stroke: var(--arrow); stroke-width: 2; stroke-dasharray: 7 6; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--arrow)" />
+    </marker>
+  </defs>
+
+  <rect class="background" width="1200" height="690" />
+  <text class="title" x="48" y="40">Cumulative learner implementation</text>
+
+  <rect class="box setup" x="48" y="64" width="150" height="92" rx="10" />
+  <text class="label" x="123" y="98" text-anchor="middle">Setup</text>
+  <text class="detail" x="123" y="122" text-anchor="middle">MLX + model files</text>
+  <text class="detail" x="123" y="141" text-anchor="middle">reference checks</text>
+
+  <rect class="box week1" x="258" y="64" width="190" height="92" rx="10" />
+  <text class="label" x="353" y="96" text-anchor="middle">Week 1</text>
+  <text class="detail" x="353" y="120" text-anchor="middle">Readable Qwen3</text>
+  <text class="detail" x="353" y="139" text-anchor="middle">matmul → text</text>
+
+  <rect class="box week2" x="508" y="64" width="190" height="92" rx="10" />
+  <text class="label" x="603" y="96" text-anchor="middle">Week 2</text>
+  <text class="detail" x="603" y="120" text-anchor="middle">Dense KV cache</text>
+  <text class="detail" x="603" y="139" text-anchor="middle">course-owned kernels</text>
+
+  <rect class="box week3" x="758" y="64" width="190" height="92" rx="10" />
+  <text class="label" x="853" y="96" text-anchor="middle">Week 3</text>
+  <text class="detail" x="853" y="120" text-anchor="middle">Batching + paged KV</text>
+  <text class="detail" x="853" y="139" text-anchor="middle">MLX projection seam</text>
+
+  <path class="arrow" d="M 198 110 L 258 110" />
+  <path class="arrow" d="M 448 110 L 508 110" />
+  <path class="arrow" d="M 698 110 L 758 110" />
+
+  <text class="title" x="258" y="222">Agent track</text>
+
+  <rect class="box week4" x="258" y="246" width="250" height="102" rx="10" />
+  <text class="label" x="383" y="278" text-anchor="middle">Week 4 · Days 1–7</text>
+  <text class="detail" x="383" y="303" text-anchor="middle">Scripted-model agent mechanics</text>
+  <text class="detail" x="383" y="323" text-anchor="middle">can start after setup</text>
+
+  <rect class="box week4" x="758" y="246" width="190" height="102" rx="10" />
+  <text class="label" x="853" y="278" text-anchor="middle">Week 4 · Day 8</text>
+  <text class="detail" x="853" y="303" text-anchor="middle">Real tokenizer +</text>
+  <text class="detail" x="853" y="323" text-anchor="middle">KV-prefix bridge</text>
+
+  <rect class="box week4" x="1008" y="246" width="144" height="102" rx="10" />
+  <text class="label" x="1080" y="278" text-anchor="middle">Day 9</text>
+  <text class="detail" x="1080" y="303" text-anchor="middle">Bound tool</text>
+  <text class="detail" x="1080" y="323" text-anchor="middle">evidence</text>
+
+  <path class="arrow" d="M 123 156 L 123 297 L 258 297" />
+  <path class="arrow" d="M 508 297 L 758 297" />
+  <path class="arrow" d="M 948 297 L 1008 297" />
+  <path class="arrow" d="M 853 156 L 853 246" />
+  <text class="small" x="866" y="203">serving bridge</text>
+
+  <text class="title" x="48" y="421">Run or inspect without completing earlier exercises</text>
+
+  <rect class="box reference optional" x="48" y="447" width="700" height="88" rx="10" />
+  <text class="label" x="74" y="478">Supplied reference solution</text>
+  <text class="detail" x="74" y="502">Run any completed checkpoint with test-refsol or --solution ref.</text>
+  <text class="detail" x="74" y="522">This demonstrates the checkpoint; it does not complete TODOs in src/tiny_llm.</text>
+
+  <rect class="box baseline optional" x="798" y="447" width="354" height="88" rx="10" />
+  <text class="label" x="824" y="478">Full MLX baseline</text>
+  <text class="detail" x="824" y="502">--solution mlx bypasses course code.</text>
+  <text class="detail" x="824" y="522">Use it for comparison, not composition.</text>
+
+  <line x1="48" y1="592" x2="111" y2="592" class="arrow" />
+  <text class="detail" x="128" y="597">learner-code prerequisite</text>
+  <line x1="390" y1="592" x2="453" y2="592" class="dash" />
+  <text class="detail" x="470" y="597">run/compare path; does not fill learner TODOs</text>
+  <text class="small" x="48" y="644">Within each week, later days are cumulative. Optional Week 3 chapters branch after the required Week 3 path.</text>
+</svg>

--- a/book/src/preface.md
+++ b/book/src/preface.md
@@ -41,24 +41,29 @@ The course supports two different goals: **implementing** the cumulative
 serving stack, or **studying and running** a later checkpoint without completing
 all earlier exercises. These are not the same path.
 
-![Tiny-LLM roadmap. The cumulative implementation path runs from Week 1 through Week 3 into Week 4 Day 8. Week 4 Days 1 through 7 form a scripted-model agent path that can start after setup; Day 8 joins the two paths, and Day 9 continues the agent path. The supplied reference solution can run any completed checkpoint, while full MLX is a comparison baseline rather than a course-code prerequisite.](./course-roadmap.svg)
+![Tiny-LLM roadmap. The cumulative interface and state path runs from Week 1 through the seven Week 2 days and Week 3 into Week 4 Day 8. Week 2 Days 3 through 7 show optional MLX operator off-ramps that preserve the course interfaces; they are different from the full-MLX model baseline. Week 4 Days 1 through 7 form a scripted-model lesson path that can start after setup; Day 8 joins the two paths, and Day 9 continues the Week 4 sequence.](./course-roadmap.svg)
 
-Solid arrows in the diagram are learner-code prerequisites. The reference and
-MLX lanes let you observe a completed system, but they do not fill in unfinished
+Solid arrows in the diagram are **interface and state prerequisites**. They do
+not mean that you must hand-write every earlier optimization. A dashed border
+marks a custom operator that you may replace locally with its MLX equivalent
+while keeping the surrounding course interface. The reference and full-MLX
+lanes let you observe a completed system, but they do not fill in unfinished
 functions in `src/tiny_llm`.
 
 | Your goal | Start here | What earlier implementation is required? |
 | --- | --- | --- |
 | Build the whole serving system | Week 1, then follow the solid arrows | Each week uses interfaces and mechanisms established by the previous week. |
+| Skip a Week 2 kernel optimization | Keep that day's course interface and wire the corresponding MLX operator at the seam | The earlier model, state, and interface work still needs to exist. This is a local code choice, not a CLI flag. |
 | Read or experiment with a later week | Open that chapter and use `tiny_llm_ref` | None in your learner tree. Run the supplied reference tests or reference loader. |
 | Compare with the production-library baseline | Use `--solution mlx` | None, but this runs the full MLX model and bypasses the course implementation. |
-| Study the agent harness first | Week 4 Day 1 | Days 1–7 use deterministic scripted models. Follow the Week 4 days in order; Day 8's real-model bridge needs the Week 3 model/tokenizer/KV-cache boundary. |
+| Start the Week 4 scripted-model lessons | Week 4 Day 1 | Days 1–7 use deterministic scripted models. Follow the Week 4 days in order; Day 8's real-model bridge needs the Week 3 model/tokenizer/KV-cache boundary. |
 
 The cumulative dependencies are deliberate:
 
 - **Week 1 → Week 2:** Week 2 starts from the readable Qwen3 model and replaces
   costs one mechanism at a time: first the generation algorithm and KV cache,
-  then quantized and fused kernels.
+  then quantized and fused kernels. Days 1–2 establish state and measurement;
+  Days 3–7 expose optimization seams.
 - **Week 2 → Week 3:** Week 3 selects MLX quantized projections, but it keeps
   course-owned normalization, activation, cache, attention, paging, batching,
   and scheduling. This is an explicit operator seam, not “use the MLX model for
@@ -66,6 +71,38 @@ The cumulative dependencies are deliberate:
 - **Week 3 → Week 4:** the early agent checkpoints exercise control flow with
   scripted models. Week 4 Day 8 reconnects that harness to the real tokenizer
   and KV cache, so that checkpoint needs a working Week 3 path.
+
+> **Is Week 2 required for Week 3? The Week 2 interfaces are; every Week 2
+> optimization is not.** The current Week 3 starter reuses the Week 2 model
+> shell, dense-cache contract, packed-weight plumbing, normalization,
+> activation, attention, and matrix-fragment interfaces. You may preserve
+> those interfaces and substitute MLX operators for custom optimization work,
+> but starting Week 3 is **not as simple as selecting `--solution mlx`**. That
+> flag selects the complete MLX model and bypasses the course-owned paging,
+> batching, attention, and scheduler surfaces that Week 3 teaches. Skipping
+> the entire Week 2 implementation would require a supplied hybrid starting
+> checkpoint; that checkpoint does not exist today.
+
+### Week 2 operator off-ramps
+
+Week 2 separates the mechanism you need later from the kernel you are invited
+to optimize. If your goal is to continue into Week 3 rather than implement
+every Metal kernel, you can make these explicit local substitutions:
+
+| Week 2 day | Keep in the course stack | Optional MLX substitution |
+| --- | --- | --- |
+| Days 1–2 | Dense KV-cache state, the Week 2 model boundary, and the matched measurement method | None; these are state and methodology rather than replaceable operators. |
+| Day 3 | Packed-weight containers, quantized embedding/model wiring, and the `quantized_linear` interface | Route projections through `mx.quantized_matmul` instead of the custom matrix-vector kernel. |
+| Day 4 | The Week 2 norm, position, and activation call sites | Use the corresponding MLX RMSNorm/RoPE operators and an MLX SiLU-based SwiGLU composition instead of the custom fused kernels. |
+| Day 5 | The dense-cache attention interface and its shape/mask adapter | Use `mx.fast.scaled_dot_product_attention` instead of the custom decode-attention kernel. |
+| Days 6–7 | The same quantized-projection interface and dispatch boundary | Keep using the Day 3 MLX projection seam instead of implementing SIMD-matrix and Split-K schedules. |
+
+Only the quantized-projection seam is already selected by canonical Week 3.
+The Day 4 and Day 5 alternatives require you to wire the MLX call at the
+existing course interface; there is no `--use-mlx-for-day` command. These
+off-ramps let you study later mechanisms, but they do not complete the skipped
+day's custom-kernel exercises, implementation-specific tests, or performance
+claims.
 
 To run a completed checkpoint without solving it first:
 
@@ -82,9 +119,11 @@ pdm run main --solution mlx
 
 `--solution ref` runs the supplied implementation end to end. `--solution mlx`
 runs MLX end to end. Neither command composes “earlier weeks from the reference
-or MLX, this week's TODOs from my learner tree.” If you want to implement a
-later week in `src/tiny_llm`, its earlier learner-code prerequisites must already
-work; the repository does not currently provide a one-command hybrid checkpoint.
+or MLX, this week's TODOs from my learner tree.” Per-operator substitution is a
+manual code edit that preserves the course interface; it is not a third
+solution mode. If you want to implement a later week in `src/tiny_llm`, its
+earlier interface and state prerequisites must already work; the repository
+does not currently provide a one-command hybrid checkpoint.
 
 ## Choose a Model for Your Mac
 

--- a/book/src/preface.md
+++ b/book/src/preface.md
@@ -35,6 +35,57 @@ small coding agent.
 - Week 3: Add further optimizations and batch requests for high-throughput serving.
 - Week 4: Reuse the serving stack in a local coding agent with tools, sessions, and evaluation.
 
+## Course Roadmap: What Depends on What
+
+The course supports two different goals: **implementing** the cumulative
+serving stack, or **studying and running** a later checkpoint without completing
+all earlier exercises. These are not the same path.
+
+![Tiny-LLM roadmap. The cumulative implementation path runs from Week 1 through Week 3 into Week 4 Day 8. Week 4 Days 1 through 7 form a scripted-model agent path that can start after setup; Day 8 joins the two paths, and Day 9 continues the agent path. The supplied reference solution can run any completed checkpoint, while full MLX is a comparison baseline rather than a course-code prerequisite.](./course-roadmap.svg)
+
+Solid arrows in the diagram are learner-code prerequisites. The reference and
+MLX lanes let you observe a completed system, but they do not fill in unfinished
+functions in `src/tiny_llm`.
+
+| Your goal | Start here | What earlier implementation is required? |
+| --- | --- | --- |
+| Build the whole serving system | Week 1, then follow the solid arrows | Each week uses interfaces and mechanisms established by the previous week. |
+| Read or experiment with a later week | Open that chapter and use `tiny_llm_ref` | None in your learner tree. Run the supplied reference tests or reference loader. |
+| Compare with the production-library baseline | Use `--solution mlx` | None, but this runs the full MLX model and bypasses the course implementation. |
+| Study the agent harness first | Week 4 Day 1 | Days 1–7 use deterministic scripted models. Follow the Week 4 days in order; Day 8's real-model bridge needs the Week 3 model/tokenizer/KV-cache boundary. |
+
+The cumulative dependencies are deliberate:
+
+- **Week 1 → Week 2:** Week 2 starts from the readable Qwen3 model and replaces
+  costs one mechanism at a time: first the generation algorithm and KV cache,
+  then quantized and fused kernels.
+- **Week 2 → Week 3:** Week 3 selects MLX quantized projections, but it keeps
+  course-owned normalization, activation, cache, attention, paging, batching,
+  and scheduling. This is an explicit operator seam, not “use the MLX model for
+  Week 2.”
+- **Week 3 → Week 4:** the early agent checkpoints exercise control flow with
+  scripted models. Week 4 Day 8 reconnects that harness to the real tokenizer
+  and KV cache, so that checkpoint needs a working Week 3 path.
+
+To run a completed checkpoint without solving it first:
+
+```bash
+# Run one supplied reference test group.
+pdm run test-refsol --week 3 --day 1
+
+# Run a completed course model.
+pdm run main --solution ref --loader week3
+
+# Run the separate full-MLX baseline.
+pdm run main --solution mlx
+```
+
+`--solution ref` runs the supplied implementation end to end. `--solution mlx`
+runs MLX end to end. Neither command composes “earlier weeks from the reference
+or MLX, this week's TODOs from my learner tree.” If you want to implement a
+later week in `src/tiny_llm`, its earlier learner-code prerequisites must already
+work; the repository does not currently provide a one-command hybrid checkpoint.
+
 ## Choose a Model for Your Mac
 
 The table below is a conservative starting point for common MacBook unified-memory sizes. Each entry is

--- a/book/src/preface.md
+++ b/book/src/preface.md
@@ -41,7 +41,47 @@ The course supports two different goals: **implementing** the cumulative
 serving stack, or **studying and running** a later checkpoint without completing
 all earlier exercises. These are not the same path.
 
-![Tiny-LLM roadmap. The cumulative interface and state path runs from Week 1 through the seven Week 2 days and Week 3 into Week 4 Day 8. Week 2 Days 3 through 7 show optional MLX operator off-ramps that preserve the course interfaces; they are different from the full-MLX model baseline. Week 4 Days 1 through 7 form a scripted-model lesson path that can start after setup; Day 8 joins the two paths, and Day 9 continues the Week 4 sequence.](./course-roadmap.svg)
+<style>
+  .course-roadmap-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    overscroll-behavior-x: contain;
+  }
+  .course-roadmap-scroll:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+  .course-roadmap-scroll img {
+    display: block;
+    width: 1200px;
+    min-width: 1200px;
+    max-width: none;
+    height: auto;
+  }
+</style>
+
+<div id="course-roadmap-scroll" class="course-roadmap-scroll" role="region" aria-label="Scrollable Tiny-LLM course roadmap" aria-describedby="course-roadmap-scroll-help" tabindex="0">
+  <img src="./course-roadmap.svg" alt="Tiny-LLM roadmap. The cumulative interface and state path runs from Week 1 through the seven Week 2 days and Week 3 into Week 4. Week 2 Days 3 through 7 show optional MLX operator off-ramps that preserve the course interfaces; they are different from the full-MLX model baseline. Week 4 keeps the course prerequisite of setup plus Weeks 1 through 3, while its deterministic scripted-model tests for Days 1 through 7 can run after setup. Day 8 joins the scripted sequence to the real-model path, and Day 9 continues the Week 4 sequence.">
+</div>
+
+<p id="course-roadmap-scroll-help">On a narrow screen, scroll the roadmap
+horizontally; when the roadmap is focused, the left and right arrow keys move
+through it without changing chapters. Its labels stay at their readable desktop
+size.</p>
+
+<script>
+  (() => {
+    const roadmap = document.getElementById("course-roadmap-scroll");
+    roadmap.addEventListener("keydown", (event) => {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      event.preventDefault();
+      event.stopPropagation();
+      const distance = Math.max(120, Math.round(roadmap.clientWidth * 0.8));
+      roadmap.scrollLeft += event.key === "ArrowLeft" ? -distance : distance;
+    });
+  })();
+</script>
 
 Solid arrows in the diagram are **interface and state prerequisites**. They do
 not mean that you must hand-write every earlier optimization. A dashed border
@@ -56,7 +96,7 @@ functions in `src/tiny_llm`.
 | Skip a Week 2 kernel optimization | Keep that day's course interface and wire the corresponding MLX operator at the seam | The earlier model, state, and interface work still needs to exist. This is a local code choice, not a CLI flag. |
 | Read or experiment with a later week | Open that chapter and use `tiny_llm_ref` | None in your learner tree. Run the supplied reference tests or reference loader. |
 | Compare with the production-library baseline | Use `--solution mlx` | None, but this runs the full MLX model and bypasses the course implementation. |
-| Start the Week 4 scripted-model lessons | Week 4 Day 1 | Days 1–7 use deterministic scripted models. Follow the Week 4 days in order; Day 8's real-model bridge needs the Week 3 model/tokenizer/KV-cache boundary. |
+| Run the Week 4 Days 1–7 deterministic tests before finishing the serving stack | After setup, run the supplied scripted-model tests | The tests do not need a working serving implementation. The course still assumes setup plus Weeks 1–3 before Week 4; follow the Week 4 days in order, and Day 8's real-model bridge needs the Week 3 model/tokenizer/KV-cache boundary. |
 
 The cumulative dependencies are deliberate:
 
@@ -68,9 +108,11 @@ The cumulative dependencies are deliberate:
   course-owned normalization, activation, cache, attention, paging, batching,
   and scheduling. This is an explicit operator seam, not “use the MLX model for
   Week 2.”
-- **Week 3 → Week 4:** the early agent checkpoints exercise control flow with
-  scripted models. Week 4 Day 8 reconnects that harness to the real tokenizer
-  and KV cache, so that checkpoint needs a working Week 3 path.
+- **Week 3 → Week 4:** Week 4 remains the next cumulative course week. Its
+  Days 1–7 tests can exercise control flow with deterministic scripted models
+  after setup, even before the serving stack works. Day 8 reconnects that
+  harness to the real tokenizer and KV cache, so that checkpoint needs a
+  working Week 3 path.
 
 > **Is Week 2 required for Week 3? The Week 2 interfaces are; every Week 2
 > optimization is not.** The current Week 3 starter reuses the Week 2 model


### PR DESCRIPTION
## Why

Learners need to distinguish cumulative course interfaces and state from optimization work they may replace, and to understand that the full MLX mode is a separate whole-model baseline rather than a hybrid shortcut into later learner exercises.

## Change

- add an accessible light/dark roadmap diagram to the preface;
- compress Week 2 into a Days 1–2 foundation block and a Days 3–7 operator-optimization block;
- keep the exact Day 3–7 manual MLX substitutions in the surrounding table while preserving the course interfaces;
- make prominent that entering Week 3 is not as simple as selecting `--solution mlx`;
- preserve setup plus Weeks 1–3 as the Week 4 course prerequisite while noting that the deterministic Days 1–7 scripted-model tests can run after setup;
- show the cumulative Week 1 → Week 2 → Week 3 serving path and the clean path into Week 4 Day 8, followed by Day 9;
- distinguish manual per-operator substitution, supplied-reference exploration, and the whole-model MLX comparison baseline;
- avoid the ambiguous “agent track” label and state that the repository has no one-command hybrid of reference/MLX prerequisites with learner TODOs.

## Verification

Exact scope: `book/src/preface.md` and `book/src/course-roadmap.svg` only, on base `4757f2b80fa13d3f9200ba557a008f962a7ae4bb`. No learner, reference, runtime, tests, navigation, sitemap, or publication configuration changed.

Local checks: mdBook build, sitemap check, rendered asset/link checks, XML validation, source-seam audit, scope check, and `git diff --check` pass. Real Chrome checks at 390px and desktop in light/dark keep the 1200px diagram readable inside a focusable horizontal-scroll region; arrow keys scroll the diagram without invoking mdBook chapter navigation. Repository-wide `mdbook test` retains four pre-existing failures in unchanged optional-MoE path snippets; the changed preface adds no failure.

Hosted `Test reference solution` run `32954091670`: SUCCESS on exact head `3f6423dee0ff178bf31422e3da13250bac37a5e7`.

Independent reviews on this exact head:

- `Reviewed-by: GPT-5.6 Terra + Scholar (learner)`
- `Reviewed-by: GPT-5.6 Sol + Oracle (consistency)`

AI-Assisted: GPT-5.6 Sol + Tuner
