### PR TITLE
Rename Python distribution to tiny-llm-course

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 
 [project]
-name = "tiny-llm"
+name = "tiny-llm-course"
 version = "0.1.0"
 requires-python = ">=3.10, <3.13"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- rename the root Python distribution from `tiny-llm` to `tiny-llm-course`
- preserve the `tiny_llm` and `tiny_llm_ref` import packages, repository/course branding, and runtime behavior

## Why

PyPI rejected the exact `tiny-llm` distribution name under its similarity-protection rule. The course owner selected `tiny-llm-course` as the registry-safe distribution identity while keeping the related `tiny-llm-starter`, `tiny-llm-ref`, `tiny-llm-ext`, and `tiny-llm-ext-ref` names unchanged.

## Verification

- `pdm lock --check`
- `pdm build --no-sdist -d <temporary-directory>`
- built wheel metadata reports `Name: tiny-llm-course` and `Version: 0.1.0`
- `git diff --check`

This PR changes package metadata only. It does not publish a package, alter imports, tag, release, or deploy anything.
