### PR TITLE
Repair Week 1 Day 6 generation contract

### DIFF
--- a/book/src/week1-06-generate-response.md
+++ b/book/src/week1-06-generate-response.md
@@ -46,10 +46,15 @@ the model.
 
 Generate tokens in a loop until the model emits `tokenizer.eos_token_id` or `max_tokens` new tokens have been produced.
 Append each new token to the token array so that the next model call receives the complete sequence. An EOS token already
-inside the prompt is context and does not stop generation; only a newly generated EOS does. Feed non-EOS output tokens
-to `tokenizer.detokenizer`, and print each new text segment as it becomes available. On either termination path, call
-`tokenizer.detokenizer.finalize()` and print its final `last_segment` so buffered text is not lost. The function returns
-`None` after streaming the response.
+inside the prompt is context and does not stop generation; only a newly generated EOS does.
+
+Before the loop, bind one streaming detokenizer with `detokenizer = tokenizer.detokenizer`, then call
+`detokenizer.reset()` once. Keep and reuse that same stateful object throughout generation: feed every non-EOS output
+token to `detokenizer.add_token(...)` and print each `detokenizer.last_segment` as it becomes available. With the locked
+mlx-lm 0.31.3 dependency, each separate access to the `tokenizer.detokenizer` property creates a fresh streaming
+detokenizer, so repeatedly accessing the property would discard the buffered text. On either termination path, call
+`detokenizer.finalize()` on the saved object and print its final `last_segment` so buffered text is not lost. The
+function returns `None` after streaming the response.
 
 An example of the sequences provided to the `_step` function is as below:
 

--- a/book/src/week1-06-generate-response.md
+++ b/book/src/week1-06-generate-response.md
@@ -10,7 +10,8 @@ src/tiny_llm/generate.py
 ```
 
 `simple_generate` takes a model, tokenizer, prompt, and optional sampler, then streams the generated response to standard
-output. Generation has two phases: prefill and decode.
+output. Its optional `max_tokens` argument defaults to 256 and limits the number of newly generated tokens. Generation
+has two phases: prefill and decode.
 
 First, implement the nested `_step` function. It takes a one-dimensional array of token IDs, adds the batch dimension,
 and passes the result to the model. The model returns unnormalized logits over the vocabulary for every sequence position.
@@ -30,19 +31,25 @@ logits = output_logits[:, -1, :]
 
 You may normalize these logits into log probabilities with the log-sum-exp trick. This normalization does not change
 the result of `argmax`, but the sampler introduced on Day 7 expects log probabilities. If `sampler` is `None`, use
-`mx.argmax` along the final, vocabulary dimension. Otherwise, pass the log probabilities to `sampler`. Selecting the
-highest-scoring token at every step is called greedy decoding.
+`mx.argmax` along the final, vocabulary dimension. Otherwise, pass the `(1, vocab_size)` log-probability array to
+`sampler`, which returns one token ID in an integer array with shape `(1,)`. Selecting the highest-scoring token at every
+step is called greedy decoding.
 
 - 📚 [The Log-Sum-Exp Trick](https://gregorygundersen.com/blog/2020/02/09/log-sum-exp/)
 - 📚 [Decoding Strategies in Large Language Models](https://mlabonne.github.io/blog/posts/2023-06-07-Decoding_strategies.html)
 - 📚 [Tokenizer definition](https://huggingface.co/docs/transformers/main/en/main_classes/tokenizer)
 
 With `_step` complete, implement the rest of `simple_generate`. Begin by encoding the prompt into a one-dimensional token
-array with `tokenizer.encode`.
+array with `tokenizer.encode(prompt, add_special_tokens=False)`. `main.py` has already formatted the chat prompt, so the
+tokenizer must not add another set of special tokens. If encoding produces no tokens, reject the prompt before calling
+the model.
 
-Generate tokens in a loop until the model emits `tokenizer.eos_token_id`. Append each new token to the token array so that
-the next model call receives the complete sequence. Feed non-EOS output tokens to `tokenizer.detokenizer`, and print each
-new text segment as it becomes available.
+Generate tokens in a loop until the model emits `tokenizer.eos_token_id` or `max_tokens` new tokens have been produced.
+Append each new token to the token array so that the next model call receives the complete sequence. An EOS token already
+inside the prompt is context and does not stop generation; only a newly generated EOS does. Feed non-EOS output tokens
+to `tokenizer.detokenizer`, and print each new text segment as it becomes available. On either termination path, call
+`tokenizer.detokenizer.finalize()` and print its final `last_segment` so buffered text is not lost. The function returns
+`None` after streaming the response.
 
 An example of the sequences provided to the `_step` function is as below:
 
@@ -57,22 +64,31 @@ decode: _step(model, [1, 2, 3, 4, 5, 6, 7, 8]) # returns 9
 In Week 2, we will accelerate decoding with a key-value cache so that the model does not recompute the entire sequence
 at every step.
 
-You can test your implementation by running the following command:
+First run the deterministic checkpoint, which does not download or load a model:
 
 ```bash
-# Start with the default 0.6B model.
+pdm run test --week 1 --day 6
+```
+
+Then complete the required product check with the default 0.6B model:
+
+```bash
 hf download Qwen/Qwen3-0.6B-MLX-4bit
 pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b \
   --prompt "Give me a short introduction to large language model"
+```
 
-# If downloaded, you can also try the larger models.
+The first command downloads the model once; later runs use the cached copy. The product command should produce a
+reasonable explanation of large language models. Replace `--solution tiny_llm` with `--solution ref` to run the
+reference solution.
+
+If downloaded, you can also try the larger models; these are optional demonstrations, not completion requirements:
+
+```bash
 pdm run main --solution tiny_llm --loader week1 --model qwen3-1.7b \
   --prompt "Give me a short introduction to large language model"
 pdm run main --solution tiny_llm --loader week1 --model qwen3-4b \
   --prompt "Give me a short introduction to large language model"
 ```
-
-Each command should produce a reasonable explanation of large language models. Replace `--solution tiny_llm` with
-`--solution ref` to run the reference solution.
 
 {{#include copyright.md}}

--- a/src/tiny_llm/generate.py
+++ b/src/tiny_llm/generate.py
@@ -17,6 +17,7 @@ def simple_generate(
     tokenizer: TokenizerWrapper,
     prompt: str,
     sampler: Callable[[mx.array], mx.array] | None,
+    max_tokens: int = 256,
 ) -> None:
     def _step(model, y):
         pass

--- a/src/tiny_llm_ref/generate.py
+++ b/src/tiny_llm_ref/generate.py
@@ -18,6 +18,7 @@ def simple_generate(
     tokenizer: TokenizerWrapper,
     prompt: str,
     sampler: Callable[[mx.array], mx.array] | None,
+    max_tokens: int = 256,
 ) -> None:
     def _step(model, y):
         logits = model(y[None])
@@ -33,10 +34,12 @@ def simple_generate(
 
     # prefill with the prompt
     tokens = mx.array(tokenizer.encode(prompt, add_special_tokens=False))
+    if tokens.size == 0:
+        raise ValueError("prompt must encode to at least one token")
     detokenizer = tokenizer.detokenizer
     detokenizer.reset()
     # generate/decode
-    while True:
+    for _ in range(max_tokens):
         token = _step(model, tokens)
         mx.eval(token)
         tokens = mx.concat([tokens, token])
@@ -44,6 +47,8 @@ def simple_generate(
             break
         detokenizer.add_token(token.item())
         print(detokenizer.last_segment, end="", flush=True)
+    detokenizer.finalize()
+    print(detokenizer.last_segment, end="", flush=True)
 
 
 def simple_generate_with_kv_cache(

--- a/tests_refsol/test_week_1_day_6.py
+++ b/tests_refsol/test_week_1_day_6.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mlx.core as mx
 import numpy as np
 import pytest
+from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from .tiny_llm_base import simple_generate
 
@@ -12,7 +13,7 @@ VOCAB_SIZE = 8
 
 
 class FakeDetokenizer:
-    def __init__(self):
+    def __init__(self, tokenizer=None):
         self.last_segment = ""
         self.pending = "stale"
 
@@ -33,12 +34,22 @@ class FakeTokenizer:
     def __init__(self, prompt_tokens: list[int]):
         self.prompt_tokens = prompt_tokens
         self.eos_token_id = EOS
-        self.detokenizer = FakeDetokenizer()
+
+    @property
+    def detokenizer(self):
+        return FakeDetokenizer()
 
     def encode(self, prompt: str, add_special_tokens: bool = True) -> list[int]:
         if add_special_tokens:
             return [6, *self.prompt_tokens]
         return list(self.prompt_tokens)
+
+
+class MinimalTokenizer(FakeTokenizer):
+    chat_template = None
+
+    def get_vocab(self) -> dict[str, int]:
+        return {}
 
 
 class ScriptedModel:
@@ -96,6 +107,35 @@ def test_task_1_max_tokens_bounds_non_eos_generation(capsys):
     simple_generate(model, tokenizer, "prompt", sampler=None, max_tokens=3)
 
     assert capsys.readouterr().out == "AAA"
+
+
+def test_task_1_caller_can_lower_max_tokens(capsys):
+    tokenizer = FakeTokenizer([5])
+    model = ScriptedModel([2, 2])
+
+    simple_generate(model, tokenizer, "prompt", sampler=None, max_tokens=1)
+
+    assert capsys.readouterr().out == "A"
+
+
+def test_task_1_default_max_tokens_is_256(capsys):
+    tokenizer = FakeTokenizer([5])
+    model = ScriptedModel([2] * 257)
+
+    simple_generate(model, tokenizer, "prompt", sampler=None)
+
+    assert capsys.readouterr().out == "A" * 256
+
+
+def test_task_1_real_tokenizer_wrapper_streams_nonempty_bounded_output(capsys):
+    tokenizer = TokenizerWrapper(
+        MinimalTokenizer([5]), detokenizer_class=FakeDetokenizer
+    )
+    model = ScriptedModel([2, 2])
+
+    simple_generate(model, tokenizer, "prompt", sampler=None, max_tokens=1)
+
+    assert capsys.readouterr().out == "A"
 
 
 def test_task_1_rejects_empty_encoding():

--- a/tests_refsol/test_week_1_day_6.py
+++ b/tests_refsol/test_week_1_day_6.py
@@ -1,6 +1,106 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
 import pytest
 
+from .tiny_llm_base import simple_generate
 
-@pytest.mark.skip("No unit tests for week 1 day 6: use main.py instead")
-def test_task_1():
-    pass
+
+EOS = 0
+VOCAB_SIZE = 8
+
+
+class FakeDetokenizer:
+    def __init__(self):
+        self.last_segment = ""
+        self.pending = "stale"
+
+    def reset(self):
+        self.last_segment = ""
+        self.pending = ""
+
+    def add_token(self, token: int):
+        self.last_segment = self.pending
+        self.pending = {EOS: "<eos>", 2: "A", 3: "B", 4: "C"}.get(token, "?")
+
+    def finalize(self):
+        self.last_segment = self.pending
+        self.pending = ""
+
+
+class FakeTokenizer:
+    def __init__(self, prompt_tokens: list[int]):
+        self.prompt_tokens = prompt_tokens
+        self.eos_token_id = EOS
+        self.detokenizer = FakeDetokenizer()
+
+    def encode(self, prompt: str, add_special_tokens: bool = True) -> list[int]:
+        if add_special_tokens:
+            return [6, *self.prompt_tokens]
+        return list(self.prompt_tokens)
+
+
+class ScriptedModel:
+    def __init__(self, next_tokens: list[int], decoy_token: int = 6):
+        self.next_tokens = list(next_tokens)
+        self.decoy_token = decoy_token
+
+    def __call__(self, tokens: mx.array) -> mx.array:
+        if not self.next_tokens:
+            raise AssertionError("model received an unexpected call")
+        next_token = self.next_tokens.pop(0)
+        if 6 in np.array(tokens).reshape(-1).tolist():
+            next_token = 4
+        logits = np.full((1, tokens.shape[1], VOCAB_SIZE), -10_000.0)
+        logits[:, :-1, self.decoy_token] = 10_000.0
+        logits[:, -1, next_token] = 10_000.0
+        return mx.array(logits, dtype=mx.float32)
+
+
+def test_task_1_greedy_prefill_decode_eos_and_stream_tail(capsys):
+    tokenizer = FakeTokenizer([7, EOS])
+    model = ScriptedModel([2, 3, EOS])
+
+    result = simple_generate(model, tokenizer, "prompt", sampler=None)
+
+    assert result is None
+    assert capsys.readouterr().out == "AB"
+
+
+def test_task_1_custom_sampler_receives_stable_log_probabilities(capsys):
+    tokenizer = FakeTokenizer([5])
+    model = ScriptedModel([2, EOS])
+    sampler_inputs: list[mx.array] = []
+    sampled_tokens = iter([4, EOS])
+
+    def sampler(logprobs: mx.array) -> mx.array:
+        sampler_inputs.append(logprobs)
+        return mx.array([next(sampled_tokens)], dtype=mx.int32)
+
+    simple_generate(model, tokenizer, "prompt", sampler=sampler)
+
+    assert sampler_inputs
+    for logprobs in sampler_inputs:
+        values = np.array(logprobs)
+        assert values.shape == (1, VOCAB_SIZE)
+        assert np.isfinite(values).all()
+        np.testing.assert_allclose(np.exp(values).sum(axis=-1), [1.0], atol=1e-6)
+    assert capsys.readouterr().out == "C"
+
+
+def test_task_1_max_tokens_bounds_non_eos_generation(capsys):
+    tokenizer = FakeTokenizer([5])
+    model = ScriptedModel([2, 2, 2, 2])
+
+    simple_generate(model, tokenizer, "prompt", sampler=None, max_tokens=3)
+
+    assert capsys.readouterr().out == "AAA"
+
+
+def test_task_1_rejects_empty_encoding():
+    tokenizer = FakeTokenizer([])
+    model = ScriptedModel([EOS])
+
+    with pytest.raises(Exception):
+        simple_generate(model, tokenizer, "prompt", sampler=None)

--- a/tests_refsol/test_week_1_day_6.py
+++ b/tests_refsol/test_week_1_day_6.py
@@ -61,7 +61,8 @@ class ScriptedModel:
         if not self.next_tokens:
             raise AssertionError("model received an unexpected call")
         next_token = self.next_tokens.pop(0)
-        if 6 in np.array(tokens).reshape(-1).tolist():
+        token_ids = np.array(tokens).reshape(-1).tolist()
+        if token_ids == [7] or 6 in token_ids:
             next_token = 4
         logits = np.full((1, tokens.shape[1], VOCAB_SIZE), -10_000.0)
         logits[:, :-1, self.decoy_token] = 10_000.0


### PR DESCRIPTION
## Summary

- give Week 1 Day 6 a deterministic, no-download checkpoint for the public prompt-to-stream generation contract
- bound `simple_generate` to 256 new-token steps by default, reject empty encodings before model execution, and flush the detokenizer tail on EOS or bound exhaustion
- align the lesson with the exact sampler handoff, prompt boundary, single streaming-detokenizer lifecycle, and required deterministic plus 0.6B product completion gates

## Learner contract

The supplied checkpoint grades only final stdout, return/exception behavior, and the sampler's public callback input. Its output-sensitive fakes cover greedy and final-position selection, prompt special-token handling, a prompt EOS retained as context, generated-EOS exclusion, caller-supplied and default generation bounds, empty-encoding rejection, buffered-tail output, stable normalized sampler input, custom-sampler handoff, and the real `TokenizerWrapper` detokenization surface. The fake tokenizer matches the locked mlx-lm 0.31.3 behavior in which each `detokenizer` property access returns a fresh stateful object. It does not record or assert collaborator calls, counters, model-prefix sequences, source, private names, loop shape, error wording, concrete types, internal component identity, or library choice; externally implemented equivalents remain valid when their public behavior matches. Complete-prefix recomputation, binding/resetting/reusing one streaming detokenizer, finalization, and reject-before-model remain the lesson's intended implementation and the reference behavior, not test-enforced call paths.

The learner starter remains unresolved except for the defaulted `max_tokens: int = 256` API boundary.

## Verification

- Day 6 repaired reference and completed learner: 7 passed
- untouched learner starter: 7 failed, with every checkpoint case honestly red
- full local reference suite: 592 passed, 6 skipped across 598
- ten output/callback-visible mutations killed: no-op, first-position logits, raw sampler logits, ignored sampler, emitted EOS, missing buffered-tail output, ignored bound, fixed-three generation, default-three generation, and repeated detokenizer-property access
- a structurally different incremental-input implementation passes 7/7, proving collaborator call structure is not graded
- required cached Qwen3 0.6B Week 1 completed-learner and reference product runs both completed and produced coherent large-language-model explanations
- installation, learner/reference extension builds, extension smoke test, changed-file Ruff, copied-test identity, mdBook, sitemap, diff, four-path scope, manifest, and protected-complement gates passed

## Scope

Exactly four paths change: the Day 6 chapter, supplied Day 6 test, learner `generate.py` signature, and reference `generate.py` behavior. `main.py`, exports, model/loader/tokenizer/sampler APIs, Days 1-5, Day 7+, navigation, metadata, dependencies, Week 4, and publication surfaces are preserved.

This Draft does not authorize Ready, merge, Pages publication, release, tag, deploy, visibility, Week 4, or Day 7+ work.
