### PR TITLE
Repair Week 1 Day 3 GQA learner contract

### DIFF
--- a/book/src/week1-03-gqa.md
+++ b/book/src/week1-03-gqa.md
@@ -59,7 +59,10 @@ output: N.. x H_q x L x D
 ```
 
 In addition to grouped heads, this function supports different query and key/value sequence lengths: Q uses length `L`,
-while K and V use length `S`.
+while K and V use length `S`. `H_q = H` gives ordinary multi-head attention, while `H = 1` gives multi-query
+attention. The leading `N..` batch shape may contain any number of positive-sized dimensions, and `D` is an independent
+head dimension rather than necessarily `hidden_size // H_q`. An array mask is additive and must be forwarded to the
+attention scores.
 
 You can test your implementation by running the following command:
 
@@ -79,9 +82,10 @@ Causal masking prevents attention from reading future tokens. When `mask` is set
 mask.
 
 The additive causal mask has shape `(L, S)`, where `L` is the query sequence length and `S` is the key/value sequence length.
-Allowed positions contain 0, and masked positions contain `-inf`. When `S` is greater than `L`, shift the diagonal by
-`S - L` so that the queries correspond to the final `L` positions in the key/value sequence. For example, if `L = 3`
-and `S = 5`, the mask is:
+Allowed positions contain 0, and masked positions contain `-inf`, and the returned mask must use the requested `dtype`.
+Causal attention requires `S >= L`; reject inputs with more query positions than key/value positions. When `S` is greater
+than `L`, shift the diagonal by `S - L` so that the queries correspond to the final `L` positions in the key/value
+sequence. For example, if `L = 3` and `S = 5`, the mask is:
 
 ```
 0   0   0   -inf -inf
@@ -123,9 +127,13 @@ x = scaled_dot_product_attention_grouped(q, k, v, scale, mask) -> B, H_q, L, D  
 x = linear(x, wo) -> B, L, E
 ```
 
-Qwen3 attention has no Q/K/V projection biases, and it applies RMSNorm to each Q and K head before RoPE. We will implement
-the reusable `RMSNorm` layer on Day 4, so call `mx.fast.rms_norm` directly for `q_norm` and `k_norm` today. Use
-non-traditional RoPE.
+Qwen3 attention has no Q/K/V projection biases. Apply RMSNorm to each Q and K head before applying non-traditional RoPE;
+the order matters when the normalization weights are nonuniform. We will implement the reusable `RMSNorm` layer on Day 4,
+so call `mx.fast.rms_norm` directly for `q_norm` and `k_norm` today.
+
+The grouped attention arithmetic must run in float32: cast the projected, normalized, and rotated Q and K tensors and the
+projected V tensor to float32 before calling `scaled_dot_product_attention_grouped`. Cast its result back to the input
+model dtype before the final output projection. Forward `None`, `"causal"`, or an additive array mask unchanged.
 
 You can test your implementation by running the following command:
 

--- a/src/tiny_llm_ref/attention.py
+++ b/src/tiny_llm_ref/attention.py
@@ -56,6 +56,8 @@ def scaled_dot_product_attention_grouped(
     scores = mx.matmul(query, key.swapaxes(-2, -1)) * factor
     if mask is not None:
         if mask == "causal":
+            if L > S:
+                raise ValueError("causal attention requires S >= L")
             mask = causal_mask(L, S, scores.dtype)
             scores = scores + mask
         else:

--- a/tests_refsol/test_week_1_day_3.py
+++ b/tests_refsol/test_week_1_day_3.py
@@ -140,6 +140,22 @@ def test_task_1_grouped_attention(
     grouped_attention_helper(stream, precision, batch_dimension, scale, False)
 
 
+def test_task_1_grouped_attention_three_leading_axes_without_mask():
+    with mx.stream(mx.cpu):
+        query = deterministic_array((3, 2, 10, 18, 3, 5), 0.5, mx.float32)
+        key = deterministic_array((3, 2, 10, 6, 7, 5), 0.4, mx.float32)
+        value = deterministic_array((3, 2, 10, 6, 7, 5), 0.3, mx.float32)
+        expected = mx.fast.scaled_dot_product_attention(
+            query.reshape(-1, 18, 3, 5),
+            key.reshape(-1, 6, 7, 5),
+            value.reshape(-1, 6, 7, 5),
+            scale=5**-0.5,
+            mask=None,
+        ).reshape(query.shape)
+        actual = scaled_dot_product_attention_grouped(query, key, value, mask=None)
+        assert_allclose(actual, expected, precision=mx.float32)
+
+
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 def test_task_1_mqa_and_non_divisible_heads(stream: mx.Stream):
     with mx.stream(stream):

--- a/tests_refsol/test_week_1_day_3.py
+++ b/tests_refsol/test_week_1_day_3.py
@@ -83,6 +83,7 @@ def grouped_attention_helper(
         S = 7
         BATCH = 10
         BATCH_2 = 2
+        BATCH_3 = 3
         if batch_dimension == 0:
             q_shape = (H_q, L, D)
             kv_shape = (H, S, D)
@@ -95,6 +96,10 @@ def grouped_attention_helper(
             q_shape = (BATCH_2, BATCH, H_q, L, D)
             kv_shape = (BATCH_2, BATCH, H, S, D)
             mask_shape = (BATCH_2, BATCH, H_q, L, S)
+        elif batch_dimension == 3:
+            q_shape = (BATCH_3, BATCH_2, BATCH, H_q, L, D)
+            kv_shape = (BATCH_3, BATCH_2, BATCH, H, S, D)
+            mask_shape = (BATCH_3, BATCH_2, BATCH, H_q, L, S)
         for _ in range(100):
             query = mx.random.uniform(shape=q_shape, dtype=precision)
             key = mx.random.uniform(shape=kv_shape, dtype=precision)
@@ -124,7 +129,9 @@ def grouped_attention_helper(
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 @pytest.mark.parametrize(
-    "batch_dimension", [0, 1, 2], ids=["batch_0", "batch_1", "batch_2"]
+    "batch_dimension",
+    [0, 1, 2, 3],
+    ids=["batch_0", "batch_1", "batch_2", "batch_3"],
 )
 @pytest.mark.parametrize("scale", [None, 0.8])
 def test_task_1_grouped_attention(
@@ -229,7 +236,9 @@ def test_task_2_mask_dtype_and_causal_domain(stream: mx.Stream):
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize("precision", PRECISIONS, ids=PRECISION_IDS)
 @pytest.mark.parametrize(
-    "batch_dimension", [0, 1, 2], ids=["batch_0", "batch_1", "batch_2"]
+    "batch_dimension",
+    [0, 1, 2, 3],
+    ids=["batch_0", "batch_1", "batch_2", "batch_3"],
 )
 @pytest.mark.parametrize("scale", [None, 0.8])
 def test_task_2_grouped_attention_causal_mask(

--- a/tests_refsol/test_week_1_day_3.py
+++ b/tests_refsol/test_week_1_day_3.py
@@ -1,7 +1,71 @@
 import pytest
 import mlx.core as mx
+import numpy as np
 from .tiny_llm_base import *
 from .utils import *
+
+
+def deterministic_array(shape: tuple[int, ...], scale: float, dtype: mx.Dtype):
+    values = mx.arange(int(np.prod(shape)), dtype=mx.float32).reshape(shape)
+    return (mx.sin(values * 0.37) * scale).astype(dtype)
+
+
+def qwen_attention_oracle(
+    x: mx.array,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    wq: mx.array,
+    wk: mx.array,
+    wv: mx.array,
+    wo: mx.array,
+    q_norm: mx.array,
+    k_norm: mx.array,
+    mask: mx.array | None,
+    theta: int,
+    rms_norm_eps: float,
+) -> mx.array:
+    """Independent public-operation oracle for the Day 3 Qwen attention path."""
+    B, L, _ = x.shape
+    query = mx.matmul(x, wq.T).reshape(B, L, num_heads, head_dim)
+    key = mx.matmul(x, wk.T).reshape(B, L, num_kv_heads, head_dim)
+    value = mx.matmul(x, wv.T).reshape(B, L, num_kv_heads, head_dim)
+
+    query = mx.fast.rms_norm(query, q_norm, eps=rms_norm_eps)
+    key = mx.fast.rms_norm(key, k_norm, eps=rms_norm_eps)
+    query = mx.fast.rope(
+        query.transpose(0, 2, 1, 3),
+        dims=head_dim,
+        traditional=False,
+        base=theta,
+        scale=1.0,
+        offset=0,
+    )
+    key = mx.fast.rope(
+        key.transpose(0, 2, 1, 3),
+        dims=head_dim,
+        traditional=False,
+        base=theta,
+        scale=1.0,
+        offset=0,
+    )
+    value = value.transpose(0, 2, 1, 3)
+
+    query = query.astype(mx.float32)
+    key = key.astype(mx.float32)
+    value = value.astype(mx.float32)
+    repeats = num_heads // num_kv_heads
+    query = query.reshape(B, num_kv_heads, repeats, L, head_dim)
+    key = key.reshape(B, num_kv_heads, 1, L, head_dim)
+    value = value.reshape(B, num_kv_heads, 1, L, head_dim)
+    scores = mx.matmul(query, key.swapaxes(-2, -1)) * (head_dim**-0.5)
+    if mask is not None:
+        scores = scores + mask.reshape(B, num_kv_heads, repeats, L, L)
+    output = mx.matmul(mx.softmax(scores, axis=-1), value)
+    output = output.reshape(B, num_heads, L, head_dim).astype(x.dtype)
+    output = output.transpose(0, 2, 1, 3).reshape(B, L, num_heads * head_dim)
+    return mx.matmul(output, wo.T)
 
 
 def grouped_attention_helper(
@@ -70,6 +134,32 @@ def test_task_1_grouped_attention(
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_1_mqa_and_non_divisible_heads(stream: mx.Stream):
+    with mx.stream(stream):
+        query = deterministic_array((2, 6, 3, 4), 0.5, mx.float32)
+        key = deterministic_array((2, 1, 5, 4), 0.4, mx.float32)
+        value = deterministic_array((2, 1, 5, 4), 0.3, mx.float32)
+        expected = mx.fast.scaled_dot_product_attention(
+            query, key, value, scale=4**-0.5
+        )
+        actual = scaled_dot_product_attention_grouped(query, key, value)
+        assert_allclose(actual, expected, precision=mx.float32)
+
+        try:
+            scaled_dot_product_attention_grouped(
+                query[:, :5],
+                mx.broadcast_to(key, (2, 2, 5, 4)),
+                mx.broadcast_to(value, (2, 2, 5, 4)),
+            )
+        except Exception:
+            pass
+        else:
+            raise AssertionError(
+                "non-divisible query and key/value heads were accepted"
+            )
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 def test_task_2_mask_only_same_dim(
     stream: mx.Stream,
 ):
@@ -117,6 +207,23 @@ def test_task_2_mask_only_different_dim(
             ),
             precision=mx.float32,
         )
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_2_mask_dtype_and_causal_domain(stream: mx.Stream):
+    with mx.stream(stream):
+        mask = causal_mask(2, 4, mx.bfloat16)
+        assert mask.dtype == mx.bfloat16
+
+        query = mx.ones((2, 5, 4), dtype=mx.float32)
+        key = mx.ones((1, 3, 4), dtype=mx.float32)
+        value = mx.ones((1, 3, 4), dtype=mx.float32)
+        try:
+            scaled_dot_product_attention_grouped(query, key, value, mask="causal")
+        except Exception:
+            pass
+        else:
+            raise AssertionError("causal attention accepted more queries than keys")
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
@@ -195,3 +302,106 @@ def test_task_3_qwen3_grouped_query_attention(
         mlx_output = mlx_attention(x, mask=mask, cache=None)
 
         assert_allclose(user_output, mlx_output, precision=precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_3_qwen_public_shape_norm_and_additive_mask(stream: mx.Stream):
+    with mx.stream(stream):
+        B, L, hidden_size = 2, 4, 12
+        num_heads, num_kv_heads, head_dim = 4, 1, 4
+        theta = 10000
+        eps = 1e-6
+        x = deterministic_array((B, L, hidden_size), 0.4, mx.float32)
+        wq = deterministic_array((num_heads * head_dim, hidden_size), 0.3, mx.float32)
+        wk = deterministic_array(
+            (num_kv_heads * head_dim, hidden_size), 0.2, mx.float32
+        )
+        wv = deterministic_array(
+            (num_kv_heads * head_dim, hidden_size), 0.25, mx.float32
+        )
+        wo = deterministic_array((hidden_size, num_heads * head_dim), 0.2, mx.float32)
+        q_norm = mx.array([0.4, 0.9, 1.3, 1.8], dtype=mx.float32)
+        k_norm = mx.array([1.7, 1.2, 0.8, 0.3], dtype=mx.float32)
+        mask = deterministic_array((B, num_heads, L, L), 0.2, mx.float32)
+
+        layer = qwen3_week1.Qwen3MultiHeadAttention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            wq=wq,
+            wk=wk,
+            wv=wv,
+            wo=wo,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            theta=theta,
+            rms_norm_eps=eps,
+        )
+        expected = qwen_attention_oracle(
+            x,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            wq=wq,
+            wk=wk,
+            wv=wv,
+            wo=wo,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            mask=mask,
+            theta=theta,
+            rms_norm_eps=eps,
+        )
+        actual = layer(x, mask=mask)
+        assert actual.shape == (B, L, hidden_size)
+        assert_allclose(actual, expected, precision=mx.float32)
+
+
+def test_task_3_qwen_bfloat16_attention_arithmetic():
+    with mx.stream(mx.gpu):
+        B, L, hidden_size = 2, 8, 16
+        num_heads, num_kv_heads, head_dim = 4, 2, 6
+        theta = 10000
+        eps = 1e-6
+        dtype = mx.bfloat16
+        x = deterministic_array((B, L, hidden_size), 2.0, dtype)
+        wq = deterministic_array((num_heads * head_dim, hidden_size), 1.5, dtype)
+        wk = deterministic_array((num_kv_heads * head_dim, hidden_size), 1.7, dtype)
+        wv = deterministic_array((num_kv_heads * head_dim, hidden_size), 1.3, dtype)
+        wo = deterministic_array((hidden_size, num_heads * head_dim), 1.1, dtype)
+        q_norm = deterministic_array((head_dim,), 1.4, dtype) + mx.array(1.7, dtype)
+        k_norm = deterministic_array((head_dim,), 1.2, dtype) + mx.array(1.5, dtype)
+
+        layer = qwen3_week1.Qwen3MultiHeadAttention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            wq=wq,
+            wk=wk,
+            wv=wv,
+            wo=wo,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            theta=theta,
+            rms_norm_eps=eps,
+        )
+        expected = qwen_attention_oracle(
+            x,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            wq=wq,
+            wk=wk,
+            wv=wv,
+            wo=wo,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            mask=None,
+            theta=theta,
+            rms_norm_eps=eps,
+        )
+        actual = layer(x)
+        assert actual.dtype == dtype
+        assert_allclose(actual, expected, precision=dtype, rtol=0.01, atol=0.01)


### PR DESCRIPTION
## Why

Week 1 Day 3 did not fully bind the public grouped-attention and Qwen3 attention contract. The chapter left multi-query attention, arbitrary leading dimensions, independent head dimensions, additive-mask forwarding, mask dtype, the causal `S >= L` domain, Q/K normalization order, and the float32 attention/cast-back boundary implicit. The supplied tests therefore allowed several learner-visible API and numerical errors to pass undetected.

## Change

- Explain the MHA/GQA/MQA head relationships, arbitrary positive leading axes, independent `head_dim`, additive masks, requested mask dtype, and the causal requirement that key/value length is at least query length.
- Specify that Q/K RMSNorm precedes non-traditional RoPE, attention arithmetic runs in float32, and its result returns to the model dtype before the output projection.
- Make the completed grouped-attention path reject causal `L > S` before it can produce NaNs.
- Add deterministic public behavioral witnesses for MQA and non-divisible heads, BF16 mask dtype, causal-domain rejection, Qwen batch and dimension handling, nonuniform norm weights, additive masking, and BF16 promotion/castback against an independent public-operation oracle.

## Review

- Scope from the PR base is exactly three modified existing paths: `book/src/week1-03-gqa.md`, `src/tiny_llm_ref/attention.py`, and `tests_refsol/test_week_1_day_3.py` (+254/-9), with no add/delete/rename/mode change.
- The completed/reference Day 3 checkpoint passes all 84 supplied cases; the untouched starter fails all 84 as intended. The local full reference suite is 527 passed / 8 skipped after the documented extension builds; the exact successor head's hosted check must be terminal green before delivery.
- Twelve causal mutations are rejected, covering MQA, non-divisible grouped heads, arbitrary leading axes across additive, causal, and unmasked attention, mask dtype, causal `L > S`, batch size 2, independent `head_dim`, norm/RoPE order, additive masks, float32 attention promotion, and castback.
- Installation, starter extension, copied-test freshness, Ruff formatting for changed Python, mdBook, sitemap, and diff checks pass. Both trees retain 331 records and two symlinks; the 328-record protected complement is unchanged.
- Supplied grading uses only public imports, APIs, MLX operations, numeric outputs, shapes, dtypes, and observable rejection. It does not parse source or grade private names, fields, loops, implementation shape, error wording/type, or whether K/V grouping is materialized.
- Starter code and public signatures, already-correct Qwen behavior, Day 1/2 and Day 4+, Week 4, tooling, lockfiles, navigation, publication configuration, and unrelated bytes are unchanged. Ordinary course merge occurs only after the written exact-head gates close and will trigger the repository's existing Pages workflow.

AI-Assisted: GPT-5.6 Sol + Forge
