### PR TITLE
Repair Week 1 Day 4 RMSNorm and MLP test contract

### DIFF
--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -103,6 +103,38 @@ def test_task_1_rms_norm_rank_one_custom_epsilon(
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_1_rms_norm_cast_back_before_weight_scaling(stream: mx.Stream):
+    precision = mx.float16
+    dim = 65_536
+    eps = 1e-5
+    smallest_subnormal = np.nextafter(np.float16(0), np.float16(1))
+    largest_finite = np.finfo(np.float16).max
+
+    data_np = np.zeros(dim, dtype=np.float16)
+    data_np[0] = smallest_subnormal
+    data_np[-1] = largest_finite
+    weight_np = np.ones(dim, dtype=np.float16)
+    weight_np[0] = largest_finite
+    data = mx.array(data_np)
+    weight = mx.array(weight_np)
+
+    data_f32 = np.array(data.astype(mx.float32))
+    normalized_f32 = data_f32 / np.sqrt(np.mean(np.square(data_f32)) + eps)
+    expected = mx.array(normalized_f32).astype(precision) * weight
+
+    with mx.stream(stream):
+        output = RMSNorm(dim, weight, eps=eps)(data)
+
+    expected_f32 = np.array(expected.astype(mx.float32))
+    output_f32 = np.array(output.astype(mx.float32))
+    assert output.shape == (dim,)
+    assert output.dtype == precision
+    assert expected_f32[0] == 0
+    assert output_f32[0] == 0
+    assert_allclose(output, expected, precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize(
     "precision",
     [*PRECISIONS, mx.bfloat16],

--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -78,6 +78,31 @@ def test_task_1_rms_norm_leading_dimensions_and_dtype(
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+@pytest.mark.parametrize("precision", [mx.float16, mx.bfloat16], ids=["f16", "bf16"])
+def test_task_1_rms_norm_rank_one_custom_epsilon(
+    stream: mx.Stream,
+    precision: mx.Dtype,
+):
+    dim = 5
+    eps = 3e-4
+    data = mx.array([-0.035, -0.0175, 0.0, 0.0125, 0.0275]).astype(precision)
+    weight = mx.array(np.linspace(0.5, 1.5, dim)).astype(precision)
+
+    data_f32 = np.array(data.astype(mx.float32))
+    normalized_f32 = data_f32 / np.sqrt(
+        np.mean(np.square(data_f32), axis=-1, keepdims=True) + eps
+    )
+    expected = mx.array(normalized_f32).astype(precision) * weight
+
+    with mx.stream(stream):
+        output = RMSNorm(dim, weight, eps=eps)(data)
+
+    assert output.shape == (dim,)
+    assert output.dtype == precision
+    assert_allclose(output, expected, precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize(
     "precision",
     [*PRECISIONS, mx.bfloat16],
@@ -169,13 +194,17 @@ def test_task_2_qwen_mlp(stream: mx.Stream, precision: mx.Dtype, dims: dict):
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+@pytest.mark.parametrize(
+    "leading_shape", [(2, 1, 3), (3,)], ids=["three_leading", "no_batch"]
+)
 def test_task_2_qwen_mlp_leading_dimensions_bfloat16(
     stream: mx.Stream,
+    leading_shape: tuple[int, ...],
 ):
     precision = mx.bfloat16
     dim = 4
     hidden_dim = 6
-    shape = (2, 1, 3, dim)
+    shape = (*leading_shape, dim)
     data = mx.array(np.linspace(-0.5, 0.5, np.prod(shape)).reshape(shape)).astype(
         precision
     )

--- a/tests_refsol/test_week_1_day_4.py
+++ b/tests_refsol/test_week_1_day_4.py
@@ -1,6 +1,7 @@
 import pytest
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 from .tiny_llm_base import *
 from .utils import *
 from mlx_lm.models import qwen3
@@ -45,6 +46,38 @@ def test_task_1_rms_norm_cast_to_float32(stream: mx.Stream):
 
 
 @pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+@pytest.mark.parametrize("precision", [mx.float16, mx.bfloat16], ids=["f16", "bf16"])
+@pytest.mark.parametrize(
+    "leading_shape", [(2, 3), (2, 1, 3)], ids=["two_leading", "three_leading"]
+)
+def test_task_1_rms_norm_leading_dimensions_and_dtype(
+    stream: mx.Stream,
+    precision: mx.Dtype,
+    leading_shape: tuple[int, ...],
+):
+    dim = 5
+    eps = 3e-4
+    shape = (*leading_shape, dim)
+    data = mx.array(np.linspace(-3.5, 2.75, np.prod(shape)).reshape(shape)).astype(
+        precision
+    )
+    weight = mx.array(np.linspace(0.5, 1.5, dim)).astype(precision)
+
+    data_f32 = np.array(data.astype(mx.float32))
+    normalized_f32 = data_f32 / np.sqrt(
+        np.mean(np.square(data_f32), axis=-1, keepdims=True) + eps
+    )
+    expected = mx.array(normalized_f32).astype(precision) * weight
+
+    with mx.stream(stream):
+        output = RMSNorm(dim, weight, eps=eps)(data)
+
+    assert output.shape == shape
+    assert output.dtype == precision
+    assert_allclose(output, expected, precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
 @pytest.mark.parametrize(
     "precision",
     [*PRECISIONS, mx.bfloat16],
@@ -64,6 +97,29 @@ def test_task_2_silu(stream: mx.Stream, precision: mx.Dtype):
             user_output = silu(x)
             reference_output = nn.silu(x)
             assert_allclose(user_output, reference_output, precision=precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_2_silu_low_precision_tails(stream: mx.Stream):
+    precision = mx.float16
+    tail = -12.0
+    data = mx.array([tail, -4.0, 0.0, 4.0, -tail]).astype(precision)
+    data_f32 = np.array(data.astype(mx.float32))
+    sigmoid = np.where(
+        data_f32 < 0,
+        np.exp(data_f32) / (1 + np.exp(data_f32)),
+        1 / (1 + np.exp(-data_f32)),
+    )
+    expected = mx.array(data_f32 * sigmoid).astype(precision)
+
+    with mx.stream(stream):
+        output = silu(data)
+
+    output_f32 = np.array(output.astype(mx.float32))
+    assert output.dtype == precision
+    assert np.all(np.isfinite(output_f32))
+    assert output_f32[0] != 0
+    assert_allclose(output, expected, precision=precision)
 
 
 # Define different dimension parameters for testing
@@ -110,3 +166,56 @@ def test_task_2_qwen_mlp(stream: mx.Stream, precision: mx.Dtype, dims: dict):
         reference_output = reference_mlp(x)
 
         assert_allclose(user_output, reference_output, precision)
+
+
+@pytest.mark.parametrize("stream", AVAILABLE_STREAMS, ids=AVAILABLE_STREAMS_IDS)
+def test_task_2_qwen_mlp_leading_dimensions_bfloat16(
+    stream: mx.Stream,
+):
+    precision = mx.bfloat16
+    dim = 4
+    hidden_dim = 6
+    shape = (2, 1, 3, dim)
+    data = mx.array(np.linspace(-0.5, 0.5, np.prod(shape)).reshape(shape)).astype(
+        precision
+    )
+    w_gate = mx.array(
+        np.linspace(-0.4, 0.3, hidden_dim * dim).reshape(hidden_dim, dim)
+    ).astype(precision)
+    w_up = mx.array(
+        np.linspace(0.35, -0.25, hidden_dim * dim).reshape(hidden_dim, dim)
+    ).astype(precision)
+    w_down = mx.array(
+        np.linspace(-0.3, 0.45, dim * hidden_dim).reshape(dim, hidden_dim)
+    ).astype(precision)
+
+    data_f32 = np.array(data.astype(mx.float32))
+    gate = data_f32 @ np.array(w_gate.astype(mx.float32)).T
+    up = data_f32 @ np.array(w_up.astype(mx.float32)).T
+    sigmoid = np.where(
+        gate < 0,
+        np.exp(gate) / (1 + np.exp(gate)),
+        1 / (1 + np.exp(-gate)),
+    )
+    expected = (gate * sigmoid * up) @ np.array(w_down.astype(mx.float32)).T
+
+    with mx.stream(stream):
+        output = qwen3_week1.Qwen3MLP(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            w_gate=w_gate,
+            w_up=w_up,
+            w_down=w_down,
+        )(data)
+
+    output_f32 = np.array(output.astype(mx.float32))
+    assert output.shape == shape
+    assert output.dtype == precision
+    assert np.all(np.isfinite(output_f32))
+    assert_allclose(
+        output,
+        mx.array(expected).astype(precision),
+        precision=precision,
+        rtol=0.08,
+        atol=2e-3,
+    )


### PR DESCRIPTION
## Why

Week 1 Day 4 explains the RMSNorm and SwiGLU learner path, but its supplied tests did not enforce several public parts of that contract. A fixed-axis RMSNorm that skipped the required cast back, a direct overflow-prone SiLU formula, and an MLP restricted to exactly three-dimensional input could pass the original checkpoint. The first repairs still allowed RMSNorm to reject rank-one input, replace the requested epsilon with the weight dtype's machine epsilon, or defer the required cast back until after weight scaling; they also allowed an MLP restricted to rank-three and rank-four input. The existing random positive MLP fixtures also produced non-finite low-precision reference outputs in the single-token lanes.

## Change

- Add deterministic float16 and bfloat16 RMSNorm witnesses over zero, two, and three leading dimensions, including a low-magnitude rank-one case with a custom epsilon, independent final-axis numerical oracles, and exact output-dtype checks.
- Add a bounded 65,536-feature float16 RMSNorm witness on CPU and GPU whose independent oracle casts the normalized value back before weight scaling and whose discriminating output must be exactly zero.
- Add a targeted float16 SiLU tail witness whose stable public numerical oracle remains nonzero where the direct overflow-prone formula collapses to zero.
- Add bounded signed bfloat16 Qwen3MLP witnesses over multiple leading dimensions and no-batch `(L, E)` input, checking finite outputs, shape, dtype, and the public SwiGLU equation against an independent numerical oracle.

## Review

- Scope is exactly one modified existing path, `tests_refsol/test_week_1_day_4.py` (+170/-0), with no add, delete, rename, or mode change.
- The completed learner and maintained reference each pass all 44 Day 4 cases; all predecessor 42 cases remain unchanged and green, while the untouched starter fails all 44 as intended. The local full reference suite is 571 passed / 8 skipped after both documented extension builds.
- A cast-after-weight RMSNorm survivor passes all 42 predecessor cases and fails only the two new CPU/GPU cast-order lanes, producing `1.526e-05` instead of the required exact zero.
- The fixed-axis/no-cast-back RMSNorm survivor passes six predecessor cases and fails the fourteen multidimensional/dtype/rank-one/cast-order lanes. The direct unstable SiLU survivor fails only the two tail lanes while six predecessor cases pass. The exactly-three-dimensional MLP survivor passes twelve predecessor cases and fails the four arbitrary-leading-dimension lanes.
- The dtype-epsilon constructor replacement passes sixteen cases and fails the four low-magnitude rank-one lanes. The rank-one-rejection RMSNorm survivor passes fourteen cases and fails the six rank-one lanes. The rank-three/four-only MLP survivor passes fourteen cases and fails only the two no-batch lanes.
- Installation, both extension builds, the starter extension smoke test, copied-test freshness, Ruff formatting, mdBook, sitemap, and diff checks pass. The prospective tree retains 331 records and two symlinks; its 330-record complement outside the sole changed path is unchanged.
- Supplied grading uses only public imports, APIs, deterministic numeric inputs and outputs, shapes, dtypes, and finiteness. It does not parse source or grade private names, fields, loops, implementation shape, or error wording/type.
- The already-clear Day 4 prose, starter and public signatures, reference implementation, merged Day 1-3 surfaces, Day 5+, Week 4, tooling, lockfile, navigation, publication configuration, and unrelated bytes are unchanged. Ordinary course merge occurs only after the written exact-head gates close and will trigger the repository's existing Pages workflow.

AI-Assisted: GPT-5.6 Sol + Forge
