### PR TITLE
Repair Week 1 Day 2 RoPE learner contract

### DIFF
--- a/book/src/week1-02-positional-encodings.md
+++ b/book/src/week1-02-positional-encodings.md
@@ -1,8 +1,9 @@
 # Week 1 Day 2: Positional Encodings and RoPE
 
-On Day 2, we will implement the positional encoding used by Qwen3: rotary positional encoding (RoPE). A Transformer needs
-a way to represent each token's position in the sequence. Qwen3 applies RoPE to the query and key vectors within its
-multi-head attention layer.
+The Day 2 starter already declares `RoPE(dims, seq_len, base=10000, traditional=False)`. Its constructor and call method
+are empty. You will fill in those two methods: cache one table of position-dependent angles, then use it to rotate the
+last dimension of an input shaped `(N, L, H, D)`. Day 3 will apply the non-traditional form to Qwen3's query and key
+heads before attention.
 
 **📚 Readings**
 
@@ -13,21 +14,32 @@ multi-head attention layer.
 
 You will need to modify the following file:
 
-```
+```text
 src/tiny_llm/positional_encoding.py
 ```
 
-In traditional RoPE, as described in the readings, positional encoding is applied independently to each head of the query
-and key vectors. You can precompute the frequencies when initializing the `RoPE` class.
+Start by building the frequency table in `RoPE.__init__`. Let `M = D // 2`. Pair index `i`, where `0 <= i < M`, has
+the angular rate below; multiplying it by a token position gives the angle for that pair.
+
+```text
+angular_rate[i] = base ** (-i / (D // 2))
+angle[position, i] = position * angular_rate[i]
+```
+
+Use `mlx.core` operations such as `arange`, `power`, `outer`, `cos`, and `sin` to precompute the cosine and sine of those
+angles for every position from `0` through `seq_len - 1`. The two tables have shape `(seq_len, M)`. Implement the
+operator yourself with these array operations; `mx.fast.rope` is the supplied test's correctness oracle, not the
+implementation for this exercise. For this lesson, assume that `D` is even, so `M` pairs cover the whole head
+dimension.
 
 If `offset` is not provided, apply positions 0 through `L - 1` to the input sequence. Otherwise, select positions from
 the supplied slice. For example, with `offset=slice(5, 10)`, the input sequence must have length 5, and its first token
-uses the frequency for position 5.
+uses the frequency for position 5. Reshape the selected `(L, M)` basis to broadcast across the batch and head axes.
 
 For Week 1, you only need to support `offset=None` and a single `slice`. We will implement `list[slice]` for continuous
 batching later. For now, assume that every item in a batch uses the same offset.
 
-```
+```text
 x: (N, L, H, D)
 cos/sin_freqs: (MAX_SEQ_LEN, D // 2)
 ```
@@ -36,10 +48,7 @@ Traditional RoPE interprets adjacent values along head dimension `D` as complex-
 and `x[1]` form one pair, `x[2]` and `x[3]` form another, and so on. Both values in a pair use the same frequency from
 `cos_freqs` and `sin_freqs`.
 
-In practice, `D` can be even or odd. If it is odd, the final value has no partner and is typically left unchanged. For
-simplicity, this implementation requires `D` to be even.
-
-```
+```text
 output[0] = x[0] * cos_freqs[0] + x[1] * -sin_freqs[0]
 output[1] = x[0] * sin_freqs[0] + x[1] * cos_freqs[0]
 output[2] = x[2] * cos_freqs[1] + x[3] * -sin_freqs[1]
@@ -48,24 +57,29 @@ output[3] = x[2] * sin_freqs[1] + x[3] * cos_freqs[1]
 ```
 
 You can implement this operation by reshaping `x` to `(N, L, H, D // 2, 2)` and applying the formula to each pair.
+Stack the real and imaginary results back along the pair axis, restore the original shape, and return the result in
+`x.dtype`.
 
 **📚 Readings**
 
 - [PyTorch RotaryPositionalEmbeddings API](https://pytorch.org/torchtune/stable/generated/torchtune.modules.RotaryPositionalEmbeddings.html)
 - [MLX Implementation of RoPE before the custom metal kernel implementation](https://github.com/ml-explore/mlx/pull/676/files)
 
-You can test your implementation by running the following command:
+Run the focused command once before editing. The empty starter returns no array, so the comparison should fail when it
+tries to inspect the result. Run the same command again after implementing Task 1; when it passes, your cached basis,
+position selection, adjacent pairing, and dtype restoration work together.
 
-```
+```bash
 pdm run test --week 1 --day 2 -- -k task_1
 ```
 
 ## Task 2: Implement Non-Traditional `RoPE`
 
-Qwen3 uses a non-traditional arrangement of RoPE pairs. Split the head dimension into two halves, then pair corresponding
-values from the halves. Let `x1 = x[..., :HALF_DIM]` and `x2 = x[..., HALF_DIM:]`.
+Qwen3 uses a non-traditional arrangement of RoPE pairs. Keep the same cached frequencies and position-selection logic.
+When `traditional` is false, split the head dimension into two halves, then pair corresponding values from the halves.
+Let `x1 = x[..., :HALF_DIM]` and `x2 = x[..., HALF_DIM:]`.
 
-```
+```text
 output[0] = x1[0] * cos_freqs[0] + x2[0] * -sin_freqs[0]
 output[HALF_DIM] = x1[0] * sin_freqs[0] + x2[0] * cos_freqs[0]
 output[1] = x1[1] * cos_freqs[1] + x2[1] * -sin_freqs[1]
@@ -73,23 +87,27 @@ output[HALF_DIM + 1] = x1[1] * sin_freqs[1] + x2[1] * cos_freqs[1]
 ...and so on
 ```
 
-Implement this form by selecting the first and second halves of `x` directly, applying the rotations, and concatenating
-the results.
+Implement this form by selecting the first and second halves of `x` directly, applying the rotations, concatenating the
+results, and returning the original dtype. The constructor's default is non-traditional because that is the layout the
+Qwen3 attention block will use.
 
 **📚 Readings**
 
 - [vLLM implementation of RoPE](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/rotary_embedding)
 
-You can test your implementation by running the following command:
+This focused command should now pass with the half-split layout while reusing the same angles and offset handling:
 
-```
+```bash
 pdm run test --week 1 --day 2 -- -k task_2
 ```
 
-At the end of the day, you should be able to pass all tests of this day:
+Finally, run both layouts together:
 
-```
+```bash
 pdm run test --week 1 --day 2
 ```
+
+Once that command passes, `RoPE` is ready for Day 3 to rotate Qwen3 query and key heads with one shared slice. Per-request
+`list[slice]` offsets remain a later continuous-batching problem.
 
 {{#include copyright.md}}

--- a/tests_refsol/test_week_1_day_2.py
+++ b/tests_refsol/test_week_1_day_2.py
@@ -5,18 +5,21 @@ import numpy as np
 from .utils import *
 
 
+ROPE_CONFIGS = [
+    (1, 10, 8, 4, 20, 10000),
+    (2, 5, 3, 8, 17, 10),
+]
+ROPE_CONFIG_IDS = ["baseline", "different-shape-and-base"]
+
+
 def rope_helper(
     stream: mx.Stream,
     traditional: bool,
     precision: mx.Dtype,
     with_offset: bool,
+    config: tuple[int, int, int, int, int, int],
 ):
-    BATCH_SIZE = 1
-    NUM_HEADS = 8
-    HEAD_DIM = 4
-    MAX_SEQ_LEN = 20
-    SEQ_LEN = 10
-    BASE = 10000
+    BATCH_SIZE, SEQ_LEN, NUM_HEADS, HEAD_DIM, MAX_SEQ_LEN, BASE = config
     with mx.stream(stream):
         for _ in range(100):
             user_layer = RoPE(HEAD_DIM, MAX_SEQ_LEN, BASE, traditional=traditional)
@@ -56,10 +59,14 @@ def rope_helper(
     "with_offset", [True, False], ids=["with_offset", "without_offset"]
 )
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
+@pytest.mark.parametrize("config", ROPE_CONFIGS, ids=ROPE_CONFIG_IDS)
 def test_task_1_rope_mlx_traditional(
-    stream: mx.Stream, with_offset: bool, precision: mx.Dtype
+    stream: mx.Stream,
+    with_offset: bool,
+    precision: mx.Dtype,
+    config: tuple[int, int, int, int, int, int],
 ):
-    rope_helper(stream, True, precision, with_offset)
+    rope_helper(stream, True, precision, with_offset, config)
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
@@ -67,7 +74,11 @@ def test_task_1_rope_mlx_traditional(
     "with_offset", [True, False], ids=["with_offset", "without_offset"]
 )
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
+@pytest.mark.parametrize("config", ROPE_CONFIGS, ids=ROPE_CONFIG_IDS)
 def test_task_2_rope_mlx_non_traditional(
-    stream: mx.Stream, with_offset: bool, precision: mx.Dtype
+    stream: mx.Stream,
+    with_offset: bool,
+    precision: mx.Dtype,
+    config: tuple[int, int, int, int, int, int],
 ):
-    rope_helper(stream, False, precision, with_offset)
+    rope_helper(stream, False, precision, with_offset, config)

--- a/tests_refsol/test_week_1_day_2.py
+++ b/tests_refsol/test_week_1_day_2.py
@@ -42,6 +42,7 @@ def rope_helper(
                 offset=input_pos_mx or 0,
             ).transpose(0, 2, 1, 3)
             user_output = user_layer(x, input_pos_user)
+            assert user_output.dtype == x.dtype
             assert_allclose(
                 user_output,
                 reference_output,


### PR DESCRIPTION
## Summary

- Rewrite Week 1 Day 2 around the intentionally empty `RoPE` starter and the exact frequency-table construction learners own.
- Turn the two pair layouts into capability-led checkpoints with honest first-run feedback, dtype preservation, and the Day 3 query/key handoff.
- Add public dtype preservation and contrasting `N=2`, `D=8`, `base=10` witnesses across both layouts while retaining independent `mx.fast.rope` value oracles.

## Verification

- `pdm run test --week 1 --day 2 -- -k task_1 -q` — expected red on the empty starter.
- `pdm run test --week 1 --day 2 -- -q --tb=no` — expected red on the empty starter.
- `pdm run test-refsol --week 1 --day 2 -- -k task_1 -q` — 16 passed, 16 deselected.
- `pdm run test-refsol --week 1 --day 2 -- -q` — 32 passed.
- `mdbook build book` — passed.
- `ruff format --check tests_refsol/test_week_1_day_2.py` — passed.
- Exact two-path, link/command/equation, test-byte, complement-record, and symlink preservation checks — passed.

## Scope

Only `book/src/week1-02-positional-encodings.md` and `tests_refsol/test_week_1_day_2.py` change. Starter/reference implementation, tooling, navigation, adjacent and later lessons, Week 4, and publication surfaces remain unchanged.

AI-Assisted: GPT-5.6 Sol + Sentinel
