### PR TITLE
Align Week 1 lessons with runnable checkpoints

### DIFF
--- a/book/src/week1-01-attention.md
+++ b/book/src/week1-01-attention.md
@@ -1,8 +1,9 @@
 # Week 1 Day 1: Attention and Multi-Head Attention
 
-The starter already provides `softmax`. Your Day 1 work is to complete `scaled_dot_product_attention_simple` and
-`SimpleMultiHeadAttention` in `src/tiny_llm/attention.py`, plus the `linear` helper in `src/tiny_llm/basics.py`. Other
-attention functions in the starter are for later days and are not part of this chapter.
+The starter provides `softmax` through MLX so that Day 1 can focus on the attention data flow. Your required work is to
+complete `scaled_dot_product_attention_simple` and `SimpleMultiHeadAttention` in `src/tiny_llm/attention.py`, plus the
+`linear` helper in `src/tiny_llm/basics.py`. Other attention functions in the starter are for later days and are not part
+of this chapter.
 
 Start by running the focused Task 1 tests. The command refreshes the supplied Day 1 test in `tests/` before running it:
 
@@ -10,8 +11,8 @@ Start by running the focused Task 1 tests. The command refreshes the supplied Da
 pdm run test --week 1 --day 1 -- -k task_1
 ```
 
-The untouched starter reports 4 passing and 32 failing tests. The four passing cases cover the supplied `softmax`; the
-failures show the behavior that your attention implementation must add.
+The supplied `softmax` cases pass in the untouched starter, while the attention cases fail. This expected red checkpoint
+shows the behavior that your attention implementation must add.
 
 An attention layer processes an input sequence and weighs the relevance of its different positions when producing each
 output. Attention is a key building block of Transformer models.
@@ -69,7 +70,9 @@ output: N.. x L x D
 scale = 1/sqrt(D) if not specified
 ```
 
-You may use MLX's `softmax`; we will revisit lower-level operations in Week 2.
+Use the supplied `softmax` helper for the required exercise. As an optional, ungraded bonus, replace its MLX call with
+your own numerically stable implementation: subtract the maximum value along `axis`, exponentiate the shifted values,
+then divide by their sum along the same axis. Preserve the helper's public API and output behavior.
 
 When this function is called from multi-head attention, the tensors will usually have these shapes:
 
@@ -84,13 +87,14 @@ mask: 1 x H x L x L
 The function itself operates on the last two dimensions and must support any number of leading batch dimensions. The mask
 only needs a shape that can broadcast to the attention-score shape.
 
-At the end of this task, you should be able to pass the following tests:
+Run the Task 1 checkpoint again after implementing the function:
 
 ```
 pdm run test --week 1 --day 1 -- -k task_1
 ```
 
-The completed Task 1 reports 36 passed.
+When this checkpoint turns green, your attention function supports arbitrary leading batch dimensions, optional masks,
+and default or explicit scaling.
 
 ## Task 2: Implement `SimpleMultiHeadAttention`
 
@@ -121,7 +125,8 @@ Use the focused linear tests as your next checkpoint:
 pdm run test --week 1 --day 1 -- -k test_task_2_linear
 ```
 
-Before you implement `linear`, all four cases fail. Afterward, the checkpoint reports 4 passed.
+Before you implement `linear`, this checkpoint is red. When it turns green, `linear` supports optional bias across the
+tested precisions and devices.
 
 For `SimpleMultiHeadAttention`, the input tensors `query`, `key`, and `value` have shape `N x L x E`, where `E` is the
 embedding dimension for one token. The Q, K, and V projections each map `E` to `H x D`: `H` heads, each with dimension
@@ -149,13 +154,14 @@ output/input: N x L x E
 w_o: E x (H x D)
 ```
 
-At the end of the task, you should be able to pass the following tests:
+Run the Task 2 checkpoint after implementing the layer:
 
 ```console
 pdm run test --week 1 --day 1 -- -k task_2
 ```
 
-The completed Task 2 reports 8 passed.
+When this checkpoint turns green, your layer projects query, key, and value tensors into independent attention heads and
+recombines their outputs through the final projection.
 
 You can run all tests for the day with:
 
@@ -163,7 +169,9 @@ You can run all tests for the day with:
 pdm run test --week 1 --day 1
 ```
 
-The completed day reports 44 passed. Day 3 will generalize this attention mechanism to grouped-query attention for Qwen3;
-the `SimpleMultiHeadAttention` layer built here is a standalone exercise, not the model's exact call path.
+When the full Day 1 suite turns green, you have a standalone multi-head attention layer that projects Q/K/V, evaluates
+each head independently, and recombines the result. Day 3 will generalize this attention mechanism to grouped-query
+attention for Qwen3; the `SimpleMultiHeadAttention` layer built here is a standalone exercise, not the model's exact call
+path.
 
 {{#include copyright.md}}

--- a/book/src/week1-01-attention.md
+++ b/book/src/week1-01-attention.md
@@ -1,8 +1,20 @@
 # Week 1 Day 1: Attention and Multi-Head Attention
 
-On Day 1, we will implement basic attention and multi-head attention. An attention layer processes an input sequence and
-weighs the relevance of its different positions when producing each output. Attention is a key building block of Transformer
-models.
+The starter already provides `softmax`. Your Day 1 work is to complete `scaled_dot_product_attention_simple` and
+`SimpleMultiHeadAttention` in `src/tiny_llm/attention.py`, plus the `linear` helper in `src/tiny_llm/basics.py`. Other
+attention functions in the starter are for later days and are not part of this chapter.
+
+Start by running the focused Task 1 tests. The command copies the supplied Day 1 test into `tests/` before running it:
+
+```console
+pdm run test --week 1 --day 1 -- -k task_1
+```
+
+The untouched starter reports 4 passing and 24 failing tests. The four passing cases cover the supplied `softmax`; the
+failures show the behavior that your attention implementation must add.
+
+An attention layer processes an input sequence and weighs the relevance of its different positions when producing each
+output. Attention is a key building block of Transformer models.
 
 [📚 Reading: Transformer Architecture](https://huggingface.co/learn/llm-course/chapter1/6)
 
@@ -78,6 +90,8 @@ At the end of this task, you should be able to pass the following tests:
 pdm run test --week 1 --day 1 -- -k task_1
 ```
 
+The completed Task 1 reports 28 passed.
+
 ## Task 2: Implement `SimpleMultiHeadAttention`
 
 In this task, we will implement the multi-head attention layer.
@@ -100,6 +114,15 @@ O.
 First, implement the `linear` function in `basics.py`. It takes a tensor of shape `N.. x I`, a weight matrix of shape
 `O x I`, and an optional bias vector of shape `O`. Its output has shape `N.. x O`, where `I` is the input dimension and
 `O` is the output dimension.
+
+Use the focused linear tests as your next checkpoint:
+
+```console
+pdm run test --week 1 --day 1 -- -k test_task_2_linear
+```
+
+Before you implement `linear`, three cases fail and one unsupported FP16-on-CPU case is skipped. Afterward, the checkpoint
+reports 3 passed and 1 skipped.
 
 For `SimpleMultiHeadAttention`, the input tensors `query`, `key`, and `value` have shape `N x L x E`, where `E` is the
 embedding dimension for one token. The Q, K, and V projections each map `E` to `H x D`: `H` heads, each with dimension
@@ -129,14 +152,20 @@ w_o: E x (H x D)
 
 At the end of the task, you should be able to pass the following tests:
 
-```
+```console
 pdm run test --week 1 --day 1 -- -k task_2
 ```
 
+The completed Task 2 reports 7 passed and 1 skipped.
+
 You can run all tests for the day with:
 
-```
+```console
 pdm run test --week 1 --day 1
 ```
+
+The completed day reports 35 passed and 1 skipped. Day 3 will generalize this attention mechanism to grouped-query
+attention for Qwen3; the `SimpleMultiHeadAttention` layer built here is a standalone exercise, not the model's exact call
+path.
 
 {{#include copyright.md}}

--- a/book/src/week1-01-attention.md
+++ b/book/src/week1-01-attention.md
@@ -4,13 +4,13 @@ The starter already provides `softmax`. Your Day 1 work is to complete `scaled_d
 `SimpleMultiHeadAttention` in `src/tiny_llm/attention.py`, plus the `linear` helper in `src/tiny_llm/basics.py`. Other
 attention functions in the starter are for later days and are not part of this chapter.
 
-Start by running the focused Task 1 tests. The command copies the supplied Day 1 test into `tests/` before running it:
+Start by running the focused Task 1 tests. The command refreshes the supplied Day 1 test in `tests/` before running it:
 
 ```console
 pdm run test --week 1 --day 1 -- -k task_1
 ```
 
-The untouched starter reports 4 passing and 24 failing tests. The four passing cases cover the supplied `softmax`; the
+The untouched starter reports 4 passing and 32 failing tests. The four passing cases cover the supplied `softmax`; the
 failures show the behavior that your attention implementation must add.
 
 An attention layer processes an input sequence and weighs the relevance of its different positions when producing each
@@ -90,7 +90,7 @@ At the end of this task, you should be able to pass the following tests:
 pdm run test --week 1 --day 1 -- -k task_1
 ```
 
-The completed Task 1 reports 28 passed.
+The completed Task 1 reports 36 passed.
 
 ## Task 2: Implement `SimpleMultiHeadAttention`
 
@@ -121,8 +121,7 @@ Use the focused linear tests as your next checkpoint:
 pdm run test --week 1 --day 1 -- -k test_task_2_linear
 ```
 
-Before you implement `linear`, three cases fail and one unsupported FP16-on-CPU case is skipped. Afterward, the checkpoint
-reports 3 passed and 1 skipped.
+Before you implement `linear`, all four cases fail. Afterward, the checkpoint reports 4 passed.
 
 For `SimpleMultiHeadAttention`, the input tensors `query`, `key`, and `value` have shape `N x L x E`, where `E` is the
 embedding dimension for one token. The Q, K, and V projections each map `E` to `H x D`: `H` heads, each with dimension
@@ -156,7 +155,7 @@ At the end of the task, you should be able to pass the following tests:
 pdm run test --week 1 --day 1 -- -k task_2
 ```
 
-The completed Task 2 reports 7 passed and 1 skipped.
+The completed Task 2 reports 8 passed.
 
 You can run all tests for the day with:
 
@@ -164,8 +163,7 @@ You can run all tests for the day with:
 pdm run test --week 1 --day 1
 ```
 
-The completed day reports 35 passed and 1 skipped. Day 3 will generalize this attention mechanism to grouped-query
-attention for Qwen3; the `SimpleMultiHeadAttention` layer built here is a standalone exercise, not the model's exact call
-path.
+The completed day reports 44 passed. Day 3 will generalize this attention mechanism to grouped-query attention for Qwen3;
+the `SimpleMultiHeadAttention` layer built here is a standalone exercise, not the model's exact call path.
 
 {{#include copyright.md}}

--- a/scripts/dev-tools.py
+++ b/scripts/dev-tools.py
@@ -51,7 +51,7 @@ def test(args):
                     return status
                 targets.append(f"tests/test_week_{args.week}_day_{day}.py")
             return pytest.main(["-v", *targets] + args.remainders)
-        copy_test(args, skip_if_exists=True)
+        copy_test(args, force=True)
         return pytest.main(
             ["-v", f"tests/test_week_{args.week}_day_{args.day}.py"] + args.remainders
         )

--- a/src/tiny_llm/basics.py
+++ b/src/tiny_llm/basics.py
@@ -3,7 +3,7 @@ import math
 
 
 def softmax(x: mx.array, axis: int) -> mx.array:
-    # TODO: manual implementation
+    # Supplied for Day 1; a manual implementation is an optional bonus exercise.
     return mx.softmax(x, axis=axis)
 
 

--- a/src/tiny_llm_ref/basics.py
+++ b/src/tiny_llm_ref/basics.py
@@ -3,7 +3,7 @@ import math
 
 
 def softmax(x: mx.array, axis: int) -> mx.array:
-    # TODO: manual implementation
+    # Supplied for Day 1; a manual implementation is an optional bonus exercise.
     return mx.softmax(x, axis=axis)
 
 

--- a/tests_refsol/test_dev_tools.py
+++ b/tests_refsol/test_dev_tools.py
@@ -86,24 +86,25 @@ def test_non_positive_week_day_selection_fails_closed(tmp_path, command, selecto
         assert "Week and day must be positive integers" in result.stdout
 
 
-def test_copy_test_missing_source_fails_closed(tmp_path):
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(DEV_TOOLS),
-            "copy-test",
-            "--week",
-            "99",
-            "--day",
-            "99",
-        ],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode != 0
-    assert "tests_refsol/test_week_99_day_99.py" in result.stderr
+def test_copy_and_test_missing_source_fail_closed(tmp_path):
+    for command in ("copy-test", "test"):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(DEV_TOOLS),
+                command,
+                "--week",
+                "99",
+                "--day",
+                "99",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "tests_refsol/test_week_99_day_99.py" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -138,7 +139,7 @@ def test_missing_command_fails_closed(tmp_path):
     assert "the following arguments are required" in result.stderr
 
 
-def test_week_4_day_selection_refreshes_and_runs_every_day_so_far(tmp_path):
+def test_day_selection_refreshes_supplied_tests_without_overwriting_source(tmp_path):
     supplied = tmp_path / "tests_refsol"
     learner = tmp_path / "tests"
     supplied.mkdir()
@@ -181,3 +182,42 @@ def test_week_4_day_selection_refreshes_and_runs_every_day_so_far(tmp_path):
     assert (learner / "test_week_4_day_2.py").read_bytes() == (
         supplied / "test_week_4_day_2.py"
     ).read_bytes()
+
+    # The ordinary Week 1-3 path also refreshes a stale copied test on every run.
+    # Only the selected test fixture is replaced; learner implementation stays intact.
+    implementation = tmp_path / "src" / "tiny_llm" / "attention.py"
+    implementation.parent.mkdir(parents=True)
+    implementation.write_text("LEARNER-IMPLEMENTATION\n", encoding="utf-8")
+    fresh_test = 'def test_fresh():\n    print("FRESH-DAY-1")\n'
+    stale_test = 'def test_stale():\n    print("STALE-DAY-1")\n    assert False\n'
+    supplied_test = supplied / "test_week_1_day_1.py"
+    learner_test = learner / "test_week_1_day_1.py"
+    supplied_test.write_text(fresh_test, encoding="utf-8")
+
+    for _ in range(2):
+        learner_test.write_text(stale_test, encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(DEV_TOOLS),
+                "test",
+                "--week",
+                "1",
+                "--day",
+                "1",
+                "--",
+                "-q",
+                "-s",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert "FRESH-DAY-1" in result.stdout
+        assert "STALE-DAY-1" not in result.stdout
+        assert "1 passed" in result.stdout
+        assert learner_test.read_text(encoding="utf-8") == fresh_test
+        assert implementation.read_text(encoding="utf-8") == "LEARNER-IMPLEMENTATION\n"

--- a/tests_refsol/test_dev_tools.py
+++ b/tests_refsol/test_dev_tools.py
@@ -86,25 +86,24 @@ def test_non_positive_week_day_selection_fails_closed(tmp_path, command, selecto
         assert "Week and day must be positive integers" in result.stdout
 
 
-def test_copy_and_test_missing_source_fail_closed(tmp_path):
-    for command in ("copy-test", "test"):
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(DEV_TOOLS),
-                command,
-                "--week",
-                "99",
-                "--day",
-                "99",
-            ],
-            cwd=tmp_path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "tests_refsol/test_week_99_day_99.py" in result.stderr
+def test_copy_test_missing_source_fails_closed(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DEV_TOOLS),
+            "copy-test",
+            "--week",
+            "99",
+            "--day",
+            "99",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "tests_refsol/test_week_99_day_99.py" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -139,7 +138,7 @@ def test_missing_command_fails_closed(tmp_path):
     assert "the following arguments are required" in result.stderr
 
 
-def test_day_selection_refreshes_supplied_tests_without_overwriting_source(tmp_path):
+def test_week_4_day_selection_refreshes_and_runs_every_day_so_far(tmp_path):
     supplied = tmp_path / "tests_refsol"
     learner = tmp_path / "tests"
     supplied.mkdir()
@@ -182,42 +181,3 @@ def test_day_selection_refreshes_supplied_tests_without_overwriting_source(tmp_p
     assert (learner / "test_week_4_day_2.py").read_bytes() == (
         supplied / "test_week_4_day_2.py"
     ).read_bytes()
-
-    # The ordinary Week 1-3 path also refreshes a stale copied test on every run.
-    # Only the selected test fixture is replaced; learner implementation stays intact.
-    implementation = tmp_path / "src" / "tiny_llm" / "attention.py"
-    implementation.parent.mkdir(parents=True)
-    implementation.write_text("LEARNER-IMPLEMENTATION\n", encoding="utf-8")
-    fresh_test = 'def test_fresh():\n    print("FRESH-DAY-1")\n'
-    stale_test = 'def test_stale():\n    print("STALE-DAY-1")\n    assert False\n'
-    supplied_test = supplied / "test_week_1_day_1.py"
-    learner_test = learner / "test_week_1_day_1.py"
-    supplied_test.write_text(fresh_test, encoding="utf-8")
-
-    for _ in range(2):
-        learner_test.write_text(stale_test, encoding="utf-8")
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(DEV_TOOLS),
-                "test",
-                "--week",
-                "1",
-                "--day",
-                "1",
-                "--",
-                "-q",
-                "-s",
-            ],
-            cwd=tmp_path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        assert result.returncode == 0
-        assert "FRESH-DAY-1" in result.stdout
-        assert "STALE-DAY-1" not in result.stdout
-        assert "1 passed" in result.stdout
-        assert learner_test.read_text(encoding="utf-8") == fresh_test
-        assert implementation.read_text(encoding="utf-8") == "LEARNER-IMPLEMENTATION\n"

--- a/tests_refsol/test_week_1_day_1.py
+++ b/tests_refsol/test_week_1_day_1.py
@@ -34,9 +34,9 @@ def test_task_1_simple_attention(
         if batch_dimension == 0:
             BATCH_SIZE = ()
         elif batch_dimension == 1:
-            BATCH_SIZE = (2, 3)
+            BATCH_SIZE = (2,)
         elif batch_dimension == 2:
-            BATCH_SIZE = (2, 3, 3)
+            BATCH_SIZE = (2, 3)
         DIM_L = 4
         DIM_D = 5
         for _ in range(100):
@@ -76,9 +76,9 @@ def test_task_1_simple_attention_scale_mask(
         if batch_dimension == 0:
             BATCH_SIZE = ()
         elif batch_dimension == 1:
-            BATCH_SIZE = (2, 3)
+            BATCH_SIZE = (2,)
         elif batch_dimension == 2:
-            BATCH_SIZE = (2, 3, 3)
+            BATCH_SIZE = (2, 3)
         DIM_L = 4
         DIM_D = 5
         for _ in range(100):
@@ -111,6 +111,8 @@ def test_task_1_simple_attention_scale_mask(
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 def test_task_2_linear(stream: mx.Stream, precision: mx.Dtype):
+    if precision == mx.float16 and stream == mx.cpu:
+        pytest.skip("mx.addmm does not support float16 on CPU")
     with mx.stream(stream):
         BATCH_SIZE = 10
         DIM_Y = 10
@@ -120,9 +122,6 @@ def test_task_2_linear(stream: mx.Stream, precision: mx.Dtype):
             w = mx.random.uniform(shape=(DIM_Y, DIM_X), dtype=precision)
             b = mx.random.uniform(shape=(DIM_Y,), dtype=precision)
             user_output = linear(x, w, b)
-            if precision == mx.float16 and stream == mx.cpu:
-                # unsupported
-                break
             reference_output = mx.addmm(b, x, w.T)
             assert_allclose(user_output, reference_output, precision=precision)
 

--- a/tests_refsol/test_week_1_day_1.py
+++ b/tests_refsol/test_week_1_day_1.py
@@ -115,6 +115,27 @@ def test_task_1_simple_attention_scale_mask(
             )
             assert_allclose(user_output, reference_output, precision=precision)
 
+        if batch_dimension == 2:
+            mask = mx.array(
+                [
+                    [0.0, -0.5, -1.0, -1.5],
+                    [-1.5, 0.0, -0.5, -1.0],
+                    [-1.0, -1.5, 0.0, -0.5],
+                    [-0.5, -1.0, -1.5, 0.0],
+                ],
+                dtype=precision,
+            )
+            scores = mx.matmul(query, key.swapaxes(-2, -1)) * scale + mask
+            reference_output = mx.matmul(mx.softmax(scores, axis=-1), value)
+            user_output = scaled_dot_product_attention_simple(
+                query,
+                key,
+                value,
+                scale=scale,
+                mask=mask,
+            )
+            assert_allclose(user_output, reference_output, precision=precision)
+
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
@@ -129,6 +150,10 @@ def test_task_2_linear(stream: mx.Stream, precision: mx.Dtype):
             b = mx.random.uniform(shape=(DIM_Y,), dtype=precision)
             user_output = linear(x, w, b)
             reference_output = mx.addmm(b, x, w.T)
+            assert_allclose(user_output, reference_output, precision=precision)
+
+            user_output = linear(x, w)
+            reference_output = mx.matmul(x, w.T)
             assert_allclose(user_output, reference_output, precision=precision)
 
 

--- a/tests_refsol/test_week_1_day_1.py
+++ b/tests_refsol/test_week_1_day_1.py
@@ -21,7 +21,9 @@ def test_task_1_softmax(stream: mx.Stream, precision: mx.Dtype):
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 @pytest.mark.parametrize(
-    "batch_dimension", [0, 1, 2], ids=["batch_0", "batch_1", "batch_2"]
+    "batch_dimension",
+    [0, 1, 2, 3],
+    ids=["batch_0", "batch_1", "batch_2", "batch_3"],
 )
 def test_task_1_simple_attention(
     stream: mx.Stream, precision: mx.Dtype, batch_dimension: int
@@ -37,6 +39,8 @@ def test_task_1_simple_attention(
             BATCH_SIZE = (2,)
         elif batch_dimension == 2:
             BATCH_SIZE = (2, 3)
+        elif batch_dimension == 3:
+            BATCH_SIZE = (2, 3, 3)
         DIM_L = 4
         DIM_D = 5
         for _ in range(100):
@@ -64,7 +68,9 @@ def test_task_1_simple_attention(
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 @pytest.mark.parametrize(
-    "batch_dimension", [0, 1, 2], ids=["batch_0", "batch_1", "batch_2"]
+    "batch_dimension",
+    [0, 1, 2, 3],
+    ids=["batch_0", "batch_1", "batch_2", "batch_3"],
 )
 def test_task_1_simple_attention_scale_mask(
     stream: mx.Stream, precision: mx.Dtype, batch_dimension: int
@@ -79,6 +85,8 @@ def test_task_1_simple_attention_scale_mask(
             BATCH_SIZE = (2,)
         elif batch_dimension == 2:
             BATCH_SIZE = (2, 3)
+        elif batch_dimension == 3:
+            BATCH_SIZE = (2, 3, 3)
         DIM_L = 4
         DIM_D = 5
         for _ in range(100):
@@ -111,8 +119,6 @@ def test_task_1_simple_attention_scale_mask(
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 def test_task_2_linear(stream: mx.Stream, precision: mx.Dtype):
-    if precision == mx.float16 and stream == mx.cpu:
-        pytest.skip("mx.addmm does not support float16 on CPU")
     with mx.stream(stream):
         BATCH_SIZE = 10
         DIM_Y = 10


### PR DESCRIPTION
## Why

Week 1 Day 1 is already published, but its first useful test command appears only after the attention theory and does not explain which starter pieces are learner-owned. The supplied attention fixture also omitted a one-leading-dimension case, lost higher-rank coverage while correcting that gap, and treated a supported FP16-on-CPU `mx.addmm` case as unsupported. Finally, the documented `pdm run test` path could keep an older copied fixture instead of activating the current supplied test.

The first draft of this repair also left a misleading manual-implementation TODO beside the supplied MLX softmax and turned checkpoint outcomes into test-ledger prose.

## Change

- Lead the chapter with the required Day 1 ownership and an expected-red focused checkpoint; describe later checkpoints by the learner-visible capability that turns green rather than fixed pass counts.
- Keep MLX softmax supplied and ungraded, correct its starter/reference comments, and offer a numerically stable manual implementation only as an optional bonus.
- Exercise zero, one, two, and three leading dimensions in both simple-attention families and run all four `linear` precision/device cases against the public MLX oracle.
- Make non-Week-4 `pdm run test --week W --day D` refresh only the selected copied test on every run. The ordinary learner command demonstrates this behavior; this change adds no test-runner or framework self-tests.

## Review

- Scope from `main` is exactly five existing paths: `book/src/week1-01-attention.md`, `scripts/dev-tools.py`, `src/tiny_llm/basics.py`, `src/tiny_llm_ref/basics.py`, and `tests_refsol/test_week_1_day_1.py` (+83/-18).
- Untouched starter: Task 1 is 4 passed / 32 failed; `linear` is 4 failed; whole Day 1 is 4 passed / 40 failed.
- Completed learner and reference: Task 1 is 36 passed, `linear` is 4 passed, Task 2 is 8 passed, and Day 1 is 44 passed. The local full reference suite is 511 passed / 8 skipped after the documented extension builds.
- The documented learner command replaced a deliberately stale copied Day 1 test and ran the supplied softmax cases while leaving the learner implementation behavior unchanged. `tests_refsol/test_dev_tools.py` is restored byte-for-byte to `main`.
- Changed Python files are Ruff-format clean; mdBook builds successfully. Apart from the described selected-day refresh behavior and Day 1 collection increase from 36 to 44, all public APIs, model implementation behavior, navigation, later-day, benchmark, model, asset, and Week 4 bytes are unchanged. This Week 1 maintenance work remains owner-held because merging to `main` deploys GitHub Pages.

AI-Assisted: GPT-5.6 Sol + Forge
