### PR TITLE
Repair Week 1 Day 7 sampling contract

### DIFF
--- a/book/src/week1-07-sampling-prepare.md
+++ b/book/src/week1-07-sampling-prepare.md
@@ -71,9 +71,9 @@ pdm run copy-test --week 1 --day 7
 pdm run test --week 1 --day 7 -- -q --tb=short
 ```
 
-The transformation cases observe the numeric logits passed to categorical
-sampling; a separate seeded case checks repeatability. An unseeded draw should
-not be expected to return one particular token.
+The distribution cases observe returned-token support and frequencies; the
+seeded case checks same-seed repeatability and different-seed divergence. An
+unseeded draw should not be expected to return one particular token.
 
 After the focused checkpoint passes, verify the completed sampler in the full
 Week 1 product loop:

--- a/book/src/week1-07-sampling-prepare.md
+++ b/book/src/week1-07-sampling-prepare.md
@@ -1,10 +1,14 @@
 # Week 1 Day 7: Sampling and Preparing for Week 2
 
-On Day 7, we will implement several sampling strategies and prepare the development environment for Week 2.
+The Week 1 model can now produce normalized log probabilities and generate a
+greedy response. Today you will complete its single-request sampling path, run
+that path in the full Qwen3 loop, and prepare the tools needed for Week 2's
+custom Metal extensions.
 
 ## Task 1: Sampling
 
-On Day 6, we implemented greedy decoding. In this task, we will add temperature, top-k, and top-p (nucleus) sampling.
+The starter already handles `temp=0` with greedy decoding. You own the
+nonzero-temperature path: temperature, top-k, and top-p (nucleus) sampling.
 
 ```
 src/tiny_llm/sampler.py
@@ -12,28 +16,29 @@ src/tiny_llm/sampler.py
 
 - 📚 [mlx-lm sampler implementation](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/sample_utils.py)
 
+For one active request, the sampler receives normalized log probabilities with
+shape `(1, vocab_size)` and returns one token-ID array with shape `(1,)` and
+dtype `uint32`. The product does not pass multiple rows to this sampler.
+
+When filtering, first copy the input. MLX indexed assignment mutates the array
+object, so masking the caller's array directly would corrupt the log
+probabilities that the generation loop supplied.
+
 ### Temperature Sampling
 
 When `temp=0`, use greedy decoding. When `temp` is greater than 0, sample the next token from the log-probability distribution.
 A higher temperature flattens the distribution, making lower-probability tokens more likely and increasing output variety.
 
-To implement temperature sampling, divide the log probabilities by the temperature and pass them to
-`mx.random.categorical`.
-
-```bash
-pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b --sampler-temp 0.5
-```
+To implement temperature sampling, divide the log probabilities by the
+temperature and pass them to `mx.random.categorical` with `axis=-1`.
 
 ### Top-k Sampling
 
-Top-k sampling keeps only the `k` tokens with the highest log probabilities. Apply this filter before temperature scaling.
+Top-k sampling keeps only the `k` tokens with the highest log probabilities.
+Apply this filter before top-p and temperature scaling.
 
 Use `mx.argpartition` to find the indices outside the top `k`, mask their log probabilities with `-mx.inf`, then apply
 temperature sampling.
-
-```bash
-pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b --sampler-temp 0.5 --sampler-top-k 10
-```
 
 ### Top-p (Nucleus) Sampling
 
@@ -43,67 +48,114 @@ Apply this filter before temperature scaling.
 One implementation uses `mx.argsort` to order the log probabilities from highest to lowest, applies `exp` to recover
 probabilities, and applies `cumsum` to compute cumulative probability. Keep a token when the cumulative probability before
 it is less than `p`; this includes the token that crosses the threshold. Mask the remaining log probabilities with
-`-mx.inf`, then apply temperature sampling.
+`-mx.inf`.
+
+The complete non-greedy order is:
+
+1. copy the input;
+2. apply top-k;
+3. apply top-p, retaining the threshold-crossing token;
+4. divide by temperature; and
+5. draw with `mx.random.categorical(..., axis=-1)`.
+
+`None` or a non-positive value disables its corresponding filter.
+`top_k == vocab_size` and `top_p == 1` leave the vocabulary unfiltered. The
+existing implementation raises `ValueError` when `top_k` is larger than the
+vocabulary; inputs outside these boundaries are not part of this lesson's
+contract.
+
+Run the deterministic, no-download checkpoint first:
 
 ```bash
+pdm run copy-test --week 1 --day 7
+pdm run test --week 1 --day 7 -- -q --tb=short
+```
+
+The transformation cases observe the numeric logits passed to categorical
+sampling; a separate seeded case checks repeatability. An unseeded draw should
+not be expected to return one particular token.
+
+After the focused checkpoint passes, verify the completed sampler in the full
+Week 1 product loop:
+
+```bash
+pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b --sampler-temp 0.5
+pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b --sampler-temp 0.5 --sampler-top-k 10
 pdm run main --solution tiny_llm --loader week1 --model qwen3-0.6b --sampler-temp 0.5 --sampler-top-p 0.9
 ```
 
+These commands require the cached 0.6B model. If it is missing, download it and
+rerun them:
+
+```bash
+hf download Qwen/Qwen3-0.6B-MLX-4bit
+```
+
+Larger models remain optional and are not a Day 7 completion gate.
+
 ## Task 2: Prepare for Week 2
 
-In Week 2, we will optimize the Qwen3 serving infrastructure with C++ and Metal kernels. You will need Xcode and its
-command-line tools, including the Metal compiler, to build them.
+Week 2 Days 1 and 2 introduce KV caching in Python, so you can begin them before
+the custom-extension toolchain is ready. Starting on Day 3, the C++ and Metal
+work requires full Xcode, its command-line tools, the Metal compiler, and CMake
+3.27 or newer.
 
 1. **Install Xcode:**
 
-    Install Xcode from the Mac App Store or from the [Apple Developer website](https://developer.apple.com/xcode/) (this may require an Apple Developer account).
+    Install full Xcode from the Mac App Store or Apple Developer downloads.
+    Full Xcode bundles its command-line tools; the standalone package described
+    in [Installing the command-line tools](https://developer.apple.com/documentation/xcode/installing-the-command-line-tools)
+    is an alternative, so you do not normally need to run
+    `xcode-select --install` after installing Xcode.
 
 2. **Launch Xcode and Install Components:**
 
     After installation, launch Xcode at least once. It may prompt you to install additional macOS components; please do so (this is usually the default option).
 
-3. **Install Xcode Command Line Tools:**
+3. **Verify the Active Xcode Path:**
 
-    Open your Terminal and run:
+    Check which developer directory the command-line tools use:
 
     ```bash
-    xcode-select --install
+    xcode-select --print-path
     ```
 
-4. **Set the Default Xcode Path (if needed):**
-
-    Ensure that your command-line tools are pointing to your newly installed Xcode. You can do this by running:
+    If it does not point to full Xcode, switch it as described in
+    [Configuring command-line tools settings](https://developer.apple.com/documentation/xcode/configuring-command-line-tools-settings):
 
     ```bash
     sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
-    xcode-select --print-path
     ```
 
     Adjust the path if Xcode is installed elsewhere.
 
-5. **Accept the Xcode License:**
+4. **Resolve First-Launch or License Prompts if Needed:**
 
-    You may also need to accept the Xcode license:
+    Launch Xcode once. Only if the tools report an incomplete first launch or
+    license problem, follow the reported recovery step, such as:
 
     ```bash
+    sudo xcodebuild -runFirstLaunch
     sudo xcodebuild -license accept
     ```
 
-6. **Verify the Metal Compiler:**
+5. **Verify the Metal Compiler:**
 
     ```bash
     xcrun metal --version
     ```
 
-    With Xcode 26, the Metal toolchain may be a separate component. If the command reports a missing Metal toolchain,
-    download it and verify the compiler again:
+    With Xcode 26, the Metal toolchain may be a separate component. If the
+    command reports that it is missing, use the conditional component workflow
+    described in [Downloading and installing additional Xcode components](https://developer.apple.com/documentation/xcode/downloading-and-installing-additional-xcode-components),
+    then verify the compiler again:
 
     ```bash
     xcodebuild -downloadComponent MetalToolchain
     xcrun metal --version
     ```
 
-7. **Install CMake:**
+6. **Install and Verify CMake 3.27 or Newer:**
 
     ```bash
     brew install cmake
@@ -120,16 +172,18 @@ pdm run build-ext
 pdm run build-ext-test
 ```
 
-It should print `correct: True`.
+It should print `c correct: True`.
 The other exported extension names are fail-closed starter stubs labeled with
 the Week 2 or Week 3 checkpoint that implements them; this setup check calls
 only `axpby`.
 
-If you are new to C++ or Metal, try a few small exercises before continuing. For example, implement element-wise operations
-such as `exp`, `sin`, and `cos`, then use them in place of the corresponding MLX operations in your model
-implementation.
+If you are new to C++ or Metal, try a few small exercises before the custom
+kernel work on Day 3. For example, implement element-wise operations such as
+`exp`, `sin`, and `cos`, then use them in place of the corresponding MLX
+operations in your model implementation.
 
-That completes Week 1. We have implemented all the components required to serve Qwen3. In Week 2, we will optimize the
-serving infrastructure for Apple silicon.
+That completes Week 1: you now have a single-request Python inference loop that
+loads Qwen3, computes logits, samples tokens, and streams a response. Week 2
+first adds KV caching in Python, then begins the custom Metal kernel path.
 
 {{#include copyright.md}}

--- a/tests_refsol/test_week_1_day_7.py
+++ b/tests_refsol/test_week_1_day_7.py
@@ -1,6 +1,146 @@
+import mlx.core as mx
+import numpy as np
 import pytest
 
+from .tiny_llm_base import make_sampler
 
-@pytest.mark.skip("No unit tests for week 1 day 7: use main.py instead")
-def test_task_1():
-    pass
+
+def log_probabilities(probabilities: list[float], dtype=mx.float32) -> mx.array:
+    return mx.log(mx.array([probabilities], dtype=dtype))
+
+
+def assert_token(token: mx.array, expected: int):
+    assert token.shape == (1,)
+    assert token.dtype == mx.uint32
+    np.testing.assert_array_equal(np.array(token), [expected])
+
+
+def categorical_result(expected: np.ndarray, token: int):
+    def categorical(logits: mx.array, axis: int) -> mx.array:
+        assert axis == -1
+        actual = np.array(logits)
+        actual_probabilities = np.exp(actual - np.max(actual, axis=-1, keepdims=True))
+        actual_probabilities /= actual_probabilities.sum(axis=-1, keepdims=True)
+        expected_probabilities = np.exp(
+            expected - np.max(expected, axis=-1, keepdims=True)
+        )
+        expected_probabilities /= expected_probabilities.sum(axis=-1, keepdims=True)
+        np.testing.assert_allclose(
+            actual_probabilities, expected_probabilities, atol=1e-6
+        )
+        return mx.array([token], dtype=mx.uint32)
+
+    return categorical
+
+
+def test_task_1_greedy_shape_dtype_preserves_input_without_rng(monkeypatch):
+    logprobs = log_probabilities([0.1, 0.6, 0.3], dtype=mx.bfloat16)
+    before = np.array(logprobs.astype(mx.float32))
+
+    def categorical_forbidden(*args, **kwargs):
+        raise AssertionError("greedy sampling consumed random state")
+
+    monkeypatch.setattr(mx.random, "categorical", categorical_forbidden)
+    token = make_sampler(temp=0, top_p=0.1, top_k=1)(logprobs)
+
+    assert_token(token, 1)
+    np.testing.assert_array_equal(np.array(logprobs.astype(mx.float32)), before)
+
+
+def test_task_1_temperature_divides_log_probabilities(monkeypatch):
+    logprobs = log_probabilities([0.1, 0.2, 0.7])
+    before = np.array(logprobs)
+    expected = before / 0.5
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
+
+    token = make_sampler(temp=0.5, top_p=None, top_k=None)(logprobs)
+
+    assert_token(token, 2)
+    np.testing.assert_array_equal(np.array(logprobs), before)
+
+
+def test_task_1_top_k_keeps_exactly_the_largest_k(monkeypatch):
+    logprobs = log_probabilities([0.1, 0.4, 0.2, 0.3])
+    before = np.array(logprobs)
+    expected = before.copy()
+    expected[:, [0, 2]] = -np.inf
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 1))
+
+    token = make_sampler(temp=1.0, top_p=None, top_k=2)(logprobs)
+
+    assert_token(token, 1)
+    np.testing.assert_array_equal(np.array(logprobs), before)
+
+
+def test_task_1_top_p_keeps_the_threshold_crossing_token(monkeypatch):
+    logprobs = log_probabilities([0.5, 0.3, 0.15, 0.05])
+    before = np.array(logprobs)
+    expected = before.copy()
+    expected[:, 2:] = -np.inf
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 0))
+
+    token = make_sampler(temp=1.0, top_p=0.6, top_k=None)(logprobs)
+
+    assert_token(token, 0)
+    np.testing.assert_array_equal(np.array(logprobs), before)
+
+
+def test_task_1_composes_top_k_then_top_p_then_temperature(monkeypatch):
+    logprobs = log_probabilities([0.45, 0.30, 0.15, 0.10])
+    before = np.array(logprobs)
+    expected = before.copy()
+    expected[:, 2:] = -np.inf
+    expected /= 0.5
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 1))
+
+    token = make_sampler(temp=0.5, top_p=0.7, top_k=3)(logprobs)
+
+    assert_token(token, 1)
+    np.testing.assert_array_equal(np.array(logprobs), before)
+
+
+def test_task_1_none_disables_both_filters(monkeypatch):
+    logprobs = log_probabilities([0.2, 0.3, 0.5])
+    expected = np.array(logprobs)
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
+
+    assert_token(make_sampler(1.0, None, None)(logprobs), 2)
+
+
+def test_task_1_non_positive_values_disable_both_filters(monkeypatch):
+    logprobs = log_probabilities([0.2, 0.3, 0.5])
+    expected = np.array(logprobs)
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
+
+    assert_token(make_sampler(1.0, 0.0, 0)(logprobs), 2)
+
+
+def test_task_1_full_vocabulary_boundaries_are_unfiltered(monkeypatch):
+    logprobs = log_probabilities([0.1, 0.2, 0.3, 0.4])
+    expected = np.array(logprobs)
+    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 3))
+
+    assert_token(make_sampler(1.0, 1.0, 4)(logprobs), 3)
+
+
+def test_task_1_oversized_top_k_preserves_existing_error():
+    logprobs = log_probabilities([0.1, 0.2, 0.3, 0.4])
+
+    with pytest.raises(ValueError):
+        mx.eval(make_sampler(1.0, None, 5)(logprobs))
+
+
+def test_task_1_seeded_categorical_sampling_is_repeatable():
+    logprobs = log_probabilities([0.05, 0.15, 0.3, 0.5])
+    sampler = make_sampler(0.8, 0.95, 4)
+
+    mx.random.seed(2026)
+    first = sampler(logprobs)
+    mx.eval(first)
+    mx.random.seed(2026)
+    second = sampler(logprobs)
+    mx.eval(second)
+
+    assert first.shape == (1,)
+    assert first.dtype == mx.uint32
+    np.testing.assert_array_equal(np.array(first), np.array(second))

--- a/tests_refsol/test_week_1_day_7.py
+++ b/tests_refsol/test_week_1_day_7.py
@@ -15,112 +15,129 @@ def assert_token(token: mx.array, expected: int):
     np.testing.assert_array_equal(np.array(token), [expected])
 
 
-def categorical_result(expected: np.ndarray, token: int):
-    def categorical(logits: mx.array, axis: int) -> mx.array:
-        assert axis == -1
-        actual = np.array(logits)
-        actual_probabilities = np.exp(actual - np.max(actual, axis=-1, keepdims=True))
-        actual_probabilities /= actual_probabilities.sum(axis=-1, keepdims=True)
-        expected_probabilities = np.exp(
-            expected - np.max(expected, axis=-1, keepdims=True)
-        )
-        expected_probabilities /= expected_probabilities.sum(axis=-1, keepdims=True)
-        np.testing.assert_allclose(
-            actual_probabilities, expected_probabilities, atol=1e-6
-        )
-        return mx.array([token], dtype=mx.uint32)
-
-    return categorical
+def sampled_tokens(
+    sampler, logprobs: mx.array, *, draws: int = 384, seed: int = 2026
+) -> np.ndarray:
+    tokens = np.empty(draws, dtype=np.int64)
+    mx.random.seed(seed)
+    for index in range(draws):
+        token = sampler(logprobs)
+        mx.eval(token)
+        assert token.shape == (1,)
+        assert token.dtype == mx.uint32
+        tokens[index] = int(np.array(token).item())
+    return tokens
 
 
-def test_task_1_greedy_shape_dtype_preserves_input_without_rng(monkeypatch):
+def sampled_frequencies(
+    sampler, logprobs: mx.array, *, draws: int = 384, seed: int = 2026
+) -> np.ndarray:
+    tokens = sampled_tokens(sampler, logprobs, draws=draws, seed=seed)
+    counts = np.bincount(tokens, minlength=logprobs.shape[-1])
+    return counts / draws
+
+
+def assert_distribution(
+    actual: np.ndarray, expected: list[float], *, atol: float = 0.08
+):
+    expected_array = np.array(expected, dtype=np.float64)
+    expected_array /= expected_array.sum()
+    np.testing.assert_array_equal(actual[expected_array == 0], 0.0)
+    np.testing.assert_allclose(actual, expected_array, atol=atol, rtol=0)
+
+
+def test_task_1_greedy_shape_dtype_preserves_input_and_rng_state():
     logprobs = log_probabilities([0.1, 0.6, 0.3], dtype=mx.bfloat16)
     before = np.array(logprobs.astype(mx.float32))
 
-    def categorical_forbidden(*args, **kwargs):
-        raise AssertionError("greedy sampling consumed random state")
+    mx.random.seed(2026)
+    expected_next_draw = mx.random.uniform(shape=(8,))
+    mx.eval(expected_next_draw)
 
-    monkeypatch.setattr(mx.random, "categorical", categorical_forbidden)
+    mx.random.seed(2026)
     token = make_sampler(temp=0, top_p=0.1, top_k=1)(logprobs)
+    mx.eval(token)
+    actual_next_draw = mx.random.uniform(shape=(8,))
+    mx.eval(actual_next_draw)
 
     assert_token(token, 1)
     np.testing.assert_array_equal(np.array(logprobs.astype(mx.float32)), before)
+    np.testing.assert_array_equal(
+        np.array(actual_next_draw), np.array(expected_next_draw)
+    )
 
 
-def test_task_1_temperature_divides_log_probabilities(monkeypatch):
-    logprobs = log_probabilities([0.1, 0.2, 0.7])
+def test_task_1_temperature_divides_log_probabilities():
+    probabilities = [0.7, 0.2, 0.1]
+    logprobs = log_probabilities(probabilities)
     before = np.array(logprobs)
-    expected = before / 0.5
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
 
-    token = make_sampler(temp=0.5, top_p=None, top_k=None)(logprobs)
+    frequencies = sampled_frequencies(
+        make_sampler(temp=0.5, top_p=None, top_k=None), logprobs
+    )
 
-    assert_token(token, 2)
+    assert_distribution(frequencies, [probability**2 for probability in probabilities])
     np.testing.assert_array_equal(np.array(logprobs), before)
 
 
-def test_task_1_top_k_keeps_exactly_the_largest_k(monkeypatch):
+def test_task_1_top_k_keeps_exactly_the_largest_k():
     logprobs = log_probabilities([0.1, 0.4, 0.2, 0.3])
     before = np.array(logprobs)
-    expected = before.copy()
-    expected[:, [0, 2]] = -np.inf
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 1))
 
-    token = make_sampler(temp=1.0, top_p=None, top_k=2)(logprobs)
+    frequencies = sampled_frequencies(
+        make_sampler(temp=1.0, top_p=None, top_k=2), logprobs
+    )
 
-    assert_token(token, 1)
+    assert_distribution(frequencies, [0.0, 0.4, 0.0, 0.3])
     np.testing.assert_array_equal(np.array(logprobs), before)
 
 
-def test_task_1_top_p_keeps_the_threshold_crossing_token(monkeypatch):
+def test_task_1_top_p_keeps_the_threshold_crossing_token():
     logprobs = log_probabilities([0.5, 0.3, 0.15, 0.05])
     before = np.array(logprobs)
-    expected = before.copy()
-    expected[:, 2:] = -np.inf
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 0))
 
-    token = make_sampler(temp=1.0, top_p=0.6, top_k=None)(logprobs)
+    frequencies = sampled_frequencies(
+        make_sampler(temp=1.0, top_p=0.6, top_k=None), logprobs
+    )
 
-    assert_token(token, 0)
+    assert_distribution(frequencies, [0.5, 0.3, 0.0, 0.0])
     np.testing.assert_array_equal(np.array(logprobs), before)
 
 
-def test_task_1_composes_top_k_then_top_p_then_temperature(monkeypatch):
-    logprobs = log_probabilities([0.45, 0.30, 0.15, 0.10])
+def test_task_1_composes_top_k_then_top_p_then_temperature():
+    logprobs = log_probabilities([0.55, 0.25, 0.15, 0.05])
     before = np.array(logprobs)
-    expected = before.copy()
-    expected[:, 2:] = -np.inf
-    expected /= 0.5
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 1))
 
-    token = make_sampler(temp=0.5, top_p=0.7, top_k=3)(logprobs)
+    frequencies = sampled_frequencies(
+        make_sampler(temp=0.5, top_p=0.7, top_k=3), logprobs
+    )
 
-    assert_token(token, 1)
+    assert_distribution(frequencies, [0.55**2, 0.25**2, 0.0, 0.0])
     np.testing.assert_array_equal(np.array(logprobs), before)
 
 
-def test_task_1_none_disables_both_filters(monkeypatch):
-    logprobs = log_probabilities([0.2, 0.3, 0.5])
-    expected = np.array(logprobs)
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
-
-    assert_token(make_sampler(1.0, None, None)(logprobs), 2)
-
-
-def test_task_1_non_positive_values_disable_both_filters(monkeypatch):
-    logprobs = log_probabilities([0.2, 0.3, 0.5])
-    expected = np.array(logprobs)
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 2))
-
-    assert_token(make_sampler(1.0, 0.0, 0)(logprobs), 2)
-
-
-def test_task_1_full_vocabulary_boundaries_are_unfiltered(monkeypatch):
+def test_task_1_none_disables_both_filters():
     logprobs = log_probabilities([0.1, 0.2, 0.3, 0.4])
-    expected = np.array(logprobs)
-    monkeypatch.setattr(mx.random, "categorical", categorical_result(expected, 3))
 
-    assert_token(make_sampler(1.0, 1.0, 4)(logprobs), 3)
+    frequencies = sampled_frequencies(make_sampler(1.0, None, None), logprobs)
+
+    assert_distribution(frequencies, [0.1, 0.2, 0.3, 0.4])
+
+
+def test_task_1_non_positive_values_disable_both_filters():
+    logprobs = log_probabilities([0.1, 0.2, 0.3, 0.4])
+
+    frequencies = sampled_frequencies(make_sampler(1.0, 0.0, 0), logprobs)
+
+    assert_distribution(frequencies, [0.1, 0.2, 0.3, 0.4])
+
+
+def test_task_1_full_vocabulary_boundaries_are_unfiltered():
+    logprobs = log_probabilities([0.1, 0.2, 0.3, 0.4])
+
+    frequencies = sampled_frequencies(make_sampler(1.0, 1.0, 4), logprobs)
+
+    assert_distribution(frequencies, [0.1, 0.2, 0.3, 0.4])
 
 
 def test_task_1_oversized_top_k_preserves_existing_error():
@@ -130,17 +147,11 @@ def test_task_1_oversized_top_k_preserves_existing_error():
         mx.eval(make_sampler(1.0, None, 5)(logprobs))
 
 
-def test_task_1_seeded_categorical_sampling_is_repeatable():
+def test_task_1_seeded_sampling_is_repeatable():
     logprobs = log_probabilities([0.05, 0.15, 0.3, 0.5])
     sampler = make_sampler(0.8, 0.95, 4)
 
-    mx.random.seed(2026)
-    first = sampler(logprobs)
-    mx.eval(first)
-    mx.random.seed(2026)
-    second = sampler(logprobs)
-    mx.eval(second)
+    first = sampled_tokens(sampler, logprobs, draws=32)
+    second = sampled_tokens(sampler, logprobs, draws=32)
 
-    assert first.shape == (1,)
-    assert first.dtype == mx.uint32
-    np.testing.assert_array_equal(np.array(first), np.array(second))
+    np.testing.assert_array_equal(first, second)

--- a/tests_refsol/test_week_1_day_7.py
+++ b/tests_refsol/test_week_1_day_7.py
@@ -149,11 +149,12 @@ def test_task_1_oversized_top_k_preserves_existing_error():
 
 def test_task_1_seeded_sampling_repeats_and_changes_with_seed():
     logprobs = log_probabilities([0.05, 0.15, 0.3, 0.5])
-    sampler = make_sampler(0.8, 0.95, 4)
 
-    first = sampled_tokens(sampler, logprobs, draws=32)
-    second = sampled_tokens(sampler, logprobs, draws=32)
-    different_seed = sampled_tokens(sampler, logprobs, draws=32, seed=2027)
+    first = sampled_tokens(make_sampler(0.8, 0.95, 4), logprobs, draws=32)
+    second = sampled_tokens(make_sampler(0.8, 0.95, 4), logprobs, draws=32)
+    different_seed = sampled_tokens(
+        make_sampler(0.8, 0.95, 4), logprobs, draws=32, seed=2027
+    )
 
     np.testing.assert_array_equal(first, second)
     assert np.any(first != different_seed)

--- a/tests_refsol/test_week_1_day_7.py
+++ b/tests_refsol/test_week_1_day_7.py
@@ -147,11 +147,13 @@ def test_task_1_oversized_top_k_preserves_existing_error():
         mx.eval(make_sampler(1.0, None, 5)(logprobs))
 
 
-def test_task_1_seeded_sampling_is_repeatable():
+def test_task_1_seeded_sampling_repeats_and_changes_with_seed():
     logprobs = log_probabilities([0.05, 0.15, 0.3, 0.5])
     sampler = make_sampler(0.8, 0.95, 4)
 
     first = sampled_tokens(sampler, logprobs, draws=32)
     second = sampled_tokens(sampler, logprobs, draws=32)
+    different_seed = sampled_tokens(sampler, logprobs, draws=32, seed=2027)
 
     np.testing.assert_array_equal(first, second)
+    assert np.any(first != different_seed)


### PR DESCRIPTION
## Why

Week 1 Day 7 currently reports success only because its sole supplied test is
unconditionally skipped, even though the learner-owned nonzero-temperature
sampler still returns no token. The chapter also leaves the sampler's actual
single-request shape/dtype, filter composition, completion command, and several
supported boundaries implicit. Its Week 2 preparation treats recovery commands
as unconditional setup and does not identify the repository's CMake 3.27
minimum or the point at which the extension toolchain becomes blocking.

## Change

- Replace the skipped checkpoint with ten deterministic, no-download public
  tests for greedy behavior, shape/dtype, caller-input and greedy RNG-state
  preservation, temperature distribution, exact top-k and top-p support,
  filter/temperature composition, supported filter boundaries, the existing
  oversized-k error, and same-seed repeatability plus different-seed divergence.
- Teach the normalized `(1, vocab_size)` to `(1,)` `uint32` contract, input
  copying, the complete filter order, the focused checkpoint, and the cached
  0.6B product check before optional larger models.
- Separate required Week 2 tools from conditional Xcode/Metal recovery steps,
  state the CMake 3.27 minimum and Day 3 dependency boundary, and correct the
  extension smoke output to `c correct: True`.

## Review note

Exactly two existing paths change: the Day 7 chapter and supplied Day 7 test.
The learner and reference sampler implementations, product/model/loader/
tokenizer/generation code, navigation and overviews, dependencies and
extensions, Days 1-6, Week 2+ implementations/tests, Week 4, and delivery
surfaces remain unchanged.

The maintained reference, a structurally different valid categorical sampler,
and a valid Gumbel-max sampler pass 10/10; the untouched starter passes only the
supplied greedy case and is honestly red on the remaining 9/10. Nine targeted
broken implementations each fail their causal witness. Sampling checks use only
public returned tokens, support, distributions, and seeded RNG behavior; seeded
comparisons use fresh sampler instances, do not intercept categorical calls,
and do not require one implementation path. The cached 0.6B Week 1 reference
product, selected test copy, Ruff, mdBook, sitemap, link, diff, scope, manifest,
and preservation checks pass locally. Hosted CI must still pass on the eventual
exact Draft head; no audit or local evidence is a review verdict.

This Draft does not authorize Ready, merge, Pages publication, release, tag,
deploy, visibility, Week 4, or Week 2 implementation work.

AI-Assisted: GPT-5.6 Sol + Forge
